### PR TITLE
Convert build context path to absolute during final normalisation

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1601,7 +1601,7 @@ class PodmanCompose:
             compose.get("services", {}), set(args.profile)
         )
         compose["services"] = resolved_services
-        if not args.no_normalize:
+        if not getattr(args, "no_normalize", None):
             compose = normalize_final(compose, self.dirname)
         self.merged_yaml = yaml.safe_dump(compose)
         merged_json_b = json.dumps(compose, separators=(",", ":")).encode("utf-8")

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -24,7 +24,6 @@ import json
 import glob
 
 from threading import Thread
-from pathlib import Path
 
 import shlex
 
@@ -1292,10 +1291,12 @@ def normalize_service_final(service: dict, project_dir: str) -> dict:
     if "build" in service:
         build = service["build"]
         context = build if is_str(build) else build.get("context", ".")
-        context = str((Path(project_dir) / context).resolve())
-        dockerfile = "Dockerfile"
-        if "dockerfile" in service["build"]:
-            dockerfile = service["build"]["dockerfile"]
+        context = os.path.normpath(os.path.join(project_dir, context))
+        dockerfile = (
+            "Dockerfile"
+            if is_str(build)
+            else service["build"].get("dockerfile", "Dockerfile")
+        )
         if not is_dict(service["build"]):
             service["build"] = {}
         service["build"]["dockerfile"] = dockerfile

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1601,7 +1601,8 @@ class PodmanCompose:
             compose.get("services", {}), set(args.profile)
         )
         compose["services"] = resolved_services
-        compose = normalize_final(compose, self.dirname)
+        if not args.no_normalize:
+            compose = normalize_final(compose, self.dirname)
         self.merged_yaml = yaml.safe_dump(compose)
         merged_json_b = json.dumps(compose, separators=(",", ":")).encode("utf-8")
         self.yaml_hash = hashlib.sha256(merged_json_b).hexdigest()
@@ -3052,6 +3053,9 @@ def compose_build_parse(parser):
 
 @cmd_parse(podman_compose, "config")
 def compose_config_parse(parser):
+    parser.add_argument(
+        "--no-normalize", help="Don't normalize compose model.", action="store_true"
+    )
     parser.add_argument(
         "--services", help="Print the service names, one per line.", action="store_true"
     )

--- a/pytests/test_can_merge_build.py
+++ b/pytests/test_can_merge_build.py
@@ -138,7 +138,9 @@ def test__parse_compose_file_when_multiple_composes() -> None:
         if actual_compose != expected_result:
             print("compose:   ", test_input)
             print("override:  ", test_override)
-            print("result:    ", expected_result)
+            print("expected:  ", expected_result)
+            print("actual:    ", actual_compose)
+
         compose_expected = expected_result
 
         assert compose_expected == actual_compose
@@ -151,6 +153,7 @@ def set_args(podman_compose: PodmanCompose, file_names: list[str]) -> None:
     podman_compose.global_args.env_file = None
     podman_compose.global_args.profile = []
     podman_compose.global_args.in_pod = True
+    podman_compose.global_args.no_normalize = True
 
 
 def dump_yaml(compose: dict, name: str) -> None:

--- a/pytests/test_can_merge_cmd_ent.py
+++ b/pytests/test_can_merge_cmd_ent.py
@@ -107,6 +107,7 @@ def set_args(podman_compose: PodmanCompose, file_names: list[str]) -> None:
     podman_compose.global_args.env_file = None
     podman_compose.global_args.profile = []
     podman_compose.global_args.in_pod = True
+    podman_compose.global_args.no_normalize = None
 
 
 def dump_yaml(compose: dict, name: str) -> None:

