### PR TITLE
Use asyncio for subprocess calls

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run] 
+parallel=True

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -21,7 +21,7 @@ jobs:
         python-version: "3.10"
     - name: Install dependencies
       run: |
-        apt update && apt install podman
+        sudo apt update && apt install podman
         python -m pip install --upgrade pip
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         if [ -f test-requirements.txt ]; then pip install -r test-requirements.txt; fi

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -21,9 +21,10 @@ jobs:
         python-version: "3.10"
     - name: Install dependencies
       run: |
+        apt update && apt install podman
         python -m pip install --upgrade pip
-        pip install flake8 pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        if [ -f test-requirements.txt ]; then pip install -r test-requirements.txt; fi
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
@@ -32,5 +33,7 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        python -m pytest ./pytests
-
+        coverage run --source podman_compose -m pytest ./pytests
+        python -m pytest ./tests
+        coverage combine
+        coverage report

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,15 @@ $ pre-commit install
 ```shell
 $ pre-commit run --all-files
 ```
-6. Commit your code to your fork's branch. 
+6. Run code coverage
+```shell
+coverage run --source podman_compose -m pytest ./pytests
+python -m pytest ./tests
+coverage combine
+coverage report
+coverage html
+```
+7. Commit your code to your fork's branch. 
    - Make sure you include a `Signed-off-by` message in your commits. Read [this guide](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) to learn how to sign your commits 
    - In the commit message reference the Issue ID that your code fixes and a brief description of the changes. Example: `Fixes #516: allow empty network`
 7. Open a PR to `containers/podman-compose:devel` and wait for a maintainer to review your work.
@@ -48,18 +56,18 @@ $ pre-commit run --all-files
 
 To add a command you need to add a function that is decorated
 with `@cmd_run` passing the compose instance, command name and
-description. the wrapped function should accept two arguments
-the compose instance and the command-specific arguments (resulted
-from python's `argparse` package) inside that command you can
-run PodMan like this `compose.podman.run(['inspect', 'something'])`
-and inside that function you can access `compose.pods`
-and `compose.containers` ...etc.
-Here is an example
+description. This function must be declared `async` the wrapped 
+function should accept two arguments the compose instance and 
+the command-specific arguments (resulted from python's `argparse` 
+package) inside that command you can run PodMan like this 
+`await compose.podman.run(['inspect', 'something'])`and inside 
+that function you can access `compose.pods` and `compose.containers` 
+...etc. Here is an example
 
 ```
 @cmd_run(podman_compose, 'build', 'build images defined in the stack')
-def compose_build(compose, args):
-    compose.podman.run(['build', 'something'])
+async def compose_build(compose, args):
+    await compose.podman.run(['build', 'something'])
 ```
 
 ## Command arguments parsing
@@ -90,10 +98,10 @@ do something like:
 
 ```
 @cmd_run(podman_compose, 'up', 'up desc')
-def compose_up(compose, args):
-    compose.commands['down'](compose, args)
+async def compose_up(compose, args):
+    await compose.commands['down'](compose, args)
     # or
-    compose.commands['down'](argparse.Namespace(foo=123))
+    await compose.commands['down'](argparse.Namespace(foo=123))
 ```
 
 

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
             "black",
             "pylint",
             "pre-commit",
+            "coverage"
         ]
     }
     # test_suite='tests',

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,7 +3,6 @@
 # process, which may cause wedges in the gate later.
 
 coverage
-pytest-cov
 pytest
 tox
 black

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,3 +6,4 @@ coverage
 pytest
 tox
 black
+flake8

--- a/tests/deps/README.md
+++ b/tests/deps/README.md
@@ -1,4 +1,4 @@
 
 ```
-podman-compose run --rm sleep /bin/sh -c 'wget -O - http://localhost:8000/hosts'
+podman-compose run --rm sleep /bin/sh -c 'wget -O - http://web:8000/hosts'
 ```

--- a/tests/deps/docker-compose.yaml
+++ b/tests/deps/docker-compose.yaml
@@ -9,7 +9,8 @@ services:
     sleep:
       image: busybox
       command: ["/bin/busybox", "sh", "-c", "sleep 3600"]
-      depends_on: "web"
+      depends_on:
+        - "web"
       tmpfs:
         - /run
         - /tmp

