### PR TITLE
Exit codes

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1863,7 +1863,9 @@ def compose_push(compose, args):
             continue
         if services and cnt["_service"] not in services:
             continue
-        compose.podman.run([], "push", [cnt["image"]], sleep=0)
+        exit_code = compose.podman.run([], "push", [cnt["image"]], sleep=0).wait()
+        if (not getattr(args, "ignore_push_failures", None)) and 0 != exit_code:
+            sys.exit(exit_code)
 
 
 def build_one(compose, args, cnt):
@@ -2673,7 +2675,7 @@ def compose_push_parse(parser):
     parser.add_argument(
         "--ignore-push-failures",
         action="store_true",
-        help="Push what it can and ignores images with push failures. (not implemented)",
+        help="Push what it can and ignores images with push failures.",
     )
     parser.add_argument(
         "services", metavar="services", nargs="*", help="services to push"


### PR DESCRIPTION
Failure exit codes for `build` and `push` are currently not forwarded as exit code for podman-compose. This makes it impossible to use podman-compose in a scripted environment like CI.

With this PR, podman-compose stops building/pushing when the underlying podman command fails and forwards its exit code.