### PR TITLE
Update README with dnf install instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ curl -o ~/.local/bin/podman-compose https://raw.githubusercontent.com/containers
 chmod +x ~/.local/bin/podman-compose
 ```
 
+or install from Fedora (starting from f31) repositories:
+
+```
+sudo dnf install podman-compose
+```
+
 ## Basic Usage
 
 We have included fully functional sample stacks inside `examples/` directory.


### PR DESCRIPTION
According to the package review request on Bugzilla ([rhbz#1767240](https://bugzilla.redhat.com/show_bug.cgi?id=1767240)), it is now available in f31 since 2019-11-17.