### PR TITLE
Add `podman-compose exec` support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,6 @@ def compose_up(compose, args):
   config             Validate and view the Compose file
   create             Create services
   events             Receive real time events from containers
-  exec               Execute a command in a running container
   images             List images
   kill               Kill containers
   logs               View output from containers

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1262,8 +1262,6 @@ def compose_exec(compose, args):
         cnt['environment'].update(additional_env_vars)
     # run podman
     podman_args = container_to_args(compose, cnt, args.detach, podman_command="exec")
-    print(podman_args)
-    return
     compose.podman.run(podman_args, sleep=0)
 
 


### PR DESCRIPTION
As it was missing and I needed it. :-)

Argument generation is quite rough, but that seemed to be the quickest way to get it. This supports all arguments supported by podman 1.6.4 - as that is my use case.

What do you think?
