### PR TITLE
Fix variable escaping with $$

### DIFF
--- a/tests/interpolation/.env
+++ b/tests/interpolation/.env
@@ -1,0 +1,1 @@
+DOT_ENV_VARIABLE=This value is from the .env file

--- a/tests/interpolation/docker-compose-colon-question-error.yml
+++ b/tests/interpolation/docker-compose-colon-question-error.yml
@@ -1,0 +1,8 @@
+version: "3.7"
+services:
+    variables:
+        image: busybox
+        command: ["/bin/busybox", "sh", "-c", "export | grep EXAMPLE"]
+        environment:
+            EXAMPLE_COLON_QUESTION_ERROR: ${NOT_A_VARIABLE:?Missing variable}
+

--- a/tests/interpolation/docker-compose-question-error.yml
+++ b/tests/interpolation/docker-compose-question-error.yml
@@ -1,0 +1,8 @@
+version: "3.7"
+services:
+    variables:
+        image: busybox
+        command: ["/bin/busybox", "sh", "-c", "export | grep EXAMPLE"]
+        environment:
+            EXAMPLE_QUESTION_ERROR: ${NOT_A_VARIABLE?Missing variable}
+

--- a/tests/interpolation/docker-compose.yml
+++ b/tests/interpolation/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.7"
+services:
+    variables:
+        image: busybox
+        command: ["/bin/busybox", "sh", "-c", "export | grep EXAMPLE"]
+        environment:
+            EXAMPLE_VARIABLE: "Host user: $USER"
+            EXAMPLE_BRACES: "Host user: ${USER}"
+            EXAMPLE_COLON_DASH_DEFAULT: ${NOT_A_VARIABLE:-My default}
+            EXAMPLE_DASH_DEFAULT: ${NOT_A_VARIABLE-My other default}
+            EXAMPLE_DOT_ENV: $DOT_ENV_VARIABLE
+            EXAMPLE_LITERAL: This is a $$literal
+            EXAMPLE_EMPTY: $NOT_A_VARIABLE
+


### PR DESCRIPTION
Variable escaping did not seem to work as expected.

In the example below, the variable turns out as just `This is a $` instead of `This is a $literal`:

```yaml
version: "3.7"
services:
    variables:
        image: busybox
        command: ["/bin/busybox", "sh", "-c", "export | grep EXAMPLE"]
        environment:
            EXAMPLE_LITERAL: This is a $$literal
```

It seems that the regular expression did not match `$$`, but it did match `$literal` starting from the second dollar sign.

This pull request rearranges the matching mechanism into just one regular expression, similar to what [Python itself does with templates](https://github.com/python/cpython/blob/5f2c1345a79f205c680ed6e0a6ed44199546d79e/Lib/string.py#L104). This fixes this issue and so far didn't introduce any regressions for me. While at it I'm also submitting tests for all supported interpolation syntax.