### PR TITLE
Catch error when compose file is empty

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -874,6 +874,9 @@ class PodmanCompose:
             with open(filename, 'r') as f:
                 content = yaml.safe_load(f)
                 #print(filename, json.dumps(content, indent = 2))
+                if not isinstance(content, dict):
+                    sys.stderr.write("Compose file does not contain a top level object: %s\n"%filename)
+                    exit(1)
                 content = normalize(content)
                 #print(filename, json.dumps(content, indent = 2))
                 content = rec_subs(content, [os.environ, dotenv_dict])


### PR DESCRIPTION
Also catch cases such as the top element being a list or a string

Fixes #169