### PR TITLE
Fix linting issues

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,10 @@
 
 Defines global pytest fixtures available to all tests.
 """
-import pytest
+# pylint: disable=redefined-outer-name
 from pathlib import Path
 import os
+import pytest
 
 
 @pytest.fixture

--- a/tests/test_podman_compose_config.py
+++ b/tests/test_podman_compose_config.py
@@ -3,9 +3,10 @@ test_podman_compose_config.py
 
 Tests the podman-compose config command which is used to return defined compose services.
 """
-import pytest
+# pylint: disable=redefined-outer-name
 import os
 from test_podman_compose import capture
+import pytest
 
 
 @pytest.fixture
@@ -23,7 +24,7 @@ def test_config_no_profiles(podman_compose_path, profile_compose_file):
     """
     config_cmd = ["python3", podman_compose_path, "-f", profile_compose_file, "config"]
 
-    out, err, return_code = capture(config_cmd)
+    out, _, return_code = capture(config_cmd)
     assert return_code == 0
 
     string_output = out.decode("utf-8")
@@ -63,7 +64,7 @@ def test_config_profiles(
     config_cmd = ["python3", podman_compose_path, "-f", profile_compose_file]
     config_cmd.extend(profiles)
 
-    out, err, return_code = capture(config_cmd)
+    out, _, return_code = capture(config_cmd)
     assert return_code == 0
 
     actual_output = out.decode("utf-8")
@@ -71,7 +72,7 @@ def test_config_profiles(
     assert len(expected_services) == 3
 
     actual_services = {}
-    for service, expected_check in expected_services.items():
+    for service, _ in expected_services.items():
         actual_services[service] = service in actual_output
 
     assert expected_services == actual_services

--- a/tests/test_podman_compose_up_down.py
+++ b/tests/test_podman_compose_up_down.py
@@ -3,9 +3,10 @@ test_podman_compose_up_down.py
 
 Tests the podman compose up and down commands used to create and remove services.
 """
-import pytest
+# pylint: disable=redefined-outer-name
 import os
 from test_podman_compose import capture
+import pytest
 
 
 @pytest.fixture
@@ -65,7 +66,7 @@ def test_up(podman_compose_path, profile_compose_file, profiles, expected_servic
     ]
     up_cmd.extend(profiles)
 
-    out, err, return_code = capture(up_cmd)
+    out, _, return_code = capture(up_cmd)
     assert return_code == 0
 
     check_cmd = [
@@ -75,14 +76,14 @@ def test_up(podman_compose_path, profile_compose_file, profiles, expected_servic
         "--format",
         '"{{.Names}}"',
     ]
-    out, err, return_code = capture(check_cmd)
+    out, _, return_code = capture(check_cmd)
     assert return_code == 0
 
     assert len(expected_services) == 3
     actual_output = out.decode("utf-8")
 
     actual_services = {}
-    for service, expected_check in expected_services.items():
+    for service, _ in expected_services.items():
         actual_services[service] = service in actual_output
 
     assert expected_services == actual_services


### PR DESCRIPTION
Fixed issues:

```
************* Module tests.conftest
tests/conftest.py:17:14: W0621: Redefining name 'base_path' from outer scope (line 11) (redefined-outer-name)
tests/conftest.py:23:24: W0621: Redefining name 'base_path' from outer scope (line 11) (redefined-outer-name)
tests/conftest.py:6:0: C0411: standard import "from pathlib import Path" should be placed before "import pytest" (wrong-import-order)
tests/conftest.py:7:0: C0411: standard import "import os" should be placed before "import pytest" (wrong-import-order)
************* Module test_podman_compose_up_down
tests/test_podman_compose_up_down.py:18:34: W0621: Redefining name 'profile_compose_file' from outer scope (line 12) (redefined-outer-name)
tests/test_podman_compose_up_down.py:59:33: W0621: Redefining name 'profile_compose_file' from outer scope (line 12) (redefined-outer-name)
tests/test_podman_compose_up_down.py:68:9: W0612: Unused variable 'err' (unused-variable)
tests/test_podman_compose_up_down.py:85:17: W0612: Unused variable 'expected_check' (unused-variable)
tests/test_podman_compose_up_down.py:7:0: C0411: standard import "import os" should be placed before "import pytest" (wrong-import-order)
************* Module podman_compose
podman_compose.py:832:15: C0121: Comparison 'net_value.get('ipv4_address', None) != None' should be 'net_value.get('ipv4_address', None) is not None' (singleton-comparison)
podman_compose.py:834:15: C0121: Comparison 'net_value.get('ipv6_address', None) != None' should be 'net_value.get('ipv6_address', None) is not None' (singleton-comparison)
podman_compose.py:865:8: C0103: Variable name "multipleNets" doesn't conform to snake_case naming style (invalid-name)
podman_compose.py:866:8: C0103: Variable name "multipleNetNames" doesn't conform to snake_case naming style (invalid-name)
podman_compose.py:2029:0: R1710: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)
podman_compose.py:2098:12: R1722: Consider using 'sys.exit' instead (consider-using-sys-exit)
podman_compose.py:2102:12: R1722: Consider using 'sys.exit' instead (consider-using-sys-exit)
************* Module test_podman_compose_config
tests/test_podman_compose_config.py:17:49: W0621: Redefining name 'profile_compose_file' from outer scope (line 12) (redefined-outer-name)
tests/test_podman_compose_config.py:26:9: W0612: Unused variable 'err' (unused-variable)
tests/test_podman_compose_config.py:53:25: W0621: Redefining name 'profile_compose_file' from outer scope (line 12) (redefined-outer-name)
tests/test_podman_compose_config.py:66:9: W0612: Unused variable 'err' (unused-variable)
tests/test_podman_compose_config.py:74:17: W0612: Unused variable 'expected_check' (unused-variable)
tests/test_podman_compose_config.py:7:0: C0411: standard import "import os" should be placed before "import pytest" (wrong-import-order)
```