### PR TITLE
Addressing Error With Test Case

### DIFF
--- a/tests/test_podman_compose.py
+++ b/tests/test_podman_compose.py
@@ -43,7 +43,7 @@ def test_podman_compose_extends_w_file_subdir():
         "rmi",
         "--force",
         "localhost/subdir_test:me",
-        "docker.io/library/bash",
+        "docker.io/library/busybox",
     ]
 
     out, err, returncode = capture(command_up)


### PR DESCRIPTION
I recently forked this repository and ran the tests and found that the test case test_podman_compose_extends_w_file_subdir fails.

This PR address an issue with the test_podman_compose_extends_w_file_subdir where the image name in the test case does not align with the supporting Dockerfile resources.

closes #582 

Signed-off-by: Dixon Whitmire <dixonwh@gmail.com>