### PR TITLE
Move Python installation and test deps to requirement files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+# The order of packages is significant, because pip processes them in the order
+# of appearance. Changing the order has an impact on the overall integration
+# process, which may cause wedges in the gate later.
+
+pyyaml

--- a/setup.py
+++ b/setup.py
@@ -40,14 +40,4 @@ setup(
     },
     include_package_data=True,
     license='GPL-2.0-only',
-    install_requires=[
-        'pyyaml'
-    ],
-    # test_suite='tests',
-    # tests_require=[
-    #     'coverage',
-    #     'pytest-cov',
-    #     'pytest',
-    #     'tox',
-    # ]
 )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,8 @@
+# The order of packages is significant, because pip processes them in the order
+# of appearance. Changing the order has an impact on the overall integration
+# process, which may cause wedges in the gate later.
+
+coverage
+pytest-cov
+pytest
+tox


### PR DESCRIPTION
Installation with setup.py fails on missing yaml package, which should
be installed by "install_requires" but this also does not work because
podman_compose.__version__ also needs yaml.
Put all the Python dependencies into separate files:
    - requirements.txt
    - test-requirements.txt