### PR TITLE
Fix timeout value data type

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1782,7 +1782,7 @@ def compose_up_parse(parser):
         help="Build images before starting containers.")
     parser.add_argument("--abort-on-container-exit", action='store_true',
         help="Stops all containers if any container was stopped. Incompatible with -d.")
-    parser.add_argument("-t", "--timeout", type=float, default=10,
+    parser.add_argument("-t", "--timeout", type=int, default=10,
         help="Use this timeout in seconds for container shutdown when attached or when containers are already running. (default: 10)")
     parser.add_argument("-V", "--renew-anon-volumes", action='store_true',
         help="Recreate anonymous volumes instead of retrieving data from the previous containers.")


### PR DESCRIPTION
The data type for the timeout flag of the `podman-compose up` command is set as `float` instead of `int`, which causes values provided to be converted to float values (like 10.0) and error out.

If I run `podman-compose up --force-recreate --timeout 1` I get an error like:
`Error: invalid argument "1.0" for "-t, --time" flag: strconv.ParseUint: parsing "1.0": invalid syntax`.

This commit fixes it to `int` instead. Pls let me know your thoughts.

Thanks!