### PR TITLE
Support podman's external rootfs management

### DIFF
--- a/docs/Extensions.md
+++ b/docs/Extensions.md
@@ -65,3 +65,27 @@ In addition, podman-compose supports the following podman-specific values for `n
 
 The options to the network modes are passed to the `--network` option of the `podman create` command
 as-is.
+
+# Service management
+
+Podman-compose extends the compose specification to support some unique features of Podman. These extensions can be specified in the compose file under the "x-podman" field.
+
+Currently, podman-compose supports the following extensions:
+
+* `uidmap` - Run the container in a new user namespace using the supplied UID mapping.
+
+* `gidmap` - Run the container in a new user namespace using the supplied GID mapping.
+
+* `rootfs` - Run the container without requiring any image management; the rootfs of the container is assumed to be managed externally.
+
+For example, the following docker-compose.yml allows running a podman container with externally managed rootfs.
+```yml
+version: "3"
+services:
+    my_service:
+      command: ["/bin/busybox"]
+      x-podman:
+        rootfs: "/path/to/rootfs"
+```
+
+For explanations of these extensions, please refer to the [Podman Documentation](https://docs.podman.io/).

--- a/pytests/test_container_to_args.py
+++ b/pytests/test_container_to_args.py
@@ -161,3 +161,25 @@ class TestContainerToArgs(unittest.IsolatedAsyncioTestCase):
                 "busybox",
             ],
         )
+
+    async def test_rootfs_extension(self):
+        c = create_compose_mock()
+
+        cnt = get_minimal_container()
+        del cnt["image"]
+        cnt["x-podman"] = {
+            "rootfs": "/path/to/rootfs",
+        }
+
+        args = await container_to_args(c, cnt)
+        self.assertEqual(
+            args,
+            [
+                "--name=project_name_service_name1",
+                "-d",
+                "--network=bridge",
+                "--network-alias=service_name",
+                "--rootfs",
+                "/path/to/rootfs",
+            ],
+        )


### PR DESCRIPTION
The podman-run command supports external rootfs management by using the --rootfs flag ([documentation](https://docs.podman.io/en/latest/markdown/podman-run.1.html#rootfs)).
By specifying the --rootfs flag, the first parameter of podman-run will be the path of container's rootfs, instead of the specification of image. This patch makes the compose file parser able to recognize the "rootfs" field, and produce the correct args for podman-run command.