### PR TITLE
Add coverage to Github Action summary

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,4 +37,4 @@ jobs:
     - name: Report coverage
       run: |
         coverage combine
-        coverage report
+        coverage report --format=markdown | tee -a $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
I think this makes it easier to see the code coverage summary for a particular test run, rather than needing to drill down into the log.

[Example output](https://github.com/containers/podman-compose/actions/runs/8217491351?pr=889)

<details><summary>Screenshot</summary>
<p>
<img src="https://github.com/containers/podman-compose/assets/451345/bf94da54-f65f-400c-afca-c8b9b93d0d2a">
</p>
</details> 

