### PR TITLE
Only pull each image once

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1055,9 +1055,12 @@ def compose_version(compose, args):
 
 @cmd_run(podman_compose, 'pull', 'pull stack images')
 def compose_pull(compose, args):
+    images = set()
     for cnt in compose.containers:
         if cnt.get('build', None): continue
-        compose.podman.run(["pull", cnt["image"]], sleep=0)
+        images.add(cnt["image"])
+    for image in images:
+        compose.podman.run(["pull", image], sleep=0)
 
 @cmd_run(podman_compose, 'push', 'push stack images')
 def compose_push(compose, args):


### PR DESCRIPTION
This matches the docker-compose behavior, and speeds up the `pull` command by avoiding redundant duplicate pulls of the same image multiple times.

In my specific case this happens because I have multiple containers defined that use a Kafka image (some brokers, some tool containers that run and configure things and then exit).