### PR TITLE
Support python direct call _parse_args or run

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -22,6 +22,8 @@ import hashlib
 import random
 import json
 import glob
+from typing import Optional
+from typing import Sequence
 
 from threading import Thread
 
@@ -1463,9 +1465,9 @@ class PodmanCompose:
             xargs.extend(shlex.split(args))
         return xargs
 
-    def run(self):
+    def run(self, argv: Optional[Sequence[str]] = None):
         log("podman-compose version: " + __version__)
-        args = self._parse_args()
+        args = self._parse_args(argv)
         podman_path = args.podman_path
         if podman_path != "podman":
             if os.path.isfile(podman_path) and os.access(podman_path, os.X_OK):
@@ -1773,7 +1775,7 @@ class PodmanCompose:
                 services[name] = config
         return services
 
-    def _parse_args(self):
+    def _parse_args(self, argv: Optional[Sequence[str]] = None):
         parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
         self._init_global_parser(parser)
         subparsers = parser.add_subparsers(title="command", dest="command")
@@ -1784,7 +1786,7 @@ class PodmanCompose:
             )  # pylint: disable=protected-access
             for cmd_parser in cmd._parse_args:  # pylint: disable=protected-access
                 cmd_parser(subparser)
-        self.global_args = parser.parse_args()
+        self.global_args = parser.parse_args(argv)
         if self.global_args.version:
             self.global_args.command = "version"
         if not self.global_args.command or self.global_args.command == "help":


### PR DESCRIPTION
For example:
```
>>> from podman_compose import podman_compose
>>> podman_compose._parse_args(['version'])
>>> podman_compose.run(['help'])
```