### PR TITLE
Use mount type volume instead of converting to bind

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -387,7 +387,7 @@ def assert_volume(compose, mount_dict):
     try: out = compose.podman.output(["volume", "inspect", vol_name]).decode('utf-8')
     except subprocess.CalledProcessError:
         compose.podman.output(["volume", "create", "--label", "io.podman.compose.project={}".format(proj_name), vol_name])
-        out = compose.podman.output(["volume", "inspect", vol_name]).decode('utf-8')
+    ret=dict(mount_dict, _vol=vol_name)
 
 def mount_desc_to_mount_args(compose, mount_desc, srv_name, cnt_name):
     basedir = compose.dirname
@@ -427,6 +427,12 @@ def mount_desc_to_mount_args(compose, mount_desc, srv_name, cnt_name):
         return "type=tmpfs,destination={target},{opts}".format(
             target=target,
             opts=opts
+        ).rstrip(",")
+    elif mount_type=='volume':
+            return "type=volume,source={source},destination={target},{opts}".format(
+                source=source,
+                target=target,
+                opts=opts
         ).rstrip(",")
     else:
         raise ValueError("unknown mount type:"+mount_type)

--- a/tests/vol/docker-compose.yaml
+++ b/tests/vol/docker-compose.yaml
@@ -27,6 +27,16 @@ services:
       working_dir: /var/www/html
       volumes:
         - myvol2:/var/www/html
+    prepopulate:
+      build: ./prepopulate
+      volumes:
+        - prepopulate:/volume
+    prepopulated:
+      image: busybox
+      command: ["/bin/cat", "/volume/test_file"]
+      volumes:
+        - prepopulate:/volume
+          
 
 volumes:
   myvol2:
@@ -38,3 +48,4 @@ volumes:
   data2:
     external:
       name: actual-name-of-volume
+  prepopulate:

--- a/tests/vol/prepopulate/Dockerfile
+++ b/tests/vol/prepopulate/Dockerfile
@@ -1,0 +1,4 @@
+from busybox
+RUN mkdir /volume
+RUN echo ok > /volume/test_file
+CMD cat /volume/test_file


### PR DESCRIPTION
Simply use the supported mount type volume instead of converting it to bind.

This fixes a lot of issues for me, but I am not enough involved to decide if this is the right way to do it. 

It works for me as far to use shared volumes and pre-populate them. If anyone sees further issues or requirements, please let me know.

AFAIK Fixes #13 