--- a/pytests/test_normalize_final_build.py
+++ b/pytests/test_normalize_final_build.py
@@ -100,25 +100,6 @@ test_cases_simple_normalization = [
 
 
 #
-# [service.build] is not normalised before coompose files are merged
-#
-def test_pre_merge_normalize_service_does_not_affect_build_section() -> None:
-    for test_input, _ in copy.deepcopy(test_cases_simple_normalization):
-        expected_service = copy.deepcopy(test_input)
-        actual_service = normalize_service(test_input)
-        assert expected_service == actual_service
-
-
-def test_pre_merge_normalize_does_not_affect_build_section() -> None:
-    for test_input, _ in copy.deepcopy(test_cases_simple_normalization):
-        expected_result = copy.deepcopy(test_input)
-        compose_test = {"services": {"test-service": test_input}}
-        compose_expected = {"services": {"test-service": expected_result}}
-        actual_compose = normalize(compose_test)
-        assert compose_expected == actual_compose
-
-
-#
 # [service.build] is normalised after merges
 #
 def test_normalize_service_final_returns_absolute_path_in_context() -> None:

--- a/pytests/test_normalize_final_build.py
+++ b/pytests/test_normalize_final_build.py
@@ -146,7 +146,7 @@ def test__parse_compose_file_when_single_compose() -> None:
         dump_yaml(compose_test, "test-compose.yaml")
 
         podman_compose = PodmanCompose()
-        set_args(podman_compose, ["test-compose.yaml"])
+        set_args(podman_compose, ["test-compose.yaml"], no_normalize=None)
 
         podman_compose._parse_compose_file()
 
@@ -271,7 +271,11 @@ def test__parse_compose_file_when_multiple_composes() -> None:
         dump_yaml(compose_test_2, "test-compose-2.yaml")
 
         podman_compose = PodmanCompose()
-        set_args(podman_compose, ["test-compose-1.yaml", "test-compose-2.yaml"])
+        set_args(
+            podman_compose,
+            ["test-compose-1.yaml", "test-compose-2.yaml"],
+            no_normalize=None,
+        )
 
         podman_compose._parse_compose_file()
 
@@ -288,13 +292,16 @@ def test__parse_compose_file_when_multiple_composes() -> None:
         assert compose_expected == actual_compose
 
 
-def set_args(podman_compose: PodmanCompose, file_names: list[str]) -> None:
+def set_args(
+    podman_compose: PodmanCompose, file_names: list[str], no_normalize: bool
+) -> None:
     podman_compose.global_args = argparse.Namespace()
     podman_compose.global_args.file = file_names
     podman_compose.global_args.project_name = None
     podman_compose.global_args.env_file = None
     podman_compose.global_args.profile = []
     podman_compose.global_args.in_pod = True
+    podman_compose.global_args.no_normalize = no_normalize
 
 
 def dump_yaml(compose: dict, name: str) -> None:

--- a/pytests/test_normalize_final_build.py
+++ b/pytests/test_normalize_final_build.py
@@ -1,0 +1,278 @@
+# pylint: disable=protected-access
+
+import argparse
+import copy
+import os
+from pathlib import Path
+import yaml
+from podman_compose import (
+    normalize_service,
+    normalize,
+    normalize_final,
+    normalize_service_final,
+    PodmanCompose,
+)
+
+
+test_cases_simple_normalization = [
+    ({"image": "test-image"}, {"image": "test-image"}),
+    (
+        {"build": "."},
+        {
+            "build": {"context": str(Path.cwd()), "dockerfile": "Dockerfile"},
+        },
+    ),
+    (
+        {"build": "../relative"},
+        {
+            "build": {
+                "context": str((Path.cwd() / "../relative").resolve()),
+                "dockerfile": "Dockerfile",
+            },
+        },
+    ),
+    (
+        {"build": "./relative"},
+        {
+            "build": {
+                "context": str((Path.cwd() / "./relative").resolve()),
+                "dockerfile": "Dockerfile",
+            },
+        },
+    ),
+    (
+        {"build": "/workspace/absolute"},
+        {
+            "build": {
+                "context": "/workspace/absolute",
+                "dockerfile": "Dockerfile",
+            },
+        },
+    ),
+    (
+        {
+            "build": {
+                "dockerfile": "Dockerfile",
+            },
+        },
+        {
+            "build": {
+                "context": str(Path.cwd()),
+                "dockerfile": "Dockerfile",
+            },
+        },
+    ),
+    (
+        {
+            "build": {
+                "context": ".",
+            },
+        },
+        {
+            "build": {
+                "context": str(Path.cwd()),
+                "dockerfile": "Dockerfile",
+            },
+        },
+    ),
+    (
+        {
+            "build": {"context": "../", "dockerfile": "test-dockerfile"},
+        },
+        {
+            "build": {
+                "context": str((Path.cwd() / "../").resolve()),
+                "dockerfile": "test-dockerfile",
+            },
+        },
+    ),
+    (
+        {
+            "build": {"context": ".", "dockerfile": "./dev/test-dockerfile"},
+        },
+        {
+            "build": {
+                "context": str(Path.cwd()),
+                "dockerfile": "./dev/test-dockerfile",
+            },
+        },
+    ),
+]
+
+
+#
+# [service.build] is not normalised before coompose files are merged
+#
+def test_pre_merge_normalize_service_does_not_affect_build_section() -> None:
+    for test_input, _ in copy.deepcopy(test_cases_simple_normalization):
+        expected_service = copy.deepcopy(test_input)
+        actual_service = normalize_service(test_input)
+        assert expected_service == actual_service
+
+
+def test_pre_merge_normalize_does_not_affect_build_section() -> None:
+    for test_input, _ in copy.deepcopy(test_cases_simple_normalization):
+        expected_result = copy.deepcopy(test_input)
+        compose_test = {"services": {"test-service": test_input}}
+        compose_expected = {"services": {"test-service": expected_result}}
+        actual_compose = normalize(compose_test)
+        assert compose_expected == actual_compose
+
+
+#
+# [service.build] is normalised after merges
+#
+def test_normalize_service_final_returns_absolute_path_in_context() -> None:
+    project_dir = str(Path.cwd().resolve())
+    for test_input, expected_service in copy.deepcopy(test_cases_simple_normalization):
+        actual_service = normalize_service_final(test_input, project_dir)
+        assert expected_service == actual_service
+
+
+def test_normalize_returns_absolute_path_in_context() -> None:
+    project_dir = str(Path.cwd().resolve())
+    for test_input, expected_result in copy.deepcopy(test_cases_simple_normalization):
+        compose_test = {"services": {"test-service": test_input}}
+        compose_expected = {"services": {"test-service": expected_result}}
+        actual_compose = normalize_final(compose_test, project_dir)
+        assert compose_expected == actual_compose
+
+
+#
+# running full parse over single compose files
+#
+def test__parse_compose_file_when_single_compose() -> None:
+    for test_input, expected_result in copy.deepcopy(test_cases_simple_normalization):
+        compose_test = {"services": {"test-service": test_input}}
+        dump_yaml(compose_test, "test-compose.yaml")
+
+        podman_compose = PodmanCompose()
+        set_args(podman_compose, ["test-compose.yaml"])
+
+        podman_compose._parse_compose_file()
+
+        actual_compose = {}
+        if podman_compose.services:
+            podman_compose.services["test-service"].pop("_deps")
+            actual_compose = podman_compose.services["test-service"]
+        if actual_compose != expected_result:
+            print("compose:   ", test_input)
+            print("result:    ", expected_result)
+
+        assert expected_result == actual_compose
+
+
+test_cases_with_merges = [
+    (
+        {},
+        {"build": "."},
+        {"build": {"context": str(Path.cwd()), "dockerfile": "Dockerfile"}},
+    ),
+    (
+        {"build": "."},
+        {},
+        {"build": {"context": str(Path.cwd()), "dockerfile": "Dockerfile"}},
+    ),
+    (
+        {"build": "/workspace/absolute"},
+        {"build": "./relative"},
+        {
+            "build": {
+                "context": str((Path.cwd() / "./relative").resolve()),
+                "dockerfile": "Dockerfile",
+            }
+        },
+    ),
+    (
+        {"build": "./relative"},
+        {"build": "/workspace/absolute"},
+        {"build": {"context": "/workspace/absolute", "dockerfile": "Dockerfile"}},
+    ),
+    (
+        {"build": "./relative"},
+        {"build": "/workspace/absolute"},
+        {"build": {"context": "/workspace/absolute", "dockerfile": "Dockerfile"}},
+    ),
+    (
+        {"build": {"dockerfile": "test-dockerfile"}},
+        {},
+        {"build": {"context": str(Path.cwd()), "dockerfile": "test-dockerfile"}},
+    ),
+    (
+        {},
+        {"build": {"dockerfile": "test-dockerfile"}},
+        {"build": {"context": str(Path.cwd()), "dockerfile": "test-dockerfile"}},
+    ),
+    (
+        {},
+        {"build": {"dockerfile": "test-dockerfile"}},
+        {"build": {"context": str(Path.cwd()), "dockerfile": "test-dockerfile"}},
+    ),
+    (
+        {"build": {"dockerfile": "test-dockerfile-1"}},
+        {"build": {"dockerfile": "test-dockerfile-2"}},
+        {"build": {"context": str(Path.cwd()), "dockerfile": "test-dockerfile-2"}},
+    ),
+    (
+        {"build": "/workspace/absolute"},
+        {"build": {"dockerfile": "test-dockerfile"}},
+        {"build": {"context": "/workspace/absolute", "dockerfile": "test-dockerfile"}},
+    ),
+    (
+        {"build": {"dockerfile": "test-dockerfile"}},
+        {"build": "/workspace/absolute"},
+        {"build": {"context": "/workspace/absolute", "dockerfile": "test-dockerfile"}},
+    ),
+]
+
+
+#
+# running full parse over merged and extended compose files
+#
+def test__parse_compose_file_when_multiple_composes() -> None:
+    for test_input, test_override, expected_result in copy.deepcopy(
+        test_cases_with_merges
+    ):
+        compose_test_1 = {"services": {"test-service": test_input}}
+        compose_test_2 = {"services": {"test-service": test_override}}
+        dump_yaml(compose_test_1, "test-compose-1.yaml")
+        dump_yaml(compose_test_2, "test-compose-2.yaml")
+
+        podman_compose = PodmanCompose()
+        set_args(podman_compose, ["test-compose-1.yaml", "test-compose-2.yaml"])
+
+        podman_compose._parse_compose_file()
+
+        actual_compose = {}
+        if podman_compose.services:
+            podman_compose.services["test-service"].pop("_deps")
+            actual_compose = podman_compose.services["test-service"]
+        if actual_compose != expected_result:
+            print("compose:   ", test_input)
+            print("override:  ", test_override)
+            print("result:    ", expected_result)
+        compose_expected = expected_result
+
+        assert compose_expected == actual_compose
+
+
+def set_args(podman_compose: PodmanCompose, file_names: list[str]) -> None:
+    podman_compose.global_args = argparse.Namespace()
+    podman_compose.global_args.file = file_names
+    podman_compose.global_args.project_name = None
+    podman_compose.global_args.env_file = None
+    podman_compose.global_args.profile = []
+    podman_compose.global_args.in_pod = True
+
+
+def dump_yaml(compose: dict, name: str) -> None:
+    # Path(Path.cwd()/"subdirectory").mkdir(parents=True, exist_ok=True)
+    with open(name, "w", encoding="utf-8") as outfile:
+        yaml.safe_dump(compose, outfile, default_flow_style=False)
+
+
+def test_clean_test_yamls() -> None:
+    test_files = ["test-compose-1.yaml", "test-compose-2.yaml", "test-compose.yaml"]
+    for file in test_files:
+        if Path(file).exists():
+            os.remove(file)


### PR DESCRIPTION
Context:
Trying to make `podman-compose` work with `vscode` devcontainers.

`vscode` will take provided compose files, extend them, create its own extensions, merge them through `podman-compose config`, run, and attach to them. `vscode` will also create a dockerfiles and composes and place them in the temporary directories.

`docker-compose` is converting `context` to an absolute path, leaving `dockerfile` as a relative path. Meaning that the context directory is always fixed while the place of the compose file may vary **relative to that context directory**. Third-party tools developed for `docker-compose` will also rely on that behavior.

`podman-compose` is currently only normalizing a shape if `build` rather than its content, leaving the `context` directory relative. It results in the context path is **relative to the calling process** rather than to the location of compose file.

Minimal example:
```
services:
  dev:
    build: './'
```

Expected output of `podman-compose config`
```
services:
  dev:
    build:
      context: /absolute/path/to/compose-file
      dockerfile: Dockerfile
```

Actual output:
```
services:
  dev:
    build: ./
```

Please see [test cases](https://github.com/containers/podman-compose/compare/devel...Evedel:podman-compose:convert-build-context-path-to-absolute-during-normalisation?expand=1#diff-64fefc67a9001dc9beb4b243e4804de453235169ec614ed000b00faaf5619d45R17) for more examples of expected normalisations.