### PR TITLE
Add better output to logs and up commands

### DIFF
--- a/asyncstreamreader.py
+++ b/asyncstreamreader.py
@@ -1,0 +1,28 @@
+from threading import Thread
+from queue import Queue, Empty
+
+
+class ASyncStreamReader:
+    '''
+    This class implement an async stream reader, useful when reading from stdout/stderr in subprocesses
+    '''
+
+    def __init__(self, stdstream):
+        def threadrun(queue, stream):
+            while True:
+                row = stream.readline()
+                if row:
+                    queue.put(row)
+                else:
+                    return
+
+        self.queue = Queue()
+        self.readerthread = Thread(target=threadrun, args=(self.queue, stdstream))
+        self.readerthread.daemon = True
+        self.readerthread.start()
+
+    def readline(self):
+        try:
+            return self.queue.get(False)
+        except Empty:
+            return None


### PR DESCRIPTION
This pull request reimplements the logging part both on "logs" and "up "
commands (to behave better, and also like docker-compose). "up" log
format is now the same code of "logs", which was improved:
* Log lines are prepended with service name
* Log lines are sorted by timestamp

This fixes #111

This code rewrite fixes also the issue #112 where issuing SIGINT was
leaving some containers running. Also the
stacktrace showed when SIGINT is sent to the program during "up"
was fixed because of the rewrite.

PS: `Podman.run` was modified in the same way as #138 to bypass `wait` and have the ability to read the output of `podman` command, so it's safe to merge both