### PR TITLE
Ignore access mode when merging volumes short syntax

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1190,11 +1190,11 @@ def rec_merge_one(target, source):
         if is_list(value2):
             if key == "volumes":
                 # clean duplicate mount targets
-                pts = {v.split(":", 1)[1] for v in value2 if ":" in v}
+                pts = {v.split(":", 2)[1] for v in value2 if ":" in v}
                 del_ls = [
                     ix
                     for (ix, v) in enumerate(value)
-                    if ":" in v and v.split(":", 1)[1] in pts
+                    if ":" in v and v.split(":", 2)[1] in pts
                 ]
                 for ix in reversed(del_ls):
                     del value[ix]

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1683,7 +1683,7 @@ class cmd_run:  # pylint: disable=invalid-name,too-few-public-methods
 
         wrapped._compose = self.compose
         # Trim extra indentation at start of multiline docstrings.
-        wrapped.desc = self.cmd_desc or re.sub(r'^\s+', '', func.__doc__)
+        wrapped.desc = self.cmd_desc or re.sub(r"^\s+", "", func.__doc__)
         wrapped._parse_args = []
         self.compose.commands[self.cmd_name] = wrapped
         return wrapped

--- a/tests/volumes_merge/docker-compose.override.yaml
+++ b/tests/volumes_merge/docker-compose.override.yaml
@@ -1,0 +1,7 @@
+version: "3"
+services:
+  web:
+    volumes:
+      - ./override.txt:/var/www/html/index.html:ro,z
+      - ./override.txt:/var/www/html/index2.html:z
+      - ./override.txt:/var/www/html/index3.html

--- a/tests/volumes_merge/docker-compose.yaml
+++ b/tests/volumes_merge/docker-compose.yaml
@@ -1,0 +1,11 @@
+version: "3"
+services:
+  web:
+    image: busybox
+    command: ["/bin/busybox", "httpd", "-f", "-h", "/var/www/html", "-p", "8080"]
+    ports:
+      - 8080:8080
+    volumes:
+      - ./index.txt:/var/www/html/index.html:ro,z
+      - ./index.txt:/var/www/html/index2.html
+      - ./index.txt:/var/www/html/index3.html:ro

--- a/tests/volumes_merge/index.txt
+++ b/tests/volumes_merge/index.txt
@@ -1,0 +1,1 @@
+The file from docker-compose.yaml

--- a/tests/volumes_merge/override.txt
+++ b/tests/volumes_merge/override.txt
@@ -1,0 +1,1 @@
+The file from docker-compose.override.yaml


### PR DESCRIPTION
The target path inside the container is treated as a key. Ref:
https://github.com/compose-spec/compose-spec/blob/master/spec.md#merging-service-definitions

Fixes https://github.com/containers/podman-compose/issues/256