### PR TITLE
Do not specify a 1 second timeout when stopping

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1162,7 +1162,7 @@ def compose_up(compose, args):
 @cmd_run(podman_compose, 'down', 'tear down entire stack')
 def compose_down(compose, args):
     for cnt in compose.containers:
-        compose.podman.run(["stop", "-t=1", cnt["name"]], sleep=0)
+        compose.podman.run(["stop", cnt["name"]], sleep=0)
     for cnt in compose.containers:
         compose.podman.run(["rm", cnt["name"]], sleep=0)
     for pod in compose.pods:


### PR DESCRIPTION
Even though we're throwing away this container we need to respect the default timeout in order to properly save volumes and close connections.