### PR TITLE
Fix override of the run command

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1121,7 +1121,8 @@ def compose_run(compose, args):
         # TODO: handle volumes
         pass
     cnt['tty']=False if args.T else True
-    cnt['command']=args.cnt_command
+    if args.cnt_command is not None and len(args.cnt_command) > 0:
+        cnt['command']=args.cnt_command
     # run podman
     podman_args = container_to_args(compose, cnt, args.detach)
     if not args.detach:


### PR DESCRIPTION
If there's no command defined in the arguments, `podman-compose run` should use the command defined in docker-compose.yml