### PR TITLE
packaging: Move version definition to setup.cfg

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -7,6 +7,12 @@
 # https://docs.docker.com/compose/django/
 # https://docs.docker.com/compose/wordpress/
 
+try:
+    import importlib.metadata as importlib_metadata
+except ImportError:
+    import importlib_metadata
+
+__version__ = importlib_metadata.version("podman-compose")
 
 import sys
 import os
@@ -34,8 +40,6 @@ except ImportError:
 
 import yaml
 from dotenv import dotenv_values
-
-__version__ = "1.0.4"
 
 script = os.path.realpath(sys.argv[0])
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,4 +2,4 @@
 universal = 1
 
 [metadata]
-version = attr: podman_compose.__version__
+version = 1.0.4

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     include_package_data=True,
     license="GPL-2.0-only",
     install_requires=[
+        "importlib-metadata",
         "pyyaml",
         "python-dotenv",
     ],


### PR DESCRIPTION
An unfortunate side-effect of defining the version inside a project's
main module is that dependency issues can break installation. In this
project, even though pyyaml and python-dotenv are listed in
install_requires, installation would fail if either were not present,
because the build process requires importing that module.

Signed-off-by: Zack Cerza <zack@cerza.org>