### PR TITLE
github: Add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+
+## Contributor Checklist:
+
+If this PR adds a new feature that improves compatibility with docker-compose, please add a link
+to the exact part of compose spec that the PR touches.
+
+All changes require additional unit tests.


### PR DESCRIPTION
Adding a link to related part of compose spec is much easier for the contributors, because they're already working on the feature. This saves reviewer time.