### PR TITLE
Support for --ipc flag

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -560,6 +560,8 @@ def container_to_args(compose, cnt, detached=True, podman_command='run'):
         podman_args.extend(['--hostname', cnt['hostname']])
     if cnt.get('shm_size', None):
         podman_args.extend(['--shm-size', '{}'.format(cnt['shm_size'])])
+    if cnt.get('ipc', None):
+        podman_args.extend(['--ipc', cnt['ipc']])
     if cnt.get('stdin_open', None):
         podman_args.append('-i')
     if cnt.get('tty', None):


### PR DESCRIPTION
Support for --ipc flag as defined in the [docker-compose schema](https://github.com/docker/compose/blob/7ae632a9ee7530fcf81e212baa3e588f477ea862/compose/config/config_schema_v2.4.json#L205)

Validation:
```
$ cat docker-compose.yml 
version: '2'
services:
  test:
    image: test_image:latest
    container_name: test
    ipc: host

$ podman-compose up
using podman version: podman version 2.0.2
podman pod create --name=tmp --share net
b39c3eec07eef465b9e2bf5873c9a621784b20cd7c31deff57087ee2bea2361e
0
podman create --name=test --pod=tmp --label io.podman.compose.config-hash=123 --label io.podman.compose.project=tmp --label io.podman.compose.version=0.0.1 --label com.docker.compose.container-number=1 --label com.docker.compose.service=test --add-host test:127.0.0.1 --add-host test:127.0.0.1 --ipc host test_image:latest
```
Results in my test image creating a file in `/dev/shm/` on the host.