### PR TITLE
Support driver_opts for networks

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -713,8 +713,8 @@ def assert_cnt_nets(compose, cnt):
             if driver:
                 args.extend(("--driver", driver))
             driver_opts = net_desc.get("driver_opts", None) or {}
-            for key,value in driver_opts.items():
-                args.extend(("--opt",f"{key}={value}"))
+            for key, value in driver_opts.items():
+                args.extend(("--opt", f"{key}={value}"))
             ipam_config_ls = (net_desc.get("ipam", None) or {}).get(
                 "config", None
             ) or []

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -712,6 +712,9 @@ def assert_cnt_nets(compose, cnt):
             driver = net_desc.get("driver", None)
             if driver:
                 args.extend(("--driver", driver))
+            driver_opts = net_desc.get("driver_opts", None) or {}
+            for key,value in driver_opts.items():
+                args.extend(("--opt",f"{key}={value}"))
             ipam_config_ls = (net_desc.get("ipam", None) or {}).get(
                 "config", None
             ) or []

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -130,7 +130,7 @@ def parse_short_mount(mount_str, basedir):
         # User-relative path
         # - ~/configs:/etc/configs/:ro
         mount_type = "bind"
-        mount_src = os.path.realpath(
+        mount_src = os.path.abspath(
             os.path.join(basedir, os.path.expanduser(mount_src))
         )
     else:


### PR DESCRIPTION
Pass all `driver_opts` arguments for a network to podman with `--opt`