### PR TITLE
Fix stop/restart args stacking

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2518,10 +2518,10 @@ async def transfer_service_status(compose, args, action):
         targets.extend(container_names_by_service[service])
     if action in ["stop", "restart"]:
         targets = list(reversed(targets))
-    podman_args = []
     timeout_global = getattr(args, "timeout", None)
     tasks = []
     for target in targets:
+        podman_args = []
         if action != "start":
             timeout = timeout_global
             if timeout is None:


### PR DESCRIPTION
For reboots, arguments like '-t X' are stacked as many times as there are services, because the args list is created before the for loop iterating over the containers, and the '-t X' is extended into the arguments list.

So if my Composefile.yml has services: alpha, bravo, charlie
and I do `podman-compose -f Composefile.yml restart -t 1`
it would output roughly:
```
podman restart -t 1 alpha
podman restart -t 1 -t 1 bravo
podman restart -t 1 -t 1 -t 1 charlie
```
The fix moves the creation of the list, that collects the args, into the loop itself. This enables it to extend the list for each loop iteration.