### PR TITLE
Add transfer_service_status exit if podman cmd return 1

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1217,7 +1217,8 @@ def transfer_service_status(compose, args, action):
     if timeout is not None:
         podman_args.extend(['-t', "{}".format(timeout)])
     for target in targets:
-        compose.podman.run(podman_args+[target], sleep=0)
+        if compose.podman.run(podman_args+[target], sleep=0).returncode == 1:
+            exit(1)
 
 @cmd_run(podman_compose, 'start', 'start specific services')
 def compose_start(compose, args):


### PR DESCRIPTION
transfer_service_status exit if podman cmd return 1 because it means that a start/restart/stop failed.
If we don't do that, we can't check in a script if the command where successful.
