### PR TITLE
fix(ipam_driver): do not pass --ipam-driver option when value set to …

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -734,7 +734,7 @@ def get_network_create_args(net_desc, proj_name, net_name):
         args.extend(("--opt", f"{key}={value}"))
     ipam = net_desc.get("ipam", None) or {}
     ipam_driver = ipam.get("driver", None)
-    if ipam_driver:
+    if ipam_driver and ipam_driver != "default":
         args.extend(("--ipam-driver", ipam_driver))
     ipam_config_ls = ipam.get("config", None) or []
     if net_desc.get("enable_ipv6", None):

--- a/pytests/test_get_network_create_args.py
+++ b/pytests/test_get_network_create_args.py
@@ -77,7 +77,7 @@ class TestGetNetworkCreateArgs(unittest.TestCase):
         args = get_network_create_args(net_desc, proj_name, net_name)
         self.assertEqual(args, expected_args)
 
-    def test_ipam_driver(self):
+    def test_ipam_driver_default(self):
         net_desc = {
             "labels": [],
             "internal": False,
@@ -102,8 +102,44 @@ class TestGetNetworkCreateArgs(unittest.TestCase):
             f"io.podman.compose.project={proj_name}",
             "--label",
             f"com.docker.compose.project={proj_name}",
+            "--subnet",
+            "192.168.0.0/24",
+            "--ip-range",
+            "192.168.0.2/24",
+            "--gateway",
+            "192.168.0.1",
+            net_name,
+        ]
+        args = get_network_create_args(net_desc, proj_name, net_name)
+        self.assertEqual(args, expected_args)
+
+    def test_ipam_driver(self):
+        net_desc = {
+            "labels": [],
+            "internal": False,
+            "driver": None,
+            "driver_opts": {},
+            "ipam": {
+                "driver": "someipamdriver",
+                "config": [
+                    {
+                        "subnet": "192.168.0.0/24",
+                        "ip_range": "192.168.0.2/24",
+                        "gateway": "192.168.0.1",
+                    }
+                ],
+            },
+        }
+        proj_name = "test_project"
+        net_name = "test_network"
+        expected_args = [
+            "create",
+            "--label",
+            f"io.podman.compose.project={proj_name}",
+            "--label",
+            f"com.docker.compose.project={proj_name}",
             "--ipam-driver",
-            "default",
+            "someipamdriver",
             "--subnet",
             "192.168.0.0/24",
             "--ip-range",
@@ -122,7 +158,7 @@ class TestGetNetworkCreateArgs(unittest.TestCase):
             "driver": "bridge",
             "driver_opts": {"opt1": "value1", "opt2": "value2"},
             "ipam": {
-                "driver": "default",
+                "driver": "someipamdriver",
                 "config": [
                     {
                         "subnet": "192.168.0.0/24",
@@ -153,7 +189,7 @@ class TestGetNetworkCreateArgs(unittest.TestCase):
             "--opt",
             "opt2=value2",
             "--ipam-driver",
-            "default",
+            "someipamdriver",
             "--ipv6",
             "--subnet",
             "192.168.0.0/24",

--- a/tests/ipam_default/docker-compose.yaml
+++ b/tests/ipam_default/docker-compose.yaml
@@ -1,0 +1,15 @@
+version: '3'
+
+# --ipam-driver must not be pass when driver is "default"
+networks:
+  ipam_test_default:
+    ipam:
+      driver: default
+      config:
+          - subnet: 172.19.0.0/24
+
+services:
+  testipam:
+    image: busybox
+    command: ["echo", "ipamtest"]
+


### PR DESCRIPTION
…default

podman returns _unsupported ipam driver "default"_ when `--imap-driver default` parameter is passed.

So, when ipam driver is set to "default" in docker-compose.yml, --imap-driver must not be used when podman is called.