### PR TITLE
Fix healthcheck test type on replicas

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -755,6 +755,7 @@ def container_to_args(compose, cnt, detached=True):
             # podman does not add shell to handle command with whitespace
             podman_args.extend(['--healthcheck-command', '/bin/sh -c {}'.format(cmd_quote(healthcheck_test))])
         elif is_list(healthcheck_test):
+            healthcheck_test = healthcheck_test.copy()
             # If it's a list, first item is either NONE, CMD or CMD-SHELL.
             healthcheck_type = healthcheck_test.pop(0)
             if healthcheck_type == 'NONE':


### PR DESCRIPTION
As we have healthcheck test described in list:
```
services:
  memcached:
    image: "memcached:1.6.9-alpine"
    deploy:
      replicas: 2
    healthcheck:
      test:
        - "CMD-SHELL"
        - 'echo stats | nc 127.0.0.1 11211'
```

`podman-compose up -d` will fails:
```
# podman-compose up -d
['podman', '--version', '']
using podman version: 3.0.2-dev
** excluding:  set()
['podman', 'network', 'exists', 'test_default']
podman run --name=test_memcached_1 -d --label io.podman.compose.config-hash=123 --label io.podman.compose.project=test --label io.podman.compose.version=0.0.1 --label com.docker.compose.project=test --label com.docker.compose.project.working_dir=/root/src/test --label com.docker.compose.project.config_files=docker-compose.yml --label com.docker.compose.container-number=1 --label com.docker.compose.service=memcached --net test_default --network-alias memcached --healthcheck-command /bin/sh -c 'echo stats | nc 127.0.0.1 11211' memcached:1.6.9-alpine
55379eed332b8393223b39bef08ac8afa0ef7c8800871e1792053f9eeaa0752f
exit code: 0
['podman', 'network', 'exists', 'test_default']
Traceback (most recent call last):
  File "/usr/local/bin/podman-compose", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.6/site-packages/podman_compose.py", line 1776, in main
    podman_compose.run()
  File "/usr/local/lib/python3.6/site-packages/podman_compose.py", line 1025, in run
    cmd(self, args)
  File "/usr/local/lib/python3.6/site-packages/podman_compose.py", line 1249, in wrapped
    return func(*args, **kw)
  File "/usr/local/lib/python3.6/site-packages/podman_compose.py", line 1416, in compose_up
    podman_args = container_to_args(compose, cnt, detached=args.detach)
  File "/usr/local/lib/python3.6/site-packages/podman_compose.py", line 735, in container_to_args
    .format(healthcheck_type)
ValueError: unknown healthcheck test type [echo stats | nc 127.0.0.1 11211],                     expecting NONE, CMD or CMD-SHELL.
```

This PR will fix this by copying the `healthcheck_test` variable when it is list type.