### PR TITLE
Fix formatting of description of systemd command

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1671,7 +1671,7 @@ class PodmanCompose:
         _ = subparsers.add_parser("help", help="show help")
         for cmd_name, cmd in self.commands.items():
             subparser = subparsers.add_parser(
-                cmd_name, help=cmd.desc
+                cmd_name, help=cmd.help, description=cmd.desc
             )  # pylint: disable=protected-access
             for cmd_parser in cmd._parse_args:  # pylint: disable=protected-access
                 cmd_parser(subparser)
@@ -1779,7 +1779,13 @@ class cmd_run:  # pylint: disable=invalid-name,too-few-public-methods
 
         wrapped._compose = self.compose
         # Trim extra indentation at start of multiline docstrings.
-        wrapped.desc = self.cmd_desc or re.sub(r"^\s+", "", func.__doc__)
+        help_desc = self.cmd_desc or re.sub(r"^\s+", "", func.__doc__)
+        if "\n" in help_desc:
+            wrapped.help, wrapped.desc = help_desc.split("\n", 1)
+        else:
+            wrapped.help = help_desc
+            wrapped.desc = None
+
         wrapped._parse_args = []
         self.compose.commands[self.cmd_name] = wrapped
         return wrapped

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1668,7 +1668,7 @@ class PodmanCompose:
         parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
         self._init_global_parser(parser)
         subparsers = parser.add_subparsers(title="command", dest="command")
-        subparser = subparsers.add_parser("help", help="show help")
+        _ = subparsers.add_parser("help", help="show help")
         for cmd_name, cmd in self.commands.items():
             subparser = subparsers.add_parser(
                 cmd_name, help=cmd.desc


### PR DESCRIPTION
When running "podman-compose", the list of commands gets displayed.    The systemd command is an outlier, showing multiple lines, IMO unintended at this location.
    
This change moves the longer command description to its proper place, that is, it gets shown when "podman-compose systemd --help" is executed.

Before this, running `podman-compose`:

```...
command:
  {help,version,wait,systemd,pull,push,build,up,down,ps,run,exec,start,stop,restart,logs,config,port,pause,unpause,kill}
    help                show help
    version             show version
    wait                wait running containers to stop
    systemd             create systemd unit file and register its compose stacks
                        
                            When first installed type `sudo podman-compose systemd -a create-unit`
                            later you can add a compose stack by running `podman-compose systemd -a register`
                            then you can start/stop your stack with `systemctl --user start podman-compose@<PROJ>`
                            
    pull                pull stack images
    push                push stack images
...
```

After this, running `podman-compose`:

```
...
command:
  {help,version,wait,systemd,pull,push,build,up,down,ps,run,exec,start,stop,restart,logs,config,port,pause,unpause,kill}
    help                show help
    version             show version
    wait                wait running containers to stop
    systemd             create systemd unit file and register its compose stacks
    pull                pull stack images
    push                push stack images
...
```

And when running `podman-compose systemd --help`:

```
usage: podman-compose systemd [-h] [-a {register,create-unit,list,ls}]

When first installed type `sudo podman-compose systemd -a create-unit` later
you can add a compose stack by running `podman-compose systemd -a register`
then you can start/stop your stack with `systemctl --user start podman-
compose@<PROJ>`

options:
  -h, --help            show this help message and exit
  -a {register,create-unit,list,ls}, --action {register,create-unit,list,ls}
                        create systemd unit file or register compose stack to
                        it
```