### PR TITLE
Fix setup.py for pipx

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [bdist_wheel]
 universal = 1
+
+[metadata]
+version = attr: podman_compose.__version__

--- a/setup.py
+++ b/setup.py
@@ -6,11 +6,8 @@ try:
 except:
     readme = ''
 
-from podman_compose import __version__ as podman_compose_version
-
 setup(
     name='podman-compose',
-    version=podman_compose_version,
     description="A script to run docker-compose.yml using podman",
     long_description=readme,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Currently, pipx cannot install devel branch of podman-compose:

```
$ pipx install https://github.com/containers/podman-compose/archive/devel.tar.gz
    ERROR: Command errored out with exit status 1:
     command: /tmp/tmp7pnt367r/bin/python -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-req-build-elna2riz/setup.py'"'"'; __file__='"'"'/tmp/pip-req-build-elna2riz/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-u9tn4j8l
         cwd: /tmp/pip-req-build-elna2riz/
    Complete output (7 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-req-build-elna2riz/setup.py", line 9, in <module>
        from podman_compose import __version__ as podman_compose_version
      File "/tmp/pip-req-build-elna2riz/podman_compose.py", line 36, in <module>
        import yaml
    ModuleNotFoundError: No module named 'yaml'
    ----------------------------------------
WARNING: Discarding https://github.com/containers/podman-compose/archive/devel.tar.gz. Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
Cannot determine package name from spec 'https://github.com/containers/podman-compose/archive/devel.tar.gz'. Check package spec for errors.
```

While pipx reading `setup.py`, `setup.py` tries to import `__version__` from `podman_compose` module, and `podman_compose` module tries to import `yaml` module, which is not installed in this moment.

This PR moves `__version__` constant to separate module, and adds `pyyaml` to `install_requires` in `setup.py`