### PR TITLE
Pass environment variables from .env file

### DIFF
--- a/tests/environment/README.md
+++ b/tests/environment/README.md
@@ -1,0 +1,33 @@
+# Test compose environment variables
+
+Run from this directory:
+
+```sh
+THIS_VARIABLE_SHOULD_BE_SET_BY_SHELL=SUCCESS podman-compose up
+```
+
+Ensure that the following environment variables are set inside the `print_env`
+service container:
+
+```
+THIS_VARIABLE_SHOULD_BE_SET=SUCCESS
+THIS_VARIABLE_SHOULD_BE_SET_BY_SHELL=SUCCESS
+THIS_VARIABLE_SHOULD_BE_SET_TOO=SUCCESS
+
+```
+
+In the successful case, you should see logs like this:
+
+```
+podman start -a environment_print_env_1
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+TERM=xterm
+HOSTNAME=cafebadcafe
+container=podman
+THIS_VARIABLE_SHOULD_BE_SET=SUCCESS
+THIS_VARIABLE_SHOULD_BE_SET_BY_SHELL=SUCCESS
+THIS_VARIABLE_SHOULD_BE_SET_TOO=SUCCESS
+HOME=/root
+```
+
+Remember to run `podman-compose down` to clean up afterwards!

--- a/tests/environment/docker-compose.yaml
+++ b/tests/environment/docker-compose.yaml
@@ -1,0 +1,10 @@
+version: "3"
+services:
+  print_env:
+    image: busybox
+    command: ["/bin/busybox", "env"]
+    environment:
+      - THIS_VARIABLE_SHOULD_BE_SET # Default value provided in .env file.
+      - THIS_VARIABLE_SHOULD_BE_SET_BY_SHELL # Set this when running compose.
+      - THIS_VARIABLE_SHOULD_BE_SET_TOO=SUCCESS
+      - THIS_VARIABLE_SHOULD_BE_UNSET # Default not provided in .env file.


### PR DESCRIPTION
According to the docker-compose docs[1], environment variables specified
without values should use corresponding values from shell variables or
defaults set in a `.env` file.

[1]https://docs.docker.com/compose/environment-variables/#pass-environment-variables-to-containers

Test: See tests/environment/README.md.