### PR TITLE
add option to start podman in existing network namespace

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -751,6 +751,8 @@ def get_net_args(compose, cnt):
             net_args.extend(["--network", net])
         elif net.startswith("slirp4netns:"):
             net_args.extend(["--network", net])
+        elif net.startswith("ns:"):
+            net_args.extend(["--network", net])
         elif net.startswith("service:"):
             other_srv = net.split(":", 1)[1].strip()
             other_cnt = compose.container_names_by_service[other_srv][0]


### PR DESCRIPTION
I created a option so that you can use the --network ns:/run/netns/<namespace_name> option in a docker-compose.yml file and add a container to a existing namespace.

sudo podman run --rm  --network ns:/run/netns/protected -h ubuntu-docker ubuntu:22.04

With did small change you can now create a docker-compose.yml (podman-compose.yml) file with

```yaml
version: '3'
services:
  ubuntu:
    image: ubuntu:22.04
    container_name: ubuntu-docker
    network_mode: ns:/run/netns/protected
 ```
