### PR TITLE
Quit when an unknown service operation is reqested

### DIFF
--- a/tests/unknown_service/docker-compose.yaml
+++ b/tests/unknown_service/docker-compose.yaml
@@ -1,0 +1,5 @@
+version: "3.7"
+services:
+    sleep:
+      image: busybox
+      command: ["/bin/busybox", "sh", "-c", "sleep 3600"]

--- a/tests/unknown_service/test.sh
+++ b/tests/unknown_service/test.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+PODMAN_COMPOSE="${PODMAN_COMPOSE:-../../podman_compose.py}"
+
+failed=false
+commands='build up down run exec start stop restart logs'
+
+for cmd in $commands; do
+  $PODMAN_COMPOSE "$cmd" xyz 2>/dev/null
+  exit_code=$?
+  if [ $exit_code -ne 1 ]; then
+    echo "Expected command $cmd to exit with code 1 for unknown service, got exit code $exit_code"
+    failed=true
+  fi
+done
+
+if $failed; then
+  exit 1
+fi


### PR DESCRIPTION
Certain commands like build up down run exec start stop restart logs,
when executed for a service that does not exist, should result in a
human friendly message and exit code 1.

Update the podman_compose.py provide and use service_or_exit function,
that terminates the process if a service with the requested name does
not exist (is not defined).

	% ./podman_compose.py logs xyz
	podman-compose version: 1.0.4
	['podman', '--version', '']
	using podman version: 3.4.4
	Service xyz has not been found.
	% echo $?
	1

Resolve #434