### PR TITLE
FIX issue https://github.com/containers/podman-compose/issues/704 - Windows fix sock not working.

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -159,7 +159,8 @@ def parse_short_mount(mount_str, basedir):
         # User-relative path
         # - ~/configs:/etc/configs/:ro
         mount_type = "bind"
-        mount_src = os.path.abspath(os.path.join(basedir, os.path.expanduser(mount_src)))
+        if os.name != 'nt' or (os.name == 'nt' and ".sock" not in mount_src):
+            mount_src = os.path.abspath(os.path.join(basedir, os.path.expanduser(mount_src)))
     else:
         # Named volume
         # - datavolume:/var/lib/mysql


### PR DESCRIPTION
From issue 704:
**Describe the bug**
I try to use portainer. On podman-compose up -d - /run/podman/podman.sock:/var/run/docker.sock in docker-compose.yml becomes -v E:\run\podman\podman.sock:/var/run/docker.sock:Z

.....snuip....

**Expected behavior**

-v \run\podman\podman.sock:/var/run/docker.sock:Z

instead of

**Actual behavior**

-v E:\run\podman\podman.sock:/var/run/docker.sock:Z

The issue is for portainer, but it also affects all sock on Windows due to the code not being windows aware.