### PR TITLE
Add support for selinux in verbose bind mount specification

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -431,6 +431,11 @@ def mount_desc_to_mount_args(compose, mount_desc, srv_name, cnt_name):  # pylint
         tmpfs_mode = tmpfs_opts.get("mode", None)
         if tmpfs_mode:
             opts.append(f"tmpfs-mode={tmpfs_mode}")
+    if mount_type == "bind":
+        bind_opts = mount_desc.get("bind", {})
+        selinux = bind_opts.get("selinux", None)
+        if selinux is not None:
+            opts.append(selinux)
     opts = ",".join(opts)
     if mount_type == "bind":
         return f"type=bind,source={source},destination={target},{opts}".rstrip(",")
@@ -486,6 +491,12 @@ def mount_desc_to_volume_args(compose, mount_desc, srv_name, cnt_name):  # pylin
     read_only = mount_desc.get("read_only", None)
     if read_only is not None:
         opts.append("ro" if read_only else "rw")
+    if mount_type == "bind":
+        bind_opts = mount_desc.get("bind", {})
+        selinux = bind_opts.get("selinux", None)
+        if selinux is not None:
+            opts.append(selinux)
+
     args = f"{source}:{target}"
     if opts:
         args += ":" + ",".join(opts)

--- a/tests/selinux/docker-compose.yml
+++ b/tests/selinux/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3"
+services:
+  web1:
+    image: busybox
+    command: httpd -f -p 80 -h /var/www/html
+    volumes:
+      - type: bind
+        source: ./docker-compose.yml
+        target: /var/www/html/index.html
+        bind:
+          selinux: z
+    ports:
+      - "8080:80"
+


### PR DESCRIPTION
As specified here in the compose schema: https://github.com/compose-spec/compose-spec/blob/c35d19323fdfd7dbf9db30022498e29ef5ebeab2/schema/compose-spec.json#L382-L388

and described here in the compose spec: https://github.com/compose-spec/compose-spec/blob/master/05-services.md#long-syntax-5

it should be possible to specify selinux relabeling for a bind mount specified using the verbose syntax (as opposed to the terse syntax which already works). This PR adds support for this syntax in podman compose to achieve parity with docker compose in this area.