--- a/tests/test_podman_compose.py
+++ b/tests/test_podman_compose.py
@@ -21,7 +21,8 @@ def test_podman_compose_extends_w_file_subdir():
     main_path = Path(__file__).parent.parent
 
     command_up = [
-        "python3",
+        "coverage",
+        "run",
         str(main_path.joinpath("podman_compose.py")),
         "-f",
         str(main_path.joinpath("tests", "extends_w_file_subdir", "docker-compose.yml")),

--- a/tests/test_podman_compose.py
+++ b/tests/test_podman_compose.py
@@ -33,6 +33,8 @@ def test_podman_compose_extends_w_file_subdir():
         "podman",
         "container",
         "ps",
+        "--sort",
+        "status",
         "--all",
         "--format",
         '"{{.Image}}"',
@@ -51,14 +53,16 @@ def test_podman_compose_extends_w_file_subdir():
     # check container was created and exists
     out, _, returncode = capture(command_check_container)
     assert 0 == returncode
-    assert out == b'"localhost/subdir_test:me"\n'
+    assert b'"localhost/subdir_test:me"\n' in out
     out, _, returncode = capture(command_down)
     # cleanup test image(tags)
     assert 0 == returncode
+    print('ok')
     # check container did not exists anymore
     out, _, returncode = capture(command_check_container)
+    print(out)
     assert 0 == returncode
-    assert out == b""
+    assert b'"localhost/subdir_test:me"\n' not in out
 
 
 def test_podman_compose_extends_w_empty_service():

--- a/tests/test_podman_compose.py
+++ b/tests/test_podman_compose.py
@@ -31,14 +31,14 @@ def test_podman_compose_extends_w_file_subdir():
     ]
 
     command_check_container = [
-        "podman",
-        "container",
+        "coverage",
+        "run",
+        str(main_path.joinpath("podman_compose.py")),
+        "-f",
+        str(main_path.joinpath("tests", "extends_w_file_subdir", "docker-compose.yml")),
         "ps",
-        "--sort",
-        "status",
-        "--all",
         "--format",
-        '"{{.Image}}"',
+        '{{.Image}}',
     ]
 
     command_down = [
@@ -52,18 +52,17 @@ def test_podman_compose_extends_w_file_subdir():
     out, _, returncode = capture(command_up)
     assert 0 == returncode
     # check container was created and exists
-    out, _, returncode = capture(command_check_container)
+    out, err, returncode = capture(command_check_container)
     assert 0 == returncode
-    assert b'"localhost/subdir_test:me"\n' in out
+    assert b'localhost/subdir_test:me\n' == out
     out, _, returncode = capture(command_down)
     # cleanup test image(tags)
     assert 0 == returncode
     print('ok')
     # check container did not exists anymore
     out, _, returncode = capture(command_check_container)
-    print(out)
     assert 0 == returncode
-    assert b'"localhost/subdir_test:me"\n' not in out
+    assert b'' == out
 
 
 def test_podman_compose_extends_w_empty_service():

--- a/tests/test_podman_compose_config.py
+++ b/tests/test_podman_compose_config.py
@@ -22,7 +22,7 @@ def test_config_no_profiles(podman_compose_path, profile_compose_file):
     :param podman_compose_path: The fixture used to specify the path to the podman compose file.
     :param profile_compose_file: The fixtued used to specify the path to the "profile" compose used in the test.
     """
-    config_cmd = ["python3", podman_compose_path, "-f", profile_compose_file, "config"]
+    config_cmd = ["coverage", "run", podman_compose_path, "-f", profile_compose_file, "config"]
 
     out, _, return_code = capture(config_cmd)
     assert return_code == 0
@@ -61,7 +61,7 @@ def test_config_profiles(
     :param expected_services: Dictionary used to model the expected "enabled" services in the profile.
         Key = service name, Value = True if the service is enabled, otherwise False.
     """
-    config_cmd = ["python3", podman_compose_path, "-f", profile_compose_file]
+    config_cmd = ["coverage", "run", podman_compose_path, "-f", profile_compose_file]
     config_cmd.extend(profiles)
 
     out, _, return_code = capture(config_cmd)

--- a/tests/test_podman_compose_include.py
+++ b/tests/test_podman_compose_include.py
@@ -20,7 +20,8 @@ def test_podman_compose_include():
     main_path = Path(__file__).parent.parent
 
     command_up = [
-        "python3",
+        "coverage",
+        "run",
         str(main_path.joinpath("podman_compose.py")),
         "-f",
         str(main_path.joinpath("tests", "include", "docker-compose.yaml")),

--- a/tests/test_podman_compose_tests.py
+++ b/tests/test_podman_compose_tests.py
@@ -1,0 +1,180 @@
+"""
+test_podman_compose_up_down.py
+
+Tests the podman compose up and down commands used to create and remove services.
+"""
+# pylint: disable=redefined-outer-name
+import os
+import time
+
+from test_podman_compose import capture
+
+
+def test_exit_from(podman_compose_path, test_path):
+    up_cmd = [
+        "coverage",
+        "run",
+        podman_compose_path,
+        "-f",
+        os.path.join(test_path, "exit-from", "docker-compose.yaml"),
+        "up"
+    ]
+
+    out, _, return_code = capture(up_cmd + ["--exit-code-from", "sh1"])
+    assert return_code == 1
+
+    out, _, return_code = capture(up_cmd + ["--exit-code-from", "sh2"])
+    assert return_code == 2
+
+
+def test_run(podman_compose_path, test_path):
+    """
+    This will test depends_on as well
+    """
+    run_cmd = [
+        "coverage",
+        "run",
+        podman_compose_path,
+        "-f",
+        os.path.join(test_path, "deps", "docker-compose.yaml"),
+        "run",
+        "--rm",
+        "sleep",
+        "/bin/sh",
+        "-c",
+        "wget -q -O - http://web:8000/hosts"
+    ]
+
+    out, _, return_code = capture(run_cmd)
+    assert b'127.0.0.1\tlocalhost' in out
+
+    # Run it again to make sure we can run it twice. I saw an issue where a second run, with the container left up,
+    # would fail
+    run_cmd = [
+        "coverage",
+        "run",
+        podman_compose_path,
+        "-f",
+        os.path.join(test_path, "deps", "docker-compose.yaml"),
+        "run",
+        "--rm",
+        "sleep",
+        "/bin/sh",
+        "-c",
+        "wget -q -O - http://web:8000/hosts"
+    ]
+
+    out, _, return_code = capture(run_cmd)
+    assert b'127.0.0.1\tlocalhost' in out
+    assert return_code == 0
+
+    # This leaves a container running. Not sure it's intended, but it matches docker-compose
+    down_cmd = [
+        "coverage",
+        "run",
+        podman_compose_path,
+        "-f",
+        os.path.join(test_path, "deps", "docker-compose.yaml"),
+        "down",
+    ]
+
+    out, _, return_code = capture(run_cmd)
+    assert return_code == 0
+
+
+def test_up_with_ports(podman_compose_path, test_path):
+
+
+    up_cmd = [
+        "coverage",
+        "run",
+        podman_compose_path,
+        "-f",
+        os.path.join(test_path, "ports", "docker-compose.yml"),
+        "up",
+        "-d",
+        "--force-recreate"
+    ]
+
+    down_cmd = [
+        "coverage",
+        "run",
+        podman_compose_path,
+        "-f",
+        os.path.join(test_path, "ports", "docker-compose.yml"),
+        "down",
+        "--volumes"
+    ]
+
+    try:
+        out, _, return_code = capture(up_cmd)
+        assert return_code == 0
+
+
+    finally:
+        out, _, return_code = capture(down_cmd)
+        assert return_code == 0
+
+
+def test_down_with_vols(podman_compose_path, test_path):
+
+    up_cmd = [
+        "coverage",
+        "run",
+        podman_compose_path,
+        "-f",
+        os.path.join(test_path, "vol", "docker-compose.yaml"),
+        "up",
+        "-d"
+    ]
+
+    down_cmd = [
+        "coverage",
+        "run",
+        podman_compose_path,
+        "-f",
+        os.path.join(test_path, "vol", "docker-compose.yaml"),
+        "down",
+        "--volumes"
+    ]
+
+    try:
+        out, _, return_code = capture(["podman", "volume", "create", "my-app-data"])
+        assert return_code == 0
+        out, _, return_code = capture(["podman", "volume", "create", "actual-name-of-volume"])
+        assert return_code == 0
+
+        out, _, return_code = capture(up_cmd)
+        assert return_code == 0
+
+        capture(["podman", "inspect", "volume", ""])
+
+    finally:
+        out, _, return_code = capture(down_cmd)
+        capture(["podman", "volume", "rm", "my-app-data"])
+        capture(["podman", "volume", "rm", "actual-name-of-volume"])
+        assert return_code == 0
+
+
+def test_down_with_orphans(podman_compose_path, test_path):
+
+    container_id, _ , return_code = capture(["podman", "run", "--rm", "-d", "busybox", "/bin/busybox", "httpd", "-f", "-h", "/etc/", "-p", "8000"])
+
+    down_cmd = [
+        "coverage",
+        "run",
+        podman_compose_path,
+        "-f",
+        os.path.join(test_path, "ports", "docker-compose.yml"),
+        "down",
+        "--volumes",
+        "--remove-orphans"
+    ]
+
+    out, _, return_code = capture(down_cmd)
+    assert return_code == 0
+
+    _, _, exists = capture(["podman", "container", "exists", container_id.decode("utf-8")])
+
+    assert exists == 1
+

--- a/tests/test_podman_compose_up_down.py
+++ b/tests/test_podman_compose_up_down.py
@@ -27,7 +27,8 @@ def teardown(podman_compose_path, profile_compose_file):
     yield
 
     down_cmd = [
-        "python3",
+        "coverage",
+        "run",
         podman_compose_path,
         "--profile",
         "profile-1",
@@ -59,7 +60,8 @@ def teardown(podman_compose_path, profile_compose_file):
 )
 def test_up(podman_compose_path, profile_compose_file, profiles, expected_services):
     up_cmd = [
-        "python3",
+        "coverage",
+        "run",
         podman_compose_path,
         "-f",
         profile_compose_file,


### PR DESCRIPTION
Removes the threads from compose_up and manages it using async. Also uses async processing to format the log messages instead of piping through sed. This should work on windows without having sed installed

Adds --parallel to support pull and build in parallel, same as docker compose

This should address #679 aswell