### PR TITLE
Fix `up` arguments parsing

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1534,8 +1534,6 @@ def compose_up_parse(parser):
         help="Scale SERVICE to NUM instances. Overrides the `scale` setting in the Compose file if present.")
     parser.add_argument("--exit-code-from", metavar='SERVICE', type=str, default=None,
         help="Return the exit code of the selected service container. Implies --abort-on-container-exit.")
-    parser.add_argument('services', metavar='SERVICES', nargs='*',
-        help='service names to start')
 
 @cmd_parse(podman_compose, 'run')
 def compose_run_parse(parser):


### PR DESCRIPTION
These is already parsed here.

https://github.com/containers/podman-compose/blob/502d7cc206da1f20cc9aef480f93f6b32d576f80/podman_compose.py#L1644