### PR TITLE
needed working devel branch, hindered by non-existant args.build_arg

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1076,7 +1076,7 @@ def build_one(compose, args, cnt):
     if getattr(args, 'pull_always', None): build_args.append("--pull-always")
     elif getattr(args, 'pull', None): build_args.append("--pull")
     args_list = norm_as_list(build_desc.get('args', {}))
-    for build_arg in args_list + args.build_arg:
+    for build_arg in args_list:
         build_args.extend(("--build-arg", build_arg,))
     build_args.append(ctx)
     compose.podman.run(build_args, sleep=0)


### PR DESCRIPTION
Needed "devices" option only available within devel branch, however devel branch broken as of yesterday due to "orphaned"  `args.build_arg`, probably just WIP, removed here. 

Just close pull request if obsolete.

Best,

Johannes