### PR TITLE
Allow --services in config

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2282,7 +2282,10 @@ def compose_logs(compose, args):
 
 
 @cmd_run(podman_compose, "config", "displays the compose file")
-def compose_config(compose, args):  # pylint: disable=unused-argument
+def compose_config(compose, args):
+    if args.services:
+        for service in compose.services: print(service)
+        return
     print(compose.merged_yaml)
 
 
@@ -2660,6 +2663,15 @@ def compose_build_parse(parser):
         nargs="*",
         default=None,
         help="affected services",
+    )
+
+
+@cmd_parse(podman_compose, "config")
+def compose_config_parse(parser):
+    parser.add_argument(
+        "--services",
+        help="Print the service names, one per line.",
+        action="store_true"
     )
 
 


### PR DESCRIPTION
Adds support for `--services` on the `config` subcommand;

https://docs.docker.com/compose/reference/config/

```
  --services               Print the service names, one per line.
```