### PR TITLE
Convert numeric command arguments to string (fixes #77)

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -705,7 +705,7 @@ class Podman:
         return subprocess.check_output(cmd_ls)
 
     def run(self, podman_args, cmd='', cmd_args=None, wait=True, sleep=1, obj=None):
-        cmd_args = cmd_args or []
+        cmd_args = list(map(str, cmd_args or []))
         xargs = self.compose.get_podman_args(cmd) if cmd else []
         cmd_ls = [self.podman_path, *podman_args, cmd] + xargs + cmd_args
         print(" ".join(cmd_ls))


### PR DESCRIPTION
The input argument cmd_args is a list which may contain numeric elements.

Convert all elements to strings before passing them to functions which
expect str data type.

Signed-off-by: Stefan Weil <sw@weilnetz.de>