### PR TITLE
Implement uidmaps and gidmaps in YAML extension

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -957,6 +957,14 @@ def container_to_args(compose, cnt, detached=True):
     if "retries" in healthcheck:
         podman_args.extend(["--healthcheck-retries", str(healthcheck["retries"])])
 
+    # handle podman extension
+    x_podman = cnt.get("x-podman", None)
+    if x_podman is not None:
+        for uidmap in x_podman.get("uidmaps", []):
+            podman_args.extend(["--uidmap", uidmap])
+        for gidmap in x_podman.get("gidmaps", []):
+            podman_args.extend(["--gidmap", gidmap])
+
     podman_args.append(cnt["image"])  # command, ..etc.
     command = cnt.get("command", None)
     if command is not None:

--- a/tests/uidmaps/docker-compose.yml
+++ b/tests/uidmaps/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.7"
+services:
+  touch:
+    image: busybox
+    command: 'touch /mnt/test'
+    volumes:
+      - ./:/mnt
+    user: 999:999
+    x-podman:
+      uidmaps:
+        - "0:1:1"
+        - "999:0:1"
+      gidmaps:
+        - "0:1:1"
+        - "999:0:1"


### PR DESCRIPTION
This implements a simple x-podman YAML extension (as proposed by @repomaa for Feature Request uidmap user #228) on the level of the service nodes.

It can be used as follows:

     version: "3.7"
     services:
       touch:
         image: busybox
         command: 'touch /mnt/test'
         volumes:
           - ./:/mnt
         user: 999:999
         x-podman:
           uidmaps:
             - "0:1:1"
             - "999:0:1"
           gidmaps:
             - "0:1:1"
             - "999:0:1"

Running `podman-compose up` will create a file called `test` owned by the current user in the current working directory.

