### PR TITLE
Add stop_signal service attribute

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -571,6 +571,8 @@ def container_to_args(compose, cnt, detached=True):
         podman_args.extend(['--shm-size', '{}'.format(cnt['shm_size'])])
     if cnt.get('stdin_open', None):
         podman_args.append('-i')
+    if cnt.get('stop_signal', None):
+        podman_args.extend(['--stop-signal', cnt['stop_signal']])
     for i in cnt.get('sysctls', []):
         podman_args.extend(['--sysctl', i])
     if cnt.get('tty', None):


### PR DESCRIPTION
This adds support for the `stop_signal` attribute.
It's for programs that need a different signal to shut down. For example, some cli tools prefer `SIGINT` and systemd needs `SIGRTMIN+3`.