### PR TITLE
Add multi-platform build support

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1900,7 +1900,11 @@ def build_one(compose, args, cnt):
                 break
     if not os.path.exists(dockerfile):
         raise OSError("Dockerfile not found in " + ctx)
-    build_args = ["-t", cnt["image"], "-f", dockerfile]
+    build_args = []
+    if 1 < len(args.platform):
+        build_args.extend(["--manifest", cnt["image"], "-f", dockerfile])
+    else:
+        build_args.extend(["-t", cnt["image"], "-f", dockerfile])
     if "target" in build_desc:
         build_args.extend(["--target", build_desc["target"]])
     container_to_ulimit_args(cnt, build_args)
@@ -1918,6 +1922,8 @@ def build_one(compose, args, cnt):
                 build_arg,
             )
         )
+    for platform in args.platform:
+        build_args.extend(["--platform", platform])
     build_args.append(ctx)
     compose.podman.run([], "build", build_args, sleep=0)
 
@@ -2719,6 +2725,13 @@ def compose_build_parse(parser):
         nargs="*",
         default=None,
         help="affected services",
+    )
+    parser.add_argument(
+        "--platform",
+        metavar="val",
+        action="append",
+        default=[],
+        help="Set the OS/ARCH of the built image. When more than one platform is specified, the --manifest option will be passed to podman build.",
     )
 
 


### PR DESCRIPTION
We are currently evaluating podman-compose not only as a means for development, but also to build containers in CI. We need to build multi-platform images (linux/arm64 and linux/amd64), which is supported by podman with the `--platform` or `--arch` options. This option is not yet exposed by podman-compose.

I acknowledge that docker-compose does not support this either. However, in the docker world there is [docker buildx bake](https://docs.docker.com/engine/reference/commandline/buildx_bake/) which allows building multi-platform images from a compose file. I am not aware of tooling for podman/buildah, that builds multi-platform images for compose files. I also feel that it is the right place to add support here rather than providing some extra tool.

This PR adds a new option `--platform` which enables the use of compose files as templates for building multi-platform images. In addition, it adds a `--all-platforms` options to `podman-compose push`.

Since `--platform` is more specific and maps better to the [manifest spec](https://github.com/opencontainers/image-spec/blob/main/image-index.md) than `--arch`, we only need `--platform`.