### PR TITLE
[FIX] extended compose file with build context not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,4 +112,8 @@ There is also AWX 17.1.0
 Inside `tests/` directory we have many useless docker-compose stacks
 that are meant to test as much cases as we can to make sure we are compatible
 
-
+### pytest
+run a pytest with following command
+````shell
+pytest tests/test_podman_compose.py
+````

--- a/tests/extends_w_file_subdir/docker-compose.yml
+++ b/tests/extends_w_file_subdir/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3"
+services:
+  web:
+    extends:
+      file: sub/docker-compose.yml
+      service: webapp
+    environment:
+      - DEBUG=1

--- a/tests/extends_w_file_subdir/sub/docker-compose.yml
+++ b/tests/extends_w_file_subdir/sub/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3"
+services:
+  webapp:
+    build:
+      context: docker/example
+      dockerfile: Dockerfile
+    image: localhost/subdir_test:me
+    ports:
+      - "8000:8000"
+    volumes:
+      - "/data"
+

--- a/tests/extends_w_file_subdir/sub/docker/example/Dockerfile
+++ b/tests/extends_w_file_subdir/sub/docker/example/Dockerfile
@@ -1,0 +1,1 @@
+FROM bash as base

--- a/tests/test_podman_compose.py
+++ b/tests/test_podman_compose.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+import pytest
+import podman_compose
+import subprocess
+
+
+def capture(command):
+    proc = subprocess.Popen(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    out, err = proc.communicate()
+    return out, err, proc.returncode
+
+def test_podman_compose_extends_w_file_subdir():
+    """
+    Test that podman-compose can execute podman-compose -f <file> up with extended File which
+    includes a build context
+    :return:
+    """
+    main_path = Path(__file__).parent.parent
+
+    command_up = [
+        "python3",
+        str(main_path.joinpath("podman_compose.py")),
+        "-f",
+        str(main_path.joinpath("tests", "extends_w_file_subdir", "docker-compose.yml")),
+        "up",
+        "-d"
+    ]
+
+    command_check_container = [
+        "podman",
+        "container",
+        "ps",
+        "--all",
+        "--format",
+        "\"{{.Image}}\""
+    ]
+
+    command_down = [
+        "podman",
+        "rmi",
+        "--force",
+        "localhost/subdir_test:me",
+        "docker.io/library/bash"
+    ]
+
+    out, err, returncode = capture(command_up)
+    assert 0 == returncode
+    # check container was created and exists
+    out, err, returncode = capture(command_check_container)
+    assert 0 == returncode
+    assert out == b'"localhost/subdir_test:me"\n'
+    out, err, returncode = capture(command_down)
+    # cleanup test image(tags)
+    assert 0 == returncode
+    # check container did not exists anymore
+    out, err, returncode = capture(command_check_container)
+    assert 0 == returncode
+    assert out == b''

--- a/tests/test_podman_compose.py
+++ b/tests/test_podman_compose.py
@@ -1,6 +1,4 @@
 from pathlib import Path
-import pytest
-import podman_compose
 import subprocess
 
 


### PR DESCRIPTION
Hi @muayyad-alsadi and all other contributers,

With this PR I want to fix the issue with the extended Build-Context which is not working at this time.

I created a sample folder with following structure:

``` 
extends_w_file_subdir
 |--> docker-compose.yml
 |--> sub
   |--> docker-compose.yml
   |--> docker
     |--> example
       |--> Dockerfile
```

If I tried the cmd `./podman_compose.py -f tests/extends_w_file_subdir/docker-compose.yml up -d` I received the message that the docker/example/Dockerfile can not be found.

The goal is to prefix the context path in the extended File with path of the extending File.
I have also wrote a little pytest to check that the container was build successful.

Please can you check if this can solve some reported issues?
Thanks a lot!

PS: Can solve the Issue [#130](https://github.com/containers/podman-compose/issues/130)