### PR TITLE
Pass "target" build parameter when building an image.

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1008,6 +1008,8 @@ def build_one(compose, args, cnt):
         "build", "-t", cnt["image"],
         "-f", dockerfile
     ]
+    if "target" in build_desc:
+        build_args.extend(["--target", build_desc.get("target")])
     container_to_ulimit_args(cnt, build_args)
     if getattr(args, 'pull_always', None): build_args.append("--pull-always")
     elif getattr(args, 'pull', None): build_args.append("--pull")


### PR DESCRIPTION
As the title says, this passes the ["target" build parameter](<https://docs.docker.com/compose/compose-file/#target>) through to `podman build`.

If anyone wonders where this might be used: For a particular PHP application, I have a Dockerfile with a common [stage](<https://docs.docker.com/develop/develop-images/multistage-build/>) that builds assets and two child stages to serve the static assets via NGINX and the PHP code by PHP-FPM.