### PR TITLE
Add support for cap_add/cap_drop

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -468,6 +468,10 @@ def container_to_args(compose, cnt, detached=True, podman_command='run'):
     if net:
         podman_args.extend(['--network', net])
     env = norm_as_list(cnt.get('environment', {}))
+    for c in cnt.get('cap_add', []):
+        podman_args.extend(['--cap-add', c])
+    for c in cnt.get('cap_drop', []):
+        podman_args.extend(['--cap-drop', c])
     for d in cnt.get('devices', []):
         podman_args.extend(['--device', d])
     for e in env:


### PR DESCRIPTION
Currently, `cap_add` and `cap_drop` are being ignored by podman-compose.
Add the arguments (`--cap-add` and `--cap-drop`, respectively) to `podman create` when appropriate.