### PR TITLE
Fix environment variable precedents

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1804,8 +1804,8 @@ class PodmanCompose:
         os.environ.update({
             key: value for key, value in dotenv_dict.items() if key.startswith("PODMAN_")
         })
-        self.environ = dict(os.environ)
-        self.environ.update(dotenv_dict)
+        self.environ = dotenv_dict
+        self.environ.update(dict(os.environ))
         # see: https://docs.docker.com/compose/reference/envvars/
         # see: https://docs.docker.com/compose/env-file/
         self.environ.update({

--- a/tests/env-file-tests/README.md
+++ b/tests/env-file-tests/README.md
@@ -19,3 +19,9 @@ podman-compose -f $(pwd)/project/container-compose.env-file-obj.yaml up
 ```
 podman-compose -f $(pwd)/project/container-compose.env-file-obj-optional.yaml up
 ```
+
+based on environment variable precedent this command should give podman-rocks-321
+
+```
+ZZVAR1=podman-rocks-321 podman-compose -f $(pwd)/project/container-compose.yaml --env-file $(pwd)/env-files/project-1.env up
+```


### PR DESCRIPTION
Allow environment variables set in the host os to override the value of a variable defined in a .env file.
This is consistent with docker's environment variable precedence. Per https://docs.docker.com/compose/environment-variables/envvars-precedence/#advanced-example