### PR TITLE
improve dry run output so it's a properly escaped shell script

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -12,6 +12,7 @@ from __future__ import print_function
 import sys
 import os
 import argparse
+import shlex
 import subprocess
 import time
 import re
@@ -640,7 +641,7 @@ class Podman:
         return subprocess.check_output(cmd)
 
     def run(self, podman_args, wait=True, sleep=1):
-        podman_args_str = [str(arg) for arg in podman_args]
+        podman_args_str = [shlex.quote(str(arg)) for arg in podman_args]
         print("podman " + " ".join(podman_args_str))
         if self.dry_run:
             return None


### PR DESCRIPTION
Pass each of the the generated podman run arguments to shlex.quote()
so that the dry run output is a properly-escaped shell script. This is
useful for using podman-compose to generate a shell script that can run
on another host running a containerized distribution like Fedora CoreOS
where a Python runtime is not available on the host. We can run
podman-compose inside a container, however that podman container
currently cannot create other podman containers.