### PR TITLE
Implement conditional depends_on

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1985,7 +1985,7 @@ def wait_healthy(compose, container_name):
     if not info["Config"].get("Healthcheck"):
         raise ValueError("Container %s does not define a health check" % container_name)
 
-    health = info["State"]["Healthcheck"]["Status"]
+    health = info["State"]["Health"]["Status"]
     if health == "unhealthy":
         raise RuntimeError(
             "Container %s is in unhealthy state, aborting" % container_name

--- a/pytests/test_dependencies.py
+++ b/pytests/test_dependencies.py
@@ -1,0 +1,37 @@
+import pytest
+
+from podman_compose import flat_deps, DependsCondition
+
+
+@pytest.fixture
+def basic_services():
+    return {
+        "foo": {},
+        "bar": {
+            # string dependency
+            "depends_on": "foo",
+        },
+        "baz": {
+            # list dependency
+            "depends_on": ["bar"],
+        },
+        "ham": {
+            # dict / conditional dependency
+            "depends_on": {
+                "foo": {
+                    "condition": "service_healthy",
+                },
+            },
+        },
+    }
+
+
+def test_flat_deps(basic_services):
+    flat_deps(basic_services)
+    assert basic_services["foo"]["_deps"] == {}
+    assert basic_services["bar"]["_deps"] == {"foo": DependsCondition.STARTED}
+    assert basic_services["baz"]["_deps"] == {
+        "bar": DependsCondition.STARTED,
+        "foo": DependsCondition.STARTED,
+    }
+    assert basic_services["ham"]["_deps"] == {"foo": DependsCondition.HEALTHY}

--- a/tests/deps/docker-compose.yaml
+++ b/tests/deps/docker-compose.yaml
@@ -21,4 +21,26 @@ services:
       tmpfs:
         - /run
         - /tmp
-
+    hello_world:
+      image: busybox
+      command: ["/bin/busybox", "sh", "-c", "echo 'hello world'"]
+      depends_on:
+        sleep:
+          condition: service_started
+      tmpfs:
+        - /run
+        - /tmp
+      healthcheck:
+        test: echo "hello world"
+        interval: 10s
+        timeout: 5s
+        retries: 5
+    hello_world_2:
+      image: busybox
+      command: ["/bin/busybox", "sh", "-c", "echo 'hello world'"]
+      depends_on:
+        sleep:
+          condition: service_healthy
+      tmpfs:
+        - /run
+        - /tmp

--- a/tests/deps/docker-compose.yaml
+++ b/tests/deps/docker-compose.yaml
@@ -6,6 +6,14 @@ services:
       tmpfs:
         - /run
         - /tmp
+      healthcheck:
+        # test that httpd is running, the brackets [] thing is a trick
+        # to ignore the grep process returned by ps, meaning that this
+        # should only be true if httpd is currently running
+        test: ps | grep "[h]ttpd"
+        interval: 10s
+        timeout: 5s
+        retries: 5
     sleep:
       image: busybox
       command: ["/bin/busybox", "sh", "-c", "sleep 3600"]
@@ -13,6 +21,11 @@ services:
       tmpfs:
         - /run
         - /tmp
+      healthcheck:
+        test: sleep 15
+        interval: 10s
+        timeout: 20s
+        retries: 5
     sleep2:
       image: busybox
       command: ["/bin/busybox", "sh", "-c", "sleep 3600"]
@@ -21,7 +34,13 @@ services:
       tmpfs:
         - /run
         - /tmp
-    hello_world:
+    setup:
+      image: busybox
+      command: ["/bin/busybox", "sh", "-c", "sleep 30"]
+      tmpfs:
+        - /run
+        - /tmp
+    wait_started:
       image: busybox
       command: ["/bin/busybox", "sh", "-c", "echo 'hello world'"]
       depends_on:
@@ -30,17 +49,30 @@ services:
       tmpfs:
         - /run
         - /tmp
-      healthcheck:
-        test: echo "hello world"
-        interval: 10s
-        timeout: 5s
-        retries: 5
-    hello_world_2:
+    wait_healthy:
+      image: busybox
+      command: ["/bin/busybox", "sh", "-c", "echo 'hello world'"]
+      depends_on:
+        web:
+          condition: service_healthy
+      tmpfs:
+        - /run
+        - /tmp
+    wait_multiple_healthchecks:
       image: busybox
       command: ["/bin/busybox", "sh", "-c", "echo 'hello world'"]
       depends_on:
         sleep:
           condition: service_healthy
+      tmpfs:
+        - /run
+        - /tmp
+    wait_completed_successfully:
+      image: busybox
+      command: ["/bin/busybox", "sh", "-c", "echo 'hello world'"]
+      depends_on:
+        setup:
+          condition: service_completed_successfully
       tmpfs:
         - /run
         - /tmp


### PR DESCRIPTION
This PR implements the necessary changes so that `podman-compose` complies with the compose v3 spec's long syntax for the `depends_on` block [1]. 

This essentially means that services that depend on other services can be set up in such a way that they'll only start if the defined conditions are met for each service that it depends on.

[1] https://github.com/compose-spec/compose-spec/blob/0c768bea2e06d5550bc5f390bebe1f830dca8756/spec.md#long-syntax-1