### PR TITLE
Support multiple file includes and include cycles in include section

### DIFF
--- a/tests/include_w_cycle_fail/README.md
+++ b/tests/include_w_cycle_fail/README.md
@@ -1,0 +1,19 @@
+# Test podman-compose with include cycle (fail scenario)
+
+```shell
+podman-compose up || echo $?
+```
+
+expected output would be something like
+
+```
+Compose file contains a cyclic chain of file includes: docker-compose.base-2.yaml
+
+exit code: 1
+```
+
+Expected `podman-compose` exit code:
+```shell
+echo $?
+1
+```

--- a/tests/include_w_cycle_fail/docker-compose.base-1.yaml
+++ b/tests/include_w_cycle_fail/docker-compose.base-1.yaml
@@ -1,0 +1,9 @@
+version: '3.6'
+
+include:
+  - docker-compose.base-2.yaml
+
+services:
+  web:
+    image: busybox
+

--- a/tests/include_w_cycle_fail/docker-compose.base-2.yaml
+++ b/tests/include_w_cycle_fail/docker-compose.base-2.yaml
@@ -1,0 +1,9 @@
+version: '3.6'
+
+include:
+  - docker-compose.base-2.yaml
+
+services:
+  web:
+    command: ["/bin/busybox", "httpd", "-f", "-h", ".", "-p", "8003"]
+

--- a/tests/include_w_cycle_fail/docker-compose.yaml
+++ b/tests/include_w_cycle_fail/docker-compose.yaml
@@ -1,0 +1,4 @@
+version: '3.6'
+
+include:
+  - docker-compose.base-1.yaml

--- a/tests/include_w_multi_indegree/docker-compose.base-1.yaml
+++ b/tests/include_w_multi_indegree/docker-compose.base-1.yaml
@@ -1,0 +1,9 @@
+version: '3.6'
+
+include:
+  - docker-compose.base-2.yaml
+
+services:
+  web:
+    image: busybox
+

--- a/tests/include_w_multi_indegree/docker-compose.base-2.yaml
+++ b/tests/include_w_multi_indegree/docker-compose.base-2.yaml
@@ -1,0 +1,6 @@
+version: '3.6'
+
+services:
+  web:
+    command: ["/bin/busybox", "httpd", "-f", "-h", ".", "-p", "8003"]
+

--- a/tests/include_w_multi_indegree/docker-compose.yaml
+++ b/tests/include_w_multi_indegree/docker-compose.yaml
@@ -1,0 +1,5 @@
+version: '3.6'
+
+include:
+  - docker-compose.base-1.yaml
+  - docker-compose.base-2.yaml


### PR DESCRIPTION
Previously, include sections had to be lists of size 1 and never properly addressed other sizes. Include cycles were possible to cause infinite loops. This commit supports including multiple compose files and can detect cyclic include behavior. This commit also parses each included file only once as an optimization.