### PR TITLE
Update podman_compose.py

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -901,6 +901,8 @@ class PodmanCompose:
                 "compose.yml",
                 "compose.override.yaml",
                 "compose.override.yml",
+		"podman-compose.yaml",
+		"podman-compose.yml",
                 "docker-compose.yml",
                 "docker-compose.yaml",
                 "docker-compose.override.yml",


### PR DESCRIPTION
Simple change.
It would be nice to use "podman-compose.yml" as a compose file name. "compose.yml" is useful, but I prefer the clarity of having the "podman" prefix.