### PR TITLE
Add build subcommand  and --build arg to compose_run

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2387,7 +2387,7 @@ def compose_run(compose, args):
         services=[args.service],
         if_not_exists=(not args.build),
         build_arg=[],
-        **args.__dict__
+        **args.__dict__,
     )
     compose.commands["build"](compose, build_args)
 

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2382,6 +2382,15 @@ def compose_run(compose, args):
             )
         )
         compose.commands["up"](compose, up_args)
+
+    build_args = argparse.Namespace(
+        services=[args.service],
+        if_not_exists=(not args.build),
+        build_arg=[],
+        **args.__dict__
+    )
+    compose.commands["build"](compose, build_args)
+
     # adjust one-off container options
     name0 = "{}_{}_tmp{}".format(
         compose.project_name, args.service, random.randrange(0, 65536)
@@ -2751,6 +2760,9 @@ def compose_down_parse(parser):
 
 @cmd_parse(podman_compose, "run")
 def compose_run_parse(parser):
+    parser.add_argument(
+        "--build", action="store_true", help="Build images before starting containers."
+    )
     parser.add_argument(
         "-d",
         "--detach",


### PR DESCRIPTION
The default behavior of `docker compose run` is to build a service if it does not exist, or force build if `--build` flag is provided. `podman-compose` currently does not build missing images before `run` and does not have `--build` flag on `run` at all. Which might be quite confusing for someone migrating between the two. That would be nice if the behavior is consistent.

docker compose:
<img width="646" alt="image" src="https://user-images.githubusercontent.com/16960194/233620153-7d41ae7c-3aa7-46b5-8daf-c048fd6f0001.png">

podman-compose 1.0.6:
<img width="698" alt="image" src="https://user-images.githubusercontent.com/16960194/233620401-b632d1cf-e136-4fc3-a636-6ba6b93ee323.png">

podman-compose with this change:
<img width="702" alt="image" src="https://user-images.githubusercontent.com/16960194/233620478-8f7de31b-2a88-458b-bd0e-177d19f96e09.png">
