### PR TITLE
Fix issues with external named volumes

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -190,7 +190,7 @@ def fix_mount_dict(compose, mount_dict, proj_name, srv_name):
         elif not name:
             external = vol.get("external", None)
             if isinstance(external, dict):
-                ext_name = external.get("name", None)
+                ext_name = external.get("name", f"{source}")
             elif external:
                 ext_name = f"{source}"
             else:

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -190,9 +190,9 @@ def fix_mount_dict(compose, mount_dict, proj_name, srv_name):
         elif not name:
             external = vol.get("external", None)
             ext_name = (
-                external.get("name", None) if isinstance(external, dict) else None
+                external.get("name", f"{source}") if isinstance(external, dict) else None
             )
-            vol["name"] = ext_name if ext_name else f"{source}"
+            vol["name"] = ext_name if ext_name else f"{proj_name}_{source}"
     return mount_dict
 
 

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -192,7 +192,7 @@ def fix_mount_dict(compose, mount_dict, proj_name, srv_name):
             ext_name = (
                 external.get("name", None) if isinstance(external, dict) else None
             )
-            vol["name"] = ext_name if ext_name else f"{proj_name}_{source}"
+            vol["name"] = ext_name if ext_name else f"{source}"
     return mount_dict
 
 

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -189,9 +189,12 @@ def fix_mount_dict(compose, mount_dict, proj_name, srv_name):
             )
         elif not name:
             external = vol.get("external", None)
-            ext_name = (
-                external.get("name", f"{source}") if isinstance(external, dict) else None
-            )
+            if isinstance(external, dict):
+                ext_name = external.get("name", None)
+            elif external:
+                ext_name = f"{source}"
+            else:
+                ext_name = None
             vol["name"] = ext_name if ext_name else f"{proj_name}_{source}"
     return mount_dict
 

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -190,12 +190,11 @@ def fix_mount_dict(compose, mount_dict, proj_name, srv_name):
         elif not name:
             external = vol.get("external", None)
             if isinstance(external, dict):
-                ext_name = external.get("name", f"{source}")
+                vol["name"] = external.get("name", f"{source}")
             elif external:
-                ext_name = f"{source}"
+                vol["name"] = f"{source}"
             else:
-                ext_name = None
-            vol["name"] = ext_name if ext_name else f"{proj_name}_{source}"
+                vol["name"] = f"{proj_name}_{source}"
     return mount_dict
 
 


### PR DESCRIPTION
Two issues were raised in #441 :
- External volumes were created even if it does not exist
- podman-compose was looking for the wrong volume name if `name` field was not given

This pull request should fix these issues.