### PR TITLE
Support platform property

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -904,6 +904,9 @@ def container_to_args(compose, cnt, detached=True):
         if is_str(entrypoint):
             entrypoint = shlex.split(entrypoint)
         podman_args.extend(["--entrypoint", json.dumps(entrypoint)])
+    platform = cnt.get("platform", None)
+    if platform is not None:
+        podman_args.extend(["--platform", platform])
 
     # WIP: healthchecks are still work in progress
     healthcheck = cnt.get("healthcheck", None) or {}


### PR DESCRIPTION
As per https://github.com/compose-spec/compose-spec/blob/master/spec.md#platform

Example:

```
services:
  mysql:
    image: mysql:5.7
    platform: linux/x86_64
```