### PR TITLE
pre-commit black check only mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,9 @@ repos:
         # https://pre-commit.com/#top_level-default_language_version
         language_version: python3.10
         types: [python]
+        args: [
+          "--check",  # Don't apply changes automatically
+        ]
   - repo: https://github.com/pycqa/flake8
     rev: 6.0.0
     hooks:


### PR DESCRIPTION
This PR modifies `pre-commit` config file so that `black` does not automatically changes files on execution