### PR TITLE
Show stopped containers in ps

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1088,9 +1088,9 @@ def compose_down(compose, args):
 def compose_ps(compose, args):
     proj_name = compose.project_name
     if args.quiet == True:
-        compose.podman.run(["ps", "--format", "{{.ID}}", "--filter", f"label=io.podman.compose.project={proj_name}"])
+        compose.podman.run(["ps", "-a", "--format", "{{.ID}}", "--filter", f"label=io.podman.compose.project={proj_name}"])
     else:
-        compose.podman.run(["ps", "--filter", f"label=io.podman.compose.project={proj_name}"])
+        compose.podman.run(["ps", "-a", "--filter", f"label=io.podman.compose.project={proj_name}"])
 
 @cmd_run(podman_compose, 'run', 'create a container similar to a service to run a one-off command')
 def compose_run(compose, args):


### PR DESCRIPTION
To be consistent with `docker-compose ps` behavior, we should view all containers from the current project to be able to see what's stopped and what's running.

From `docker-compose help ps` however, there's an option called `--all` which shows created containers but not started/exited:
```
Usage: ps [options] [SERVICE...]

Options:
    -q, --quiet          Only display IDs
    --services           Display services
    --filter KEY=VAL     Filter services by a property
    -a, --all            Show all stopped containers (including those created by the run command)
```

The current implementation displays all including created but not started containers as the default of `-a` in `podman ps`.