### PR TITLE
Fix infinite loop

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1151,12 +1151,13 @@ def compose_up(compose, args):
         thread.start()
         threads.append(thread)
         time.sleep(1)
-    while True:
+    while threads:
         for thread in threads:
             thread.join(timeout=1.0)
-            if thread.is_alive(): continue
-            if args.abort_on_container_exit:
-                exit(-1)
+            if not thread.is_alive():
+                threads.remove(thread)
+                if args.abort_on_container_exit:
+                    exit(-1)
 
 @cmd_run(podman_compose, 'down', 'tear down entire stack')
 def compose_down(compose, args):


### PR DESCRIPTION
Since we never remove thread from the list of thread, podman-compose
up never return as long as 1 thread is alive.