### PR TITLE
ENH: forward restart policy, compose build args appended up args

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -567,7 +567,7 @@ def container_to_args(compose, cnt, detached=True, podman_command='run'):
     if cnt.get('privileged', None):
         podman_args.append('--privileged')
     if cnt.get('restart', None) is not None:
-        podman_args.append(['--restart', cnt['restart']])
+        podman_args.extend(['--restart', cnt['restart']])
     container_to_ulimit_args(cnt, podman_args)
     # currently podman shipped by fedora does not package this
     # if cnt.get('init', None):

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -566,6 +566,8 @@ def container_to_args(compose, cnt, detached=True, podman_command='run'):
         podman_args.append('--tty')
     if cnt.get('privileged', None):
         podman_args.append('--privileged')
+    if cnt.get('restart', None) is not None:
+        podman_args.append(['--restart', cnt['restart']])
     container_to_ulimit_args(cnt, podman_args)
     # currently podman shipped by fedora does not package this
     # if cnt.get('init', None):
@@ -1292,7 +1294,8 @@ def compose_up_parse(parser):
         help="Return the exit code of the selected service container. Implies --abort-on-container-exit.")
     parser.add_argument('services', metavar='SERVICES', nargs='*',
         help='service names to start')
-
+    # might want to add build-related options to  'up' command as 'up' might evoke build if images not available
+    compose_build_parse(parser)
 
 @cmd_parse(podman_compose, 'run')
 def compose_run_parse(parser):

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1280,8 +1280,6 @@ def compose_up_parse(parser):
         help="Don't start the services after creating them.")
     parser.add_argument("--build", action='store_true',
         help="Build images before starting containers.")
-    parser.add_argument("--build-arg", metavar="key=val", action="append", default=[],
-        help="Set build-time variables for services.")
     parser.add_argument("--abort-on-container-exit", action='store_true',
         help="Stops all containers if any container was stopped. Incompatible with -d.")
     parser.add_argument("-t", "--timeout", type=float, default=10,
@@ -1296,8 +1294,6 @@ def compose_up_parse(parser):
         help="Return the exit code of the selected service container. Implies --abort-on-container-exit.")
     parser.add_argument('services', metavar='SERVICES', nargs='*',
         help='service names to start')
-    # might want to add build-related options to  'up' command as 'up' might evoke build if images not available
-    compose_build_parse(parser)
 
 @cmd_parse(podman_compose, 'run')
 def compose_run_parse(parser):
@@ -1368,7 +1364,7 @@ def compose_ps_parse(parser):
     parser.add_argument("-q", "--quiet",
         help="Only display container IDs", action='store_true')
 
-@cmd_parse(podman_compose, 'build')
+@cmd_parse(podman_compose, ['build', 'up'])
 def compose_build_parse(parser):
     parser.add_argument("--pull",
         help="attempt to pull a newer version of the image", action='store_true')


### PR DESCRIPTION
Two suggestions:

1 - Simple forwarding of restart policy to `podman run`, tested for policy 'always' as in the following compose file snippet on podman v 1.6.4:

```yaml
...
services:
  mongodb:
    image: mongod-on-smb
    init: true
    restart: always
...
```

2 - appending `build` command args to up command args, as `up` might build images if they don't exist already. That replaces https://github.com/containers/podman-compose/pull/179 .

Best,

Johannes