### PR TITLE
FIXES #586: preserve exit code for podman-compose build

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1934,7 +1934,8 @@ def build_one(compose, args, cnt):
             )
         )
     build_args.append(ctx)
-    compose.podman.run([], "build", build_args, sleep=0)
+    status = compose.podman.run([], "build", build_args, sleep=0)
+    return status
 
 
 @cmd_run(podman_compose, "build", "build stack images")
@@ -1944,10 +1945,12 @@ def compose_build(compose, args):
         compose.assert_services(args.services)
         for service in args.services:
             cnt = compose.container_by_name[container_names_by_service[service][0]]
-            build_one(compose, args, cnt)
+            p = build_one(compose, args, cnt)
+            exit(p.returncode)
     else:
         for cnt in compose.containers:
-            build_one(compose, args, cnt)
+            p = build_one(compose, args, cnt)
+            exit(p.returncode)
 
 
 def create_pods(compose, args):  # pylint: disable=unused-argument


### PR DESCRIPTION
Following the example in https://github.com/containers/podman-compose/commit/09c6cbe503ba79f2856846c20af2f9b7000c24a5