### PR TITLE
Check for target property when building images

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1019,6 +1019,9 @@ def build_one(compose, args, cnt):
     for build_arg in args_list:
         build_args.extend(("--build-arg", build_arg,))
     build_args.append(ctx)
+    build_target = build_desc.get('target')
+    if build_target:
+        build_args.extend(('--target', build_target))
     compose.podman.run(build_args, sleep=0)
 
 @cmd_run(podman_compose, 'build', 'build stack images')


### PR DESCRIPTION
Enables this feature: https://docs.docker.com/compose/compose-file/#target

For multi-stage builds, this allows picking a stage to build up to a certain stage in the given Dockerfile.

Podman already seems to support this, so it was as easy as passing through the value, if it exists.

This version worked for me, but I don't know the complexities of handling the other arguments or what would be a good way to test this.  Definitely open to feedback, I'm just limited on time, so it may take me a while to get back to it.

Thanks for your hard work on podman-compose so far!