### PR TITLE
Add support for 'Containerfile' when building images

### DIFF
--- a/tests/build/docker-compose.yml
+++ b/tests/build/docker-compose.yml
@@ -20,6 +20,6 @@ services:
     test_build_arg_argument:
       build:
         context: ./context
-        dockerfile: Dockerfile-alt
+        containerfile: Dockerfile-alt
       image: my-busybox-httpd2
       command: env


### PR DESCRIPTION
- Add support for `cnt['build']['containerfile']` (same behaviour as `dockerfile`).
- Add support for `Containerfile` if `cnt['build']['containerfile']` is not specified.

e.g.
```
.
├── api
│   └── Containerfile.yaml
└── web
    └── Containerfile.staging.yaml
```
```yaml
services:
  web:
    build:
      context: ./web
      containerfile: Containerfile.staging.yaml

  api:
    build: ./api # Now works without having to specify `Containerfile`
```