### PR TITLE
Add necessary commands for VSCode Devcontainers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,5 +70,4 @@ def compose_up(compose, args):
   scale              Set number of containers for a service
   top                Display the running processes
   unpause            Unpause services
-  version            Show the Docker-Compose version information
 ```

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1280,13 +1280,13 @@ class cmd_parse:
 
 @cmd_run(podman_compose, 'version', 'show version')
 def compose_version(compose, args):
-    # log("podman-composer version", __version__)
     if getattr(args, 'short', False): 
         print(__version__)
         return
     if getattr(args, 'format', 'pretty') == 'json':
         print('{ "version": "{version}" }'.replace('{version}', __version__))
         return
+    log("podman-composer version", __version__)
     compose.podman.run(["--version"], "", [], sleep=0)
 
 def is_local(container: dict) -> bool:

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1648,6 +1648,15 @@ def compose_logs(compose, args):
         podman_args.append(target)
     compose.podman.run([], 'logs', podman_args)
 
+@cmd_run(podman_compose, 'config', "displays the compose file")
+def compose_config(compose, args):
+    file_path = getattr(args, 'file', [])[0]
+    if (file_path == None):
+        sys.stderr("File path is required. use -f flag to set the input file")
+        return
+    f = open(file_path, "r")
+    print(f.read())
+
 ###################
 # command arguments parsing
 ###################

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1280,7 +1280,13 @@ class cmd_parse:
 
 @cmd_run(podman_compose, 'version', 'show version')
 def compose_version(compose, args):
-    log("podman-composer version ", __version__)
+    # log("podman-composer version", __version__)
+    if getattr(args, 'short', False): 
+        print(__version__)
+        return
+    if getattr(args, 'format', 'pretty') == 'json':
+        print('{ "version": "{version}" }'.replace('{version}', __version__))
+        return
     compose.podman.run(["--version"], "", [], sleep=0)
 
 def is_local(container: dict) -> bool:
@@ -1645,6 +1651,13 @@ def compose_logs(compose, args):
 ###################
 # command arguments parsing
 ###################
+
+@cmd_parse(podman_compose, 'version')
+def compose_version_parse(parser):
+    parser.add_argument("-f", "--format", type=str, default='pretty', 
+        help="Format the output. Values: [pretty | json].")
+    parser.add_argument("--short", action='store_true', 
+        help="Shows only Podman Compose's version number")
 
 @cmd_parse(podman_compose, 'up')
 def compose_up_parse(parser):

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1284,7 +1284,8 @@ def compose_version(compose, args):
         print(__version__)
         return
     if getattr(args, 'format', 'pretty') == 'json':
-        print('{ "version": "{version}" }'.replace('{version}', __version__))
+        res = {"version": __version__}
+        print(json.dumps(res))
         return
     log("podman-composer version", __version__)
     compose.podman.run(["--version"], "", [], sleep=0)
@@ -1651,9 +1652,6 @@ def compose_logs(compose, args):
 @cmd_run(podman_compose, 'config', "displays the compose file")
 def compose_config(compose, args):
     file_path = getattr(args, 'file', [])[0]
-    if (file_path == None):
-        sys.stderr("File path is required. use -f flag to set the input file")
-        return
     f = open(file_path, "r")
     print(f.read())
 
@@ -1663,8 +1661,8 @@ def compose_config(compose, args):
 
 @cmd_parse(podman_compose, 'version')
 def compose_version_parse(parser):
-    parser.add_argument("-f", "--format", type=str, default='pretty', 
-        help="Format the output. Values: [pretty | json].")
+    parser.add_argument("-f", "--format", choices=['pretty', 'json'], default='pretty',
+        help="Format the output")
     parser.add_argument("--short", action='store_true', 
         help="Shows only Podman Compose's version number")
 


### PR DESCRIPTION
Changes:
* Added `short` and `format` args to `version` command
* Added a trivial implementation of the `config` command which echos out the content when given an absolute path of a file

Resolves:
* microsoft/vscode-remote-release#5553
* #106 