### PR TITLE
Allow empty default/error value in substitution

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -179,8 +179,8 @@ var_re = re.compile(r"""
         (?:{
             (?P<braced>[_a-zA-Z][_a-zA-Z0-9]*)
             (?:(?P<empty>:)?(?:
-                (?:-(?P<default>[^}]+)) |
-                (?:\?(?P<err>[^}]+))
+                (?:-(?P<default>[^}]*)) |
+                (?:\?(?P<err>[^}]*))
             ))?
         })
     )


### PR DESCRIPTION
Looks like #174 was undone in https://github.com/containers/podman-compose/commit/00840d0613f4eb689975bc214f9b1883fc15dfe4.

Merge #389 before this.