### PR TITLE
Add argument --multiple-pods

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -313,6 +313,16 @@ def norm_ulimit(inner_value):
 
 
 def transform(args, project_name, given_containers):
+    if args.multiple_pods:
+        pods = []
+        containers = []
+        for cnt in given_containers:
+            pod_name = f"pod_{project_name}_{cnt['name']}"
+            pod = dict(name=pod_name)
+            pods.append(pod)
+            containers.append(dict(cnt, pod=pod_name))
+        return pods, containers
+    
     if args.no_pod:
         pod_name = None
         pods = []
@@ -1591,6 +1601,12 @@ class PodmanCompose:
         parser.add_argument(
             "--no-pod",
             help="disable pod creation",
+            action="store_true",
+            default=False,
+        )        
+        parser.add_argument(
+            "--multiple-pods",
+            help="create a pod for each container",
             action="store_true",
             default=False,
         )


### PR DESCRIPTION
This argument will create a pod for each container. This is a useful feature, because, by definition, all containers in a Podman pod share the same network namespace. Sometimes containers in a compose file listen to the same port and then bind error happens, which is not a problem in docker-compose.

This PR can be a temporary workaround for issue #206 (but it is just a workaround, so please don't close the issue)
