### PR TITLE
Fixed typo in ulimit tag, now according to compose specification

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -496,7 +496,7 @@ def container_to_args(compose, cnt, detached=True, podman_command='run'):
         podman_args.append('-i')
     if cnt.get('tty'):
         podman_args.append('--tty')
-    ulimit = cnt.get('ulimit', [])
+    ulimit = cnt.get('ulimits', [])
     if ulimit is not None:
         # ulimit can be a single value, i.e. ulimit: host
         if is_str(ulimit):


### PR DESCRIPTION
As in issue #54 described the ulimit tag in the docker compose file should be "ulimits" according to the [compose file reference ](https://docs.docker.com/compose/compose-file/#ulimits). 
It was "ulimit" so it didn't parse the ulimits tag.