### PR TITLE
Avoid crash when no services are defined

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -828,6 +828,10 @@ class PodmanCompose:
             print(" ** merged:\n", json.dumps(compose, indent = 2))
         ver = compose.get('version')
         services = compose.get('services')
+        if services is None:
+            services = {}
+            print("WARNING: No services defined")
+		
         # NOTE: maybe add "extends.service" to _deps at this stage
         flat_deps(services, with_extends=True)
         service_names = sorted([ (len(srv["_deps"]), name) for name, srv in services.items() ])

--- a/tests/no_services/docker-compose.yaml
+++ b/tests/no_services/docker-compose.yaml
@@ -1,0 +1,7 @@
+version: '3'
+networks:
+  shared-network:
+    driver: bridge
+    ipam:
+      config:
+          - subnet: 172.19.0.0/24


### PR DESCRIPTION
If no services are defined, podman-compose crashes as services variable is None, while the expected behavior might be an error or the same as docker-compose, which will continue the execution of the compose file (eg. creating networks, etc).

This commit fixes the crash and allows the program to continue, mimicking docker-compose behavior.

I also added a test for the described case. Fixes #134 