### PR TITLE
podman volume inspect mountPoint/Mountpoint

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -381,7 +381,10 @@ def mount_dict_vol_to_bind(compose, mount_dict):
     except subprocess.CalledProcessError:
         compose.podman.output(["volume", "create", "--label", "io.podman.compose.project={}".format(proj_name), vol_name])
         out = compose.podman.output(["volume", "inspect", vol_name]).decode('utf-8')
-    src = json.loads(out)[0]["mountPoint"]
+    try:
+        src = json.loads(out)[0]["mountPoint"]
+    except KeyError:
+        src = json.loads(out)[0]["Mountpoint"]
     ret=dict(mount_dict, type="bind", source=src, _vol=vol_name)
     bind_prop=ret.get("bind", {}).get("propagation")
     if not bind_prop:


### PR DESCRIPTION
The output of `podman volume inspect` has changed: `mountPoint` is now `Mountpoint`

## podman 1.2.0 (version in Fedora 30 repo)
```
[vagrant@localhost ~]$ podman version
Version:            1.2.0
RemoteAPI Version:  1
Go Version:         go1.12
OS/Arch:            linux/amd64

[vagrant@localhost ~]$ podman volume inspect test
[
    {
        "name": "test",
        "labels": {},
        "mountPoint": "/home/vagrant/.local/share/containers/storage/volumes/test/_data",
        "driver": "local",
        "options": {},
        "scope": "local"
    }
]
```

## podman 1.6.1 (version in Fedora 30 updates)
```
[vagrant@localhost ~]$ podman version
Version:            1.6.1
RemoteAPI Version:  1
Go Version:         go1.12.9
OS/Arch:            linux/amd64

[vagrant@localhost ~]$ podman volume inspect test
[
     {
          "Name": "test",
          "Driver": "",
          "Mountpoint": "/home/vagrant/.local/share/containers/storage/volumes/test/_data",
          "CreatedAt": "0001-01-01T00:00:00Z",
          "Labels": {
               
          },
          "Scope": "local",
          "Options": {
               
          }
     }
]
