### PR TITLE
support str style configuration for env_file

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -533,7 +533,9 @@ def container_to_args(compose, cnt, detached=True, podman_command='run'):
         podman_args.extend(['--device', d])
     for e in env:
         podman_args.extend(['-e', e])
-    for i in cnt.get('env_file', []):
+    env_file = cnt.get('env_file', [])
+    if is_str(env_file): env_file = [env_file]
+    for i in env_file:
         i = os.path.realpath(os.path.join(dirname, i))
         podman_args.extend(['--env-file', i])
     tmpfs_ls = cnt.get('tmpfs', [])


### PR DESCRIPTION
In "docker-compose.yml", `env_file: .env` is valid configuration. However, podman-compose parses it like below.

>  --env-file /path/to/project 
 --env-file /path/to/project/e
 --env-file /path/to/project/n 
 --env-file /path/to/project/v 


podman-compose expected configration like

```
env_file: 
   - .env
```

only. It's not good for compatibility with docker-compose.

This is PR for supports both type configurations.
