### PR TITLE
add pasta network mode support

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -795,6 +795,8 @@ def get_net_args(compose, cnt):
             net_args.extend(["--network", net])
         elif net.startswith("slirp4netns:"):
             net_args.extend(["--network", net])
+        elif net.startswith("pasta"):
+            net_args.extend(["--network", net])
         elif net.startswith("ns:"):
             net_args.extend(["--network", net])
         elif net.startswith("service:"):


### PR DESCRIPTION
This pull requests gives support for the new pasta network stack for podman-compose giving some advantages like ipv4, ipv6 and real source IP signaling since this functionalities did not exist before in podman.

simple use "network_mode: pasta" or "network_mode: pasta:X,Y,Z" to use the new passt/pasta stack.
https://passt.top/passt/about/