### PR TITLE
Add support for the `group_add` property of a service.

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -851,6 +851,8 @@ def container_to_args(compose, cnt, detached=True):
         podman_args.extend(["--cap-add", c])
     for c in cnt.get("cap_drop", []):
         podman_args.extend(["--cap-drop", c])
+    for item in cnt.get("group_add", []):
+        podman_args.extend(["--group-add", item])
     for item in cnt.get("devices", []):
         podman_args.extend(["--device", item])
     for item in norm_as_list(cnt.get("dns", None)):


### PR DESCRIPTION
This addresses #590 by adding support for the `group_add` section in a service container definition. It can be used like the following (as specified in the compose spec):
```yaml
services:
  app:
    group_add:
      - group1
      - group2
...
```
