### PR TITLE
Add codespell config (to ignore loved "poped") and github workflow to prevent future typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,4 @@
+[codespell]
+skip = .git,*.pdf,*.svg
+#
+# ignore-words-list =

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,4 +1,4 @@
 [codespell]
 skip = .git,*.pdf,*.svg
-#
-# ignore-words-list =
+# poped - loved variable name
+ignore-words-list = poped

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,20 @@
+---
+name: Codespell
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,7 @@ repos:
             "-sn", # Don't display the score
             "--rcfile=.pylintrc", # Link to your config file
           ]
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.5
+    hooks:
+    - id: codespell

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ $ pip install '.[devel]'
 $ pre-commit install
 ```
 4. Create a new branch, develop and add tests when possible
-5. Run linting & testing before commiting code. Ensure all the hooks are passing.
+5. Run linting & testing before committing code. Ensure all the hooks are passing.
 ```shell
 $ pre-commit run --all-files
 ```


### PR DESCRIPTION
There were prior runs of codespell committed (e.g. 78f8cad7c457b200c31a05471fc2b89b1a7be84c ).  But typos would keep appearing unless caught at their inception, which is what this PR proposes to accomplish.