### PR TITLE
Fix stop command runs start instead

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1148,7 +1148,7 @@ def compose_start(compose, args):
 
 @cmd_run(podman_compose, 'stop', 'stop specific services')
 def compose_stop(compose, args):
-    transfer_service_status(compose, args, 'start')
+    transfer_service_status(compose, args, 'stop')
 
 @cmd_run(podman_compose, 'restart', 'restart specific services')
 def compose_restart(compose, args):


### PR DESCRIPTION
A small fix to stop running containers using `podman-compose`.

The code looks like a copy/paste mistake from the method that starts containers, so this should fix it.