### PR TITLE
Support for generic  container-compose format

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -702,11 +702,15 @@ class PodmanCompose:
                 "docker-compose.yml",
                 "docker-compose.yaml",
                 "docker-compose.override.yml",
-                "docker-compose.override.yaml"
+                "docker-compose.override.yaml",
+                "container-compose.yml",
+                "container-compose.yaml",
+                "container-compose.override.yml",
+                "container-compose.override.yaml"
             ]))
         files = args.file
         if not files:
-            print("no docker-compose.yml found, pass files with -f")
+            print("no docker-compose.yml or container-compose.yml file found, pass files with -f")
         ex = map(os.path.exists, files)
         missing = [ fn0 for ex0, fn0 in zip(ex, files) if not ex0 ]
         if missing:


### PR DESCRIPTION
This is in reference to buildah issue:  https://github.com/containers/buildah/issues/1853

Long story short, this merge request is for supporting a more generic "container-compose" file format in addition to supporting the traditional "docker-compose" format for standing up podman-compose environments. I believe that a similar change is coming into Buildah for supporting "Containerfile" in addition to Dockerfile. Feel free if you want me to add any tests, container-compose.yml files under `examples`, or anything else that would support this PR.   I appreciate your time reviewing this PR! 