### PR TITLE
fix AttributeError when running a one-off command

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1526,7 +1526,7 @@ def compose_run(compose, args):
         up_args = argparse.Namespace(**dict(args.__dict__,
                detach=True, services=deps,
                # defaults
-               no_build=False, build=True, force_recreate=False, no_start=False,
+               no_build=False, build=True, force_recreate=False, no_start=False, no_cache=False, build_arg=[],
                )
         )
         compose.commands['up'](compose, up_args)


### PR DESCRIPTION
Without this, I get errors when running "podman-compose -p podname run".