### PR TITLE
Added podman kill command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,6 @@ def compose_up(compose, args):
   create             Create services
   events             Receive real time events from containers
   images             List images
-  kill               Kill containers
   logs               View output from containers
   port               Print the public port for a port binding
   ps                 List containers


### PR DESCRIPTION
this PR adds the kill command 
you can use it like this to call all services 
`podman-compose kill --all`
`podman-compose kill --all -s SIGKILL`
or you can pass the service name to args 
`podman-compose kill web`
`podman-compose kill redis -s SIGKILL`