### PR TITLE
FIXES #373: Replace "network exists" by "network inspect"

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -693,7 +693,7 @@ def assert_cnt_nets(compose, cnt):
             ext_desc.get("name", None) or net_desc.get("name", None) or default_net_name
         )
         try:
-            compose.podman.output([], "network", ["exists", net_name])
+            compose.podman.output([], "network", ["inspect", net_name])
         except subprocess.CalledProcessError as e:
             if is_ext:
                 raise RuntimeError(
@@ -735,7 +735,7 @@ def assert_cnt_nets(compose, cnt):
                     args.extend(("--gateway", gateway))
             args.append(net_name)
             compose.podman.output([], "network", args)
-            compose.podman.output([], "network", ["exists", net_name])
+            compose.podman.output([], "network", ["inspect", net_name])
 
 
 def get_net_args(compose, cnt):


### PR DESCRIPTION
The current stable version of Debian (11, bullseye) ships with Podman 3.0.1 which does not have a "podman network exists".

With 872404c3a74, Podman Compose changed the network management to CNI, to verify the network has indeed been created it invokes:

  compose.podman.output([], "network", ["exists", net_name])

Which raises a subprocess.CalledProcessError() when the network is not existing. The code then creates it, and again check whether it exists I guess as an assertion the network got created.

Since podman 3.0.1 does not have "network exists" that prevent it from working. "network inspect" would exit non zero when the given network does not exist and the command exists on podman 3.0.1.  That has let me create a pod with CNI networking and DNS resolution under Podman 3.0.1.

Reference:
"podman network exists" is in 3.1.0-rc1 (Debian 11 has 3.0.1) https://github.com/containers/podman/pull/9021