### PR TITLE
add string check for cmd line args

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -582,10 +582,11 @@ class Podman:
         return subprocess.check_output(cmd)
 
     def run(self, podman_args, wait=True, sleep=1):
-        print("podman " + " ".join(podman_args))
+        podman_args_str = [str(arg) for arg in podman_args]
+        print("podman " + " ".join(podman_args_str))
         if self.dry_run:
             return None
-        cmd = [self.podman_path]+podman_args
+        cmd = [self.podman_path]+podman_args_str
         # subprocess.Popen(args, bufsize = 0, executable = None, stdin = None, stdout = None, stderr = None, preexec_fn = None, close_fds = False, shell = False, cwd = None, env = None, universal_newlines = False, startupinfo = None, creationflags = 0)
         p = subprocess.Popen(cmd)
         if wait:


### PR DESCRIPTION
It's common for people to include integers when specifying ports in docker-compose files. docker-compose can handle this today. I'm proposing we match that behavior. Today, a PORT as an integer in a YAML file will cause podman-compose to fail without casting the integers to strings.

```
# ... more logs truncated here
podman create --name=nextcloud_app_1 --pod=nextcloud -l traefik.enable=true -l traefik.frontend.rule=Host
:cloud.olsonsky.com -l traefik.port=80 -l traefik.docker.network=http_network -l io.podman.compose.config
-hash=123 -l io.podman.compose.project=nextcloud -l io.podman.compose.version=0.0.1 -l com.docker.compose
.container-number=1 -l com.docker.compose.service=app --mount type=bind,source=/var/lib/containers/storag
e/volumes/nextcloud_nextcloud/_data,destination=/var/www/html,bind-propagation=Z --add-host pgsqldb:127.0
.0.1 --add-host nextcloud_pgsqldb_1:127.0.0.1 --add-host app:127.0.0.1 --add-host nextcloud_app_1:127.0.0
.1 --expose 80 nextcloud:16-apache                                                                       
Traceback (most recent call last):                                                                       
  File "/usr/lib64/python3.7/pdb.py", line 1701, in main                                                 
    pdb._runscript(mainpyfile)                                                                           
  File "/usr/lib64/python3.7/pdb.py", line 1570, in _runscript                                           
    self.run(statement)                                                                                  
  File "/usr/lib64/python3.7/bdb.py", line 585, in run                                                   
    exec(cmd, globals, locals)                                                                           
  File "<string>", line 1, in <module>                                                                   
  File "/root/.local/bin/podman-compose", line 3, in <module>                                            
    __requires__ = 'podman-compose'                                                                      
  File "/root/podman-compose/podman_compose.py", line 1093, in main                                      
    podman_compose.run()                                                                                 
  File "/root/podman-compose/podman_compose.py", line 625, in run                                        
    cmd(self, args)                                                                                      
  File "/root/podman-compose/podman_compose.py", line 782, in wrapped                                    
    return func(*args, **kw)                                                                             
  File "/root/podman-compose/podman_compose.py", line 899, in compose_up                                 
    compose.podman.run(podman_args)                                                                      
  File "/root/podman-compose/podman_compose.py", line 590, in run                                        
    p = subprocess.Popen(cmd)                                                                            
  File "/usr/lib64/python3.7/subprocess.py", line 775, in __init__                                       
    restore_signals, start_new_session)                                                                  
  File "/usr/lib64/python3.7/subprocess.py", line 1453, in _execute_child                                
    restore_signals, start_new_session, preexec_fn)                                                      
TypeError: expected str, bytes or os.PathLike object, not int 
```