### PR TITLE
Pass file secrets to "podman build" via parameter "--secret"

### DIFF
--- a/tests/build_secrets/Dockerfile
+++ b/tests/build_secrets/Dockerfile
@@ -1,0 +1,9 @@
+FROM busybox
+
+RUN --mount=type=secret,required=true,id=build_secret \
+    ls -l /run/secrets/ && cat /run/secrets/build_secret
+
+RUN --mount=type=secret,required=true,id=build_secret,target=/tmp/secret \
+    ls -l /run/secrets/ /tmp/ && cat /tmp/secret
+
+CMD [ 'echo', 'nothing here' ]

--- a/tests/build_secrets/docker-compose.yaml
+++ b/tests/build_secrets/docker-compose.yaml
@@ -1,0 +1,22 @@
+version: "3.8"
+
+services:
+  test:
+    image: test
+    secrets:
+      - run_secret                  # implicitly mount to /run/secrets/run_secret
+      - source: run_secret
+        target: /tmp/run_secret2    # explicit mount point
+
+    build:
+      context: .
+      secrets:
+        - build_secret              # can be mounted in Dockerfile with "RUN --mount=type=secret,id=build_secret"
+        - source: build_secret
+          target: build_secret2     # rename to build_secret2
+
+secrets:
+  build_secret:
+    file: ./my_secret
+  run_secret:
+    file: ./my_secret

--- a/tests/build_secrets/docker-compose.yaml.invalid
+++ b/tests/build_secrets/docker-compose.yaml.invalid
@@ -1,0 +1,18 @@
+version: "3.8"
+
+services:
+  test:
+    image: test
+    build:
+      context: .
+      secrets:
+        # invalid target argument
+        #
+        # According to https://github.com/compose-spec/compose-spec/blob/master/build.md, target is
+        # supposed to be the "name of a *file* to be mounted in /run/secrets/". Not a path.
+        - source: build_secret
+          target: /build_secret
+
+secrets:
+  build_secret:
+    file: ./my_secret

--- a/tests/build_secrets/my_secret
+++ b/tests/build_secrets/my_secret
@@ -1,0 +1,1 @@
+important-secret-is-important

--- a/tests/test_podman_compose_build_secrets.py
+++ b/tests/test_podman_compose_build_secrets.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: GPL-2.0
+
+
+"""Test how secrets in files are passed to podman."""
+
+import os
+import subprocess
+import unittest
+
+from .test_podman_compose import podman_compose_path
+from .test_podman_compose import test_path
+
+
+def compose_yaml_path():
+    """ "Returns the path to the compose file used for this test module"""
+    return os.path.join(test_path(), "build_secrets")
+
+
+class TestComposeBuildSecrets(unittest.TestCase):
+    def test_run_secret(self):
+        """podman run should receive file secrets as --volume
+
+        See build_secrets/docker-compose.yaml for secret names and mount points (aka targets)
+
+        """
+        cmd = (
+            "coverage",
+            "run",
+            podman_compose_path(),
+            "--dry-run",
+            "--verbose",
+            "-f",
+            os.path.join(compose_yaml_path(), "docker-compose.yaml"),
+            "run",
+            "test",
+        )
+        p = subprocess.run(
+            cmd, stdout=subprocess.PIPE, check=False, stderr=subprocess.STDOUT, text=True
+        )
+        self.assertEqual(p.returncode, 0)
+        secret_path = os.path.join(compose_yaml_path(), "my_secret")
+        self.assertIn(f"--volume {secret_path}:/run/secrets/run_secret:ro,rprivate,rbind", p.stdout)
+        self.assertIn(f"--volume {secret_path}:/tmp/run_secret2:ro,rprivate,rbind", p.stdout)
+
+    def test_build_secret(self):
+        """podman build should receive secrets as --secret, so that they can be used inside the
+        Dockerfile in "RUN --mount=type=secret ..." commands.
+
+        """
+        cmd = (
+            "coverage",
+            "run",
+            podman_compose_path(),
+            "--dry-run",
+            "--verbose",
+            "-f",
+            os.path.join(compose_yaml_path(), "docker-compose.yaml"),
+            "build",
+        )
+        p = subprocess.run(
+            cmd, stdout=subprocess.PIPE, check=False, stderr=subprocess.STDOUT, text=True
+        )
+        self.assertEqual(p.returncode, 0)
+        secret_path = os.path.join(compose_yaml_path(), "my_secret")
+        self.assertIn(f"--secret id=build_secret,src={secret_path}", p.stdout)
+        self.assertIn(f"--secret id=build_secret2,src={secret_path}", p.stdout)
+
+    def test_invalid_build_secret(self):
+        """build secrets in docker-compose file can only have a target argument without directory
+        component
+
+        """
+        cmd = (
+            "coverage",
+            "run",
+            podman_compose_path(),
+            "--dry-run",
+            "--verbose",
+            "-f",
+            os.path.join(compose_yaml_path(), "docker-compose.yaml.invalid"),
+            "build",
+        )
+        p = subprocess.run(
+            cmd, stdout=subprocess.PIPE, check=False, stderr=subprocess.STDOUT, text=True
+        )
+        self.assertNotEqual(p.returncode, 0)
+        self.assertIn(
+            'ValueError: ERROR: Build secret "build_secret" has invalid target "/build_secret"',
+            p.stdout,
+        )


### PR DESCRIPTION
Dear maintainers!


At the moment podman-compose always passes file secrets to podman as a `--volume` option, both when starting containers and when building images.
I propose that file secrets for building are instead passed as a `--secret` option. This would make them available for
`RUN --mount=type=secret…` instructions and would improve compatibility with docker-compose.

### Example

```
# Dockerfile
FROM busybox
RUN --mount=type=secret,required=true,id=my_secret,target=/root/my_secret \
		echo "The secret is: "; cat /root/my_secret
```
To build directly from this Dockerfile one has to supply the secret like this: 
`podman build --secret=id=my_secret,src=./my_secret .`

```
# docker-compose.yaml
services:
  my-service:
    build:
      context: .
      secrets:
        - my_secret

secrets:
  my_secret:
    file: ./my_secret
```

Building from the docker-compose.yaml with `podman-compose build my-service`  should produce the same results as the `podman build …` command above.


Yours sincerely
wiehe