### PR TITLE
README: explain that netavark is an alternative to the dnsname plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ This project focuses on:
 This project only depends on:
 
 * `podman`
-* [podman dnsname plugin](https://github.com/containers/dnsname): It is usually found in the `podman-plugins` or `podman-dnsname` distro packages, those packages are not pulled by default and you need to install them. This allows containers to be able to resolve each other if they are on the same CNI network.
+* [podman dnsname plugin](https://github.com/containers/dnsname): It is usually found in
+  the `podman-plugins` or `podman-dnsname` distro packages, those packages are not pulled
+  by default and you need to install them. This allows containers to be able to resolve
+  each other if they are on the same CNI network. This is not necessary when podman is using
+  netavark as a network backend.
 * Python3
 * [PyYAML](https://pyyaml.org/)
 * [python-dotenv](https://pypi.org/project/python-dotenv/)


### PR DESCRIPTION
This is a useful hint when the dnsname plugin is not packaged.