### PR TITLE
Handle sysctls maps

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -956,8 +956,18 @@ async def container_to_args(compose, cnt, detached=True):
         podman_args.append("-i")
     if cnt.get("stop_signal", None):
         podman_args.extend(["--stop-signal", cnt["stop_signal"]])
-    for i in cnt.get("sysctls", []):
-        podman_args.extend(["--sysctl", i])
+
+    sysctls = cnt.get("sysctls")
+    if sysctls is not None:
+        if isinstance(sysctls, dict):
+            for sysctl, value in sysctls.items():
+                podman_args.extend(["--sysctl", "{}={}".format(sysctl, value)])
+        elif isinstance(sysctls, list):
+            for i in sysctls:
+                podman_args.extend(["--sysctl", i])
+        else:
+            raise TypeError("sysctls should be either dict or list")
+
     if cnt.get("tty", None):
         podman_args.append("--tty")
     if cnt.get("privileged", None):

--- a/pytests/test_container_to_args.py
+++ b/pytests/test_container_to_args.py
@@ -25,7 +25,7 @@ def get_minimal_container():
     }
 
 
-class TestContainerToArgs(unittest.TestCase):
+class TestContainerToArgs(unittest.IsolatedAsyncioTestCase):
     async def test_minimal(self):
         c = create_compose_mock()
 


### PR DESCRIPTION
- Add support to handle sysctls maps.
- Directly raise an error if sysctls is neither an array nor map instead of letting podman fail with an unhelpful message.

Support for sysctls arrays was added in #261.

Fixes #754: sysctls only works with arrays, not maps