### PR TITLE
Use SELinux mount flag for secrets

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -538,7 +538,7 @@ def get_secret_args(compose, cnt, secret):
         source_file = os.path.realpath(
             os.path.join(basedir, os.path.expanduser(source_file))
         )
-        volume_ref = ["--volume", f"{source_file}:{dest_file}:Z,ro,rprivate,rbind"]
+        volume_ref = ["--volume", f"{source_file}:{dest_file}:z,ro,rprivate,rbind"]
         if uid or gid or mode:
             sec = target if target else secret_name
             log(

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -538,7 +538,7 @@ def get_secret_args(compose, cnt, secret):
         source_file = os.path.realpath(
             os.path.join(basedir, os.path.expanduser(source_file))
         )
-        volume_ref = ["--volume", f"{source_file}:{dest_file}:ro,rprivate,rbind"]
+        volume_ref = ["--volume", f"{source_file}:{dest_file}:Z,ro,rprivate,rbind"]
         if uid or gid or mode:
             sec = target if target else secret_name
             log(


### PR DESCRIPTION
Fixes issue [573](https://github.com/containers/podman-compose/issues/573). 

I tested this in Fedora CoreOS 36, which fixed the issue I had. I also tested it in Ubuntu 22.04, which does not have SELinux. The Ubuntu test showed that secrets can be mounted just fine with the 'Z' SELinux option even on systems that don't have SELinux installed.

For reference, the 'Z' option makes it s.t. SELinux allows a specific container to access a file or folder; other containers will be denied access by SELinux. This is unlike the lowercase 'z' option, which would have SELinux permit a file or folder from being accessed by _any_ container.