### PR TITLE
Use env to find a suitable python3

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python3
+#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # https://docs.docker.com/compose/compose-file/#service-configuration-reference


### PR DESCRIPTION
This helps when you have multiple of those installed, for example on macOS both the one in /usr/bin and the one from homebrew in /usr/local/bin. env will work out the one you prefer to use.