### PR TITLE
Allow environment variables to be unset

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -191,7 +191,7 @@ def norm_as_list(src):
     if src is None:
         dst = []
     elif is_dict(src):
-        dst = [("{}={}".format(k, v) if v else k) for k, v in src.items()]
+        dst = [("{}={}".format(k, v) if v is not None else k) for k, v in src.items()]
     elif is_list(src):
         dst = list(src)
     else:


### PR DESCRIPTION
Leaving keys with empty values in YAML will result in the value
ending up being None after parsing the configuration file. This
should result in the variable being imported from the external
environment according to the Compose file version 3 reference.
The resulting action for podman should be an added "-e VAR"
(without =), which is working correctly.

However, when overwriting an external variable by setting it to
e.g. "", the result in docker-compose is that the variable is
unset. For podman, this means adding "-e VAR=". This is not the
case, and this patch does a more strict check to make this case
behave correctly.