### PR TITLE
podman_compose: fix in-pod argparse type

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1927,7 +1927,7 @@ class PodmanCompose:
             "--in-pod",
             help="pod creation",
             metavar="in_pod",
-            type=bool,
+            type=lambda x: x.lower() in ["1", "true"],
             default=True,
         )
         parser.add_argument(


### PR DESCRIPTION
If "bool" is provided as an argparse type it will only evaluate to false if an empty string is provided. This lambda attempts to resolve this by filtering for "1" or "true".

I used a lambda here for backwards compatibility as argparse didn't add the `BooleanOptionalAction` action until 3.9 and you still advertise 3.7 compatibility in the README and setup.

I was looking at a previous attempt to resolve this ( #546 ) and noticed it was NAK'd for not allowing auto selection but considering the systemd template that's currently present, auto selection is not possible and we seem to be making the assumption that the default value is true.

Maybe the arg should be dropped entirely? The stable release included that template with in-pod defaulting to False leading to fun behavior described in #695 . This is uncorrectable from the user side as the script calls itself with minimal args to create the container before registering it.