### PR TITLE
Fixes #236: Ensure project name works with podman

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -864,7 +864,8 @@ class PodmanCompose:
         os.chdir(dirname)
 
         if not project_name:
-            project_name = dir_basename.lower()
+            # More strict then acually needed for simplicity: podman requires [a-zA-Z0-9][a-zA-Z0-9_.-]*
+            project_name = re.sub(r'[^a-zA-Z0-9]', '', dir_basename)
         self.project_name = project_name
 
 


### PR DESCRIPTION
In case we use dir_basename as podman project name, ensure it matches
podman project name requirement regex: [a-zA-Z0-9][a-zA-Z0-9_.-]*