### PR TITLE
Fix support for older python versions

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,4 +1,4 @@
 [codespell]
-skip = .git,*.pdf,*.svg
+skip = .git,*.pdf,*.svg,requirements.txt,test-requirements.txt
 # poped - loved variable name
 ignore-words-list = poped

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = tab
+tab_width = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length = 100
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+[*.py]
+indent_style = space
+

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -22,4 +22,4 @@ jobs:
         ruff check
     - name: Analysing the code with pylint
       run: |
-        pylint podman-compose.py
+        pylint podman_compose.py

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -20,3 +20,6 @@ jobs:
         pip install -r test-requirements.txt
         ruff format --check
         ruff check
+    - name: Analysing the code with pylint
+      run: |
+        pylint podman-compose.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,11 +26,15 @@ jobs:
         python -m pip install --upgrade pip
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         if [ -f test-requirements.txt ]; then pip install -r test-requirements.txt; fi
-    - name: Test with unittest
+    - name: Run tests in tests/
       run: |
-        coverage run --source podman_compose -m unittest pytests/*.py
         python -m unittest tests/*.py
-        coverage combine
-        coverage report
       env:
         TESTS_DEBUG: 1
+    - name: Run tests in pytests/
+      run: |
+        coverage run --source podman_compose -m unittest pytests/*.py
+    - name: Report coverage
+      run: |
+        coverage combine
+        coverage report

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,9 +6,14 @@ on:
 
 jobs:
   test:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
+
     runs-on: ubuntu-latest
     container:
-      image: docker.io/library/python:3.11-bookworm
+      image: "docker.io/library/python:${{ matrix.python-version }}-bookworm"
       # cgroupns needed to address the following error:
       # write /sys/fs/cgroup/cgroup.subtree_control: operation not supported
       options: --privileged --cgroupns=host

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1169,15 +1169,15 @@ class Podman:
             xargs = self.compose.get_podman_args(cmd) if cmd else []
             cmd_ls = [self.podman_path, *podman_args, cmd] + xargs + cmd_args
             log.info(str(cmd_ls))
-            p = await asyncio.subprocess.create_subprocess_exec(
+            p = await asyncio.create_subprocess_exec(
                 *cmd_ls, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
             )
 
             stdout_data, stderr_data = await p.communicate()
             if p.returncode == 0:
                 return stdout_data
-            else:
-                raise subprocess.CalledProcessError(p.returncode, " ".join(cmd_ls), stderr_data)
+
+            raise subprocess.CalledProcessError(p.returncode, " ".join(cmd_ls), stderr_data)
 
     def exec(
         self,
@@ -1191,7 +1191,7 @@ class Podman:
         log.info(" ".join([str(i) for i in cmd_ls]))
         os.execlp(self.podman_path, *cmd_ls)
 
-    async def run(
+    async def run(  # pylint: disable=dangerous-default-value
         self,
         podman_args,
         cmd="",
@@ -1219,7 +1219,7 @@ class Podman:
                         if stdout.at_eof():
                             break
 
-                p = await asyncio.subprocess.create_subprocess_exec(
+                p = await asyncio.create_subprocess_exec(
                     *cmd_ls, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
                 )  # pylint: disable=consider-using-with
 
@@ -1234,7 +1234,7 @@ class Podman:
                 err_t.add_done_callback(task_reference.discard)
 
             else:
-                p = await asyncio.subprocess.create_subprocess_exec(*cmd_ls)  # pylint: disable=consider-using-with
+                p = await asyncio.create_subprocess_exec(*cmd_ls)  # pylint: disable=consider-using-with
 
             try:
                 exit_code = await p.wait()
@@ -1912,9 +1912,12 @@ class PodmanCompose:
 
 podman_compose = PodmanCompose()
 
+
 ###################
 # decorators to add commands and parse options
 ###################
+class PodmanComposeError(Exception):
+    pass
 
 
 class cmd_run:  # pylint: disable=invalid-name,too-few-public-methods
@@ -1928,7 +1931,7 @@ class cmd_run:  # pylint: disable=invalid-name,too-few-public-methods
             return func(*args, **kw)
 
         if not asyncio.iscoroutinefunction(func):
-            raise Exception("Command must be async")
+            raise PodmanComposeError("Command must be async")
         wrapped._compose = self.compose
         # Trim extra indentation at start of multiline docstrings.
         wrapped.desc = self.cmd_desc or re.sub(r"^\s+", "", func.__doc__)
@@ -2010,8 +2013,8 @@ async def compose_systemd(compose, args):
                     f.write(f"{k}={v}\n")
         log.debug("writing [%s]: done.", fn)
         log.info("\n\ncreating the pod without starting it: ...\n\n")
-        process = await asyncio.subprocess.create_subprocess_exec(script, ["up", "--no-start"])
-        log.info("\nfinal exit code is ", process)
+        process = await asyncio.create_subprocess_exec(script, ["up", "--no-start"])
+        log.info("\nfinal exit code is %d", process)
         username = getpass.getuser()
         print(
             f"""
@@ -2305,7 +2308,7 @@ async def compose_up(compose: PodmanCompose, args):
                 # cause the status to overwrite. Sleeping for 1 seems to fix this and make it match
                 # docker-compose
                 await asyncio.sleep(1)
-                [_.cancel() for _ in tasks if not _.cancelling() and not _.cancelled()]
+                _ = [_.cancel() for _ in tasks if not _.cancelling() and not _.cancelled()]
             t: Task
             exiting = True
             for t in done:

--- a/pytests/test_can_merge_build.py
+++ b/pytests/test_can_merge_build.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0
+from __future__ import annotations
 
 import argparse
 import os

--- a/pytests/test_can_merge_cmd_ent.py
+++ b/pytests/test_can_merge_cmd_ent.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0
+from __future__ import annotations
 
 import argparse
 import copy

--- a/pytests/test_normalize_final_build.py
+++ b/pytests/test_normalize_final_build.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: GPL-2.0
 # pylint: disable=protected-access
+from __future__ import annotations
 
 import argparse
 import os

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,6 +4,7 @@ parameterized==0.9.0
 pytest==8.0.2
 tox==4.13.0
 ruff==0.3.1
+pylint==3.1.0
 
 # The packages below are transitive dependencies of the packages above and are included here
 # to make testing reproducible.
@@ -12,16 +13,21 @@ ruff==0.3.1
 #  pip freeze > test-requirements.txt
 # and edit test-requirements.txt to add this comment
 
+astroid==3.1.0
 cachetools==5.3.3
 chardet==5.2.0
 colorama==0.4.6
+dill==0.3.8
 distlib==0.3.8
 filelock==3.13.1
 iniconfig==2.0.0
+isort==5.13.2
+mccabe==0.7.0
 packaging==23.2
 platformdirs==4.2.0
 pluggy==1.4.0
 pyproject-api==1.6.1
 python-dotenv==1.0.1
 PyYAML==6.0.1
+tomlkit==0.12.4
 virtualenv==20.25.1


### PR DESCRIPTION
This PR replaces #869 
It retains the changes needed to support older python versions.

Also, it makes some changes to the CI, notably:
 - re-enable the pylint tests, as this catch some more stuff than ruff on its own.  I can remove this part, if you prefer
 - run the tests for all upstream-supported versions of python (3.8+) 
 - split out the tests in separate GA steps, and reduce verbosity, so that it's easier to spot which tests fail.


As a side note: because coverage now is checked in the CI, it might make sense to enable a tool like https://codecov.io/, which provides a nice web interface showing where coverage is missing, and also adds an automatic CI check to check that new PRs don't decrease coverage.