### PR TITLE
allow project name to be fetched from dotenv

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1473,7 +1473,7 @@ class PodmanCompose:
             if project_name is None:
                 # More strict then actually needed for simplicity: podman requires [a-zA-Z0-9][a-zA-Z0-9_.-]*
                 project_name = (
-                    os.environ.get("COMPOSE_PROJECT_NAME", None) or dir_basename.lower()
+                    self.environ.get("COMPOSE_PROJECT_NAME", None) or dir_basename.lower()
                 )
                 project_name = norm_re.sub("", project_name)
                 if not project_name:


### PR DESCRIPTION
Look for project name in `self.environ` which includes both `os.environ` and dotenv variables so that the project name can also be defined in an environment file.