### PR TITLE
Inverted condition in merging arguments

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1140,7 +1140,7 @@ def rec_merge_one(target, source):
         if key not in source:
             continue
         value2 = source[key]
-        if isinstance(value2, type(value)):
+        if not isinstance(value2, type(value)):
             value_type = type(value)
             value2_type = type(value2)
             raise ValueError(


### PR DESCRIPTION
Looks like commit 5c33e4efbb145d72b06bef3ac5c8245afbd14552 accidentally inverted a conditional which broke when multiple values of the same argument were given, such as the following (taken from error logs of Visual Studio Code Remote Containers extension):

```
podman-compose --project-name <redacted> -f <redacted>/docker-compose.yml -f <redacted>/.config/Code/User/globalStorage/ms-vscode-remote.remote-containers/data/docker-compose/docker-compose.devcontainer.containerFeatures-xxxxxxxxxx.yml up -d
```

I'm not a Python expert, and hopefully this fix is not breaking any styling guidelines. Parts of the command line have been redacted because this issue was discovered when working on an internal work project.