### PR TITLE
fix: check `.env` in current dir with `isfile` instead of `exists`

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -875,7 +875,7 @@ class PodmanCompose:
 
 
         dotenv_path = os.path.join(dirname, ".env")
-        if os.path.exists(dotenv_path):
+        if os.path.isfile(dotenv_path):
             with open(dotenv_path, 'r') as f:
                 dotenv_ls = [l.strip() for l in f if l.strip() and not l.startswith('#')]
                 dotenv_dict = dict([l.split("=", 1) for l in dotenv_ls if "=" in l])


### PR DESCRIPTION
This prevents cases in which an `.env` directory exists, for example
in Python projects with a local virtual environment, and then
dotenv gets passed the directory path as input.