### PR TITLE
Removing "-a" from the "start" args array. 

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2058,7 +2058,7 @@ def compose_up(compose, args):
         obj = compose if exit_code_from == cnt["_service"] else None
         thread = Thread(
             target=compose.podman.run,
-            args=[[], "start", ["-a", cnt["name"]]],
+            args=[[], "start", [cnt["name"]]],
             kwargs={"obj": obj, "log_formatter": log_formatter},
             daemon=True,
             name=cnt["name"],


### PR DESCRIPTION
Removing "-a" from the "podman start" args array. It messes with automated container build in scripts.