### PR TITLE
Add support for enable_ipv6

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -705,6 +705,9 @@ def get_network_create_args(net_desc, proj_name, net_name):
     if ipam_driver:
         args.extend(("--ipam-driver", ipam_driver))
     ipam_config_ls = ipam.get("config", None) or []
+    if net_desc.get("enable_ipv6", None):
+        args.append("--ipv6")
+
     if is_dict(ipam_config_ls):
         ipam_config_ls = [ipam_config_ls]
     for ipam_config in ipam_config_ls:

--- a/pytests/test_network_create_args.py
+++ b/pytests/test_network_create_args.py
@@ -1,0 +1,143 @@
+import unittest
+
+from podman_compose import get_network_create_args
+
+
+class TestGetNetworkCreateArgs(unittest.TestCase):
+    def test_minimal(self):
+        net_desc = {
+            "labels": [],
+            "internal": False,
+            "driver": None,
+            "driver_opts": {},
+            "ipam": {"config": []},
+            "enable_ipv6": False,
+        }
+        proj_name = "test_project"
+        net_name = "test_network"
+        expected_args = [
+            "create",
+            "--label",
+            f"io.podman.compose.project={proj_name}",
+            "--label",
+            f"com.docker.compose.project={proj_name}",
+            net_name,
+        ]
+        args = get_network_create_args(net_desc, proj_name, net_name)
+        self.assertEqual(args, expected_args)
+
+    def test_bridge(self):
+        net_desc = {
+            "labels": [],
+            "internal": False,
+            "driver": "bridge",
+            "driver_opts": {"opt1": "value1", "opt2": "value2"},
+            "ipam": {"config": []},
+            "enable_ipv6": False,
+        }
+        proj_name = "test_project"
+        net_name = "test_network"
+        expected_args = [
+            "create",
+            "--label",
+            f"io.podman.compose.project={proj_name}",
+            "--label",
+            f"com.docker.compose.project={proj_name}",
+            "--driver",
+            "bridge",
+            "--opt",
+            "opt1=value1",
+            "--opt",
+            "opt2=value2",
+            net_name,
+        ]
+        args = get_network_create_args(net_desc, proj_name, net_name)
+        self.assertEqual(args, expected_args)
+
+    def test_ipam_driver(self):
+        net_desc = {
+            "labels": [],
+            "internal": False,
+            "driver": None,
+            "driver_opts": {},
+            "ipam": {
+                "driver": "default",
+                "config": [
+                    {
+                        "subnet": "192.168.0.0/24",
+                        "ip_range": "192.168.0.2/24",
+                        "gateway": "192.168.0.1",
+                    }
+                ],
+            },
+        }
+        proj_name = "test_project"
+        net_name = "test_network"
+        expected_args = [
+            "create",
+            "--label",
+            f"io.podman.compose.project={proj_name}",
+            "--label",
+            f"com.docker.compose.project={proj_name}",
+            "--ipam-driver",
+            "default",
+            "--subnet",
+            "192.168.0.0/24",
+            "--ip-range",
+            "192.168.0.2/24",
+            "--gateway",
+            "192.168.0.1",
+            net_name,
+        ]
+        args = get_network_create_args(net_desc, proj_name, net_name)
+        self.assertEqual(args, expected_args)
+
+    def test_complete(self):
+        net_desc = {
+            "labels": ["label1", "label2"],
+            "internal": True,
+            "driver": "bridge",
+            "driver_opts": {"opt1": "value1", "opt2": "value2"},
+            "ipam": {
+                "driver": "default",
+                "config": [
+                    {
+                        "subnet": "192.168.0.0/24",
+                        "ip_range": "192.168.0.2/24",
+                        "gateway": "192.168.0.1",
+                    }
+                ],
+            },
+            "enable_ipv6": True,
+        }
+        proj_name = "test_project"
+        net_name = "test_network"
+        expected_args = [
+            "create",
+            "--label",
+            f"io.podman.compose.project={proj_name}",
+            "--label",
+            f"com.docker.compose.project={proj_name}",
+            "--label",
+            "label1",
+            "--label",
+            "label2",
+            "--internal",
+            "--driver",
+            "bridge",
+            "--opt",
+            "opt1=value1",
+            "--opt",
+            "opt2=value2",
+            "--ipam-driver",
+            "default",
+            "--subnet",
+            "192.168.0.0/24",
+            "--ip-range",
+            "192.168.0.2/24",
+            "--gateway",
+            "192.168.0.1",
+            net_name,
+        ]
+        args = get_network_create_args(net_desc, proj_name, net_name)
+        self.assertEqual(args, expected_args)

--- a/pytests/test_network_create_args.py
+++ b/pytests/test_network_create_args.py
@@ -26,6 +26,29 @@ class TestGetNetworkCreateArgs(unittest.TestCase):
         args = get_network_create_args(net_desc, proj_name, net_name)
         self.assertEqual(args, expected_args)
 
+    def test_ipv6(self):
+        net_desc = {
+            "labels": [],
+            "internal": False,
+            "driver": None,
+            "driver_opts": {},
+            "ipam": {"config": []},
+            "enable_ipv6": True,
+        }
+        proj_name = "test_project"
+        net_name = "test_network"
+        expected_args = [
+            "create",
+            "--label",
+            f"io.podman.compose.project={proj_name}",
+            "--label",
+            f"com.docker.compose.project={proj_name}",
+            "--ipv6",
+            net_name,
+        ]
+        args = get_network_create_args(net_desc, proj_name, net_name)
+        self.assertEqual(args, expected_args)
+
     def test_bridge(self):
         net_desc = {
             "labels": [],
@@ -131,6 +154,7 @@ class TestGetNetworkCreateArgs(unittest.TestCase):
             "opt2=value2",
             "--ipam-driver",
             "default",
+            "--ipv6",
             "--subnet",
             "192.168.0.0/24",
             "--ip-range",


### PR DESCRIPTION
Fixes #751

This pull request adds support for the `enable_ipv6` network option when creating the network. This is supported by `docker compose` and is contained in the compose-spec [1]. The change simply exposes the `--ipv6` option of `podman network create`

PS: One could argue that this should be on by default and only disabled when `enable_ipv6: false` is set, but doing something like that should - if we even choose to do it at all -  be delayed at the very least until https://github.com/containers/podman/issues/15850 is fixed.

[1] https://github.com/compose-spec/compose-spec/blob/master/06-networks.md#enable_ipv6