### PR TITLE
Add mention of brew installation to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,13 @@ Or latest development version from GitHub:
 pip3 install https://github.com/containers/podman-compose/archive/devel.tar.gz
 ```
 
+Or install on macOS using brew:
 
-or install from Fedora (starting from f31) repositories:
+```bash
+brew install podman-compose
+```
+
+Or install from Fedora (starting from f31) repositories:
 
 ```
 sudo dnf install podman-compose


### PR DESCRIPTION
Hi,

Just a very small addition to the readme so it mentions the brew installation - I see there's still an open issue too: https://github.com/containers/podman-compose/issues/337

Let me know if you'd like any changes.

Thanks,
Jon