### PR TITLE
Add support for sysctls in compose file

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -565,6 +565,8 @@ def container_to_args(compose, cnt, detached=True, podman_command='run'):
         podman_args.extend(['--shm-size', '{}'.format(cnt['shm_size'])])
     if cnt.get('stdin_open', None):
         podman_args.append('-i')
+    for i in cnt.get('sysctls', []):
+        podman_args.extend(['--sysctl', i])
     if cnt.get('tty', None):
         podman_args.append('--tty')
     if cnt.get('privileged', None):


### PR DESCRIPTION
See https://github.com/compose-spec/compose-spec/blob/master/spec.md#sysctls

I only tested the list format, e.g.:
```
sysctls:
    - net.ipv6.conf.all.disable_ipv6=1
```