### PR TITLE
Add support for secrets

### DIFF
--- a/tests/secrets/bad_external_name/docker-compose.yaml
+++ b/tests/secrets/bad_external_name/docker-compose.yaml
@@ -1,0 +1,18 @@
+version: "3.8"
+services:
+    test:
+      image: busybox
+      command:
+        - cat
+        - /run/secrets/new_secret
+      tmpfs:
+        - /run
+        - /tmp
+      secrets:
+        - new_secret
+
+secrets:
+  new_secret:
+    external: true
+    name: my_secret
+

--- a/tests/secrets/bad_external_target/docker-compose.yaml
+++ b/tests/secrets/bad_external_target/docker-compose.yaml
@@ -1,0 +1,18 @@
+version: "3.8"
+services:
+    test:
+      image: busybox
+      command:
+        - cat
+        - /run/secrets/my_secret_2
+      tmpfs:
+        - /run
+        - /tmp
+      secrets:
+        - source: my_secret
+          target: new_secret
+
+secrets:
+  my_secret:
+    external: true
+

--- a/tests/secrets/docker-compose.yaml
+++ b/tests/secrets/docker-compose.yaml
@@ -1,0 +1,42 @@
+version: "3.8"
+services:
+    test:
+      image: busybox
+      command:
+        - /tmp/print_secrets.sh
+      tmpfs:
+        - /run
+        - /tmp
+      volumes:
+        - ./print_secrets.sh:/tmp/print_secrets.sh
+      secrets:
+        - my_secret
+        - my_secret_2
+        - source: my_secret_3
+          target: my_secret_3
+          uid: '103'
+          gid: '103'
+          mode: 400
+        - file_secret
+        - source: file_secret
+          target: custom_name
+        - source: file_secret
+          target: /etc/custom_location
+        - source: file_secret
+          target: unused_params_warning
+          uid: '103'
+          gid: '103'
+          mode: 400
+
+secrets:
+  my_secret:
+    external: true
+  my_secret_2:
+    external: true
+    name: my_secret_2
+  my_secret_3:
+    external: true
+    name: my_secret_3
+  file_secret:
+    file: ./my_secret
+

--- a/tests/secrets/my_secret
+++ b/tests/secrets/my_secret
@@ -1,0 +1,1 @@
+important-secret-is-important

--- a/tests/secrets/print_secrets.sh
+++ b/tests/secrets/print_secrets.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+ls -la /run/secrets/*
+ls -la /etc/custom_location
+cat /run/secrets/*
+cat /etc/custom_location


### PR DESCRIPTION
Adds support for -
- (1) Declared secrets with the file location.
- (2) Declared secrets with file location, mounted as a different named secret.
- (3) Declared secrets with file location, mounted at arbitrary location.
- (4) External secrets (type=mount), mounted as original secret name.
- (5) External secrets (type=mount), mounted as original secret name, with specified uid, gid and mode.

Additionally added compose files for testing the positive and negative test-cases for the new functionality.