### PR TITLE
Lint fixes for --services flag handling in config

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2284,7 +2284,8 @@ def compose_logs(compose, args):
 @cmd_run(podman_compose, "config", "displays the compose file")
 def compose_config(compose, args):
     if args.services:
-        for service in compose.services: print(service)
+        for service in compose.services:
+            print(service)
         return
     print(compose.merged_yaml)
 
@@ -2669,9 +2670,7 @@ def compose_build_parse(parser):
 @cmd_parse(podman_compose, "config")
 def compose_config_parse(parser):
     parser.add_argument(
-        "--services",
-        help="Print the service names, one per line.",
-        action="store_true"
+        "--services", help="Print the service names, one per line.", action="store_true"
     )
 
 


### PR DESCRIPTION
Apologies, realised I introduced some pylint errors in #467 

This corrects those.