### PR TITLE
Fix 'podman-compose version' with no compose file in the working dir

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -800,7 +800,6 @@ class PodmanCompose:
 
     def run(self):
         args = self._parse_args()
-        self._parse_compose_file()
         podman_path = args.podman_path
         if podman_path != 'podman':
             if os.path.isfile(podman_path) and os.access(podman_path, os.X_OK):
@@ -822,6 +821,8 @@ class PodmanCompose:
                 exit(1)
             print("using podman version: "+self.podman_version)
         cmd_name = args.command
+        if (cmd_name != "version"):
+            self._parse_compose_file()
         cmd = self.commands[cmd_name]
         cmd(self, args)
 


### PR DESCRIPTION
The command 'podman-compose version' ends with the error message
    no docker-compose.yml or container-compose.yml file found, pass files with -f
if no compose file exists in the working directory.
It should just display the version number instead and exit.