### PR TITLE
Fix #782: add support for `http-proxy` option of podman

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -889,6 +889,8 @@ async def container_to_args(compose, cnt, detached=True):
         podman_args.extend(["--annotation", a])
     if cnt.get("read_only", None):
         podman_args.append("--read-only")
+    if cnt.get("http_proxy", None) is False:
+        podman_args.append("--http-proxy=false")
     for i in cnt.get("labels", []):
         podman_args.extend(["--label", i])
     for c in cnt.get("cap_add", []):

--- a/pytests/test_container_to_args.py
+++ b/pytests/test_container_to_args.py
@@ -152,3 +152,24 @@ class TestContainerToArgs(unittest.IsolatedAsyncioTestCase):
                 "busybox",
             ],
         )
+
+    async def test_http_proxy(self):
+        c = create_compose_mock()
+
+        cnt = get_minimal_container()
+        cnt["http_proxy"] = False
+
+        args = await container_to_args(c, cnt)
+        self.assertEqual(
+            args,
+            [
+                "--name=project_name_service_name1",
+                "-d",
+                "--http-proxy=false",
+                "--net",
+                "",
+                "--network-alias",
+                "service_name",
+                "busybox",
+            ],
+        )


### PR DESCRIPTION
#782 