### PR TITLE
Add some sanitizing functions to the project name

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -59,6 +59,8 @@ def try_int(i, fallback=None):
 
 dir_re = re.compile("^[~/\.]")
 propagation_re=re.compile("^(?:z|Z|r?shared|r?slave|r?private)$")
+invalid_proj_initial_re=re.compile("[^a-zA-Z0-9]")
+invalid_proj_name_re=re.compile("[^a-zA-Z0-9_.-]")
 
 # NOTE: if a named volume is used but not defined it gives
 # ERROR: Named volume "so and so" is used in service "xyz" but no declaration was found in the volumes section.
@@ -804,6 +806,11 @@ class PodmanCompose:
 
         if not project_name:
             project_name = dir_basename.lower()
+            project_name = invalid_proj_name_re.sub("", project_name)
+            project_name = invalid_proj_initial_re.sub("", project_name[0]) + project_name[1:]
+            if project_name == "":
+                print("Warning: invalid project directory name")
+                project_name = "invalid_name"
         self.project_name = project_name
 
 

--- a/tests/.@/README.md
+++ b/tests/.@/README.md
@@ -1,0 +1,2 @@
+This directory name is voluntary wrong to test the ability of podman-compose
+to sanitize directory names.

--- a/tests/.@/docker-compose.yaml
+++ b/tests/.@/docker-compose.yaml
@@ -1,0 +1,11 @@
+version: "3"
+services:
+    redis:
+      image: redis:alpine
+      command: ["redis-server", "--appendonly yes", "--notify-keyspace-events", "Ex"]
+      tmpfs: /run1
+      ports:
+        - "6379"
+      environment:
+        - SECRET_KEY=aabbcc
+        - ENV_IS_SET

--- a/tests/.partially_valid_name/docker-compose.yaml
+++ b/tests/.partially_valid_name/docker-compose.yaml
@@ -1,0 +1,11 @@
+version: "3"
+services:
+    redis:
+      image: redis:alpine
+      command: ["redis-server", "--appendonly yes", "--notify-keyspace-events", "Ex"]
+      tmpfs: /run1
+      ports:
+        - "6379"
+      environment:
+        - SECRET_KEY=aabbcc
+        - ENV_IS_SET


### PR DESCRIPTION
This commit fixes issue #113 (podman-compose doesn't handle correctly
project names with special characters - ie. the one not allowed in pod
names in podman).

Docker compose behavior is to add a suffix and clean the directory name
(so empty string can't appear), where podman-compose is using only the
directory name. After cleaning, if no other characters are found,
the project name is set to a fixed name "invalid_name" to mimick the ability
of docker-compose to work even with exotic directory names.

I've also added two test cases:

* `.test`: only the first char is invalid, so the project name is set to `test`
* `.@`: the whole directory name is invalid: after cleaning, an error message
will be printed out and the project name is set to `invalid_name`
