### PR TITLE
Use x- prefix for x-podman.mac_address

### DIFF
--- a/docs/Extensions.md
+++ b/docs/Extensions.md
@@ -9,8 +9,8 @@ container has multiple network interfaces, the specified MAC address is applied 
 specified network.
 
 Podman-compose in addition supports the specification of MAC addresses on a per-network basis. This
-is done by adding a `podman.mac_address` key to the network configuration in the container. The
-value of the `podman.mac_address` key is the MAC address to be used for the network interface.
+is done by adding a `x-podman.mac_address` key to the network configuration in the container. The
+value of the `x-podman.mac_address` key is the MAC address to be used for the network interface.
 
 Specifying a MAC address for the container and for individual networks at the same time is not
 supported.
@@ -40,10 +40,10 @@ services:
     networks:
       net0:
         ipv4_address: "192.168.0.10"
-        podman.mac_address: "02:aa:aa:aa:aa:aa"
+        x-podman.mac_address: "02:aa:aa:aa:aa:aa"
       net1:
         ipv4_address: "192.168.1.10"
-        podman.mac_address: "02:bb:bb:bb:bb:bb"
+        x-podman.mac_address: "02:bb:bb:bb:bb:bb"
 ```
 
 ## Podman-specific network modes

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -888,7 +888,7 @@ def get_net_args(compose, cnt):
         # specified on the network level as well
         if mac_address is not None:
             for net_config_ in multiple_nets.values():
-                network_mac = net_config_.get("podman.mac_address", None)
+                network_mac = net_config_.get("x-podman.mac_address", None)
                 if network_mac is not None:
                     raise RuntimeError(
                         f"conflicting mac addresses {mac_address} and {network_mac}:"
@@ -906,7 +906,7 @@ def get_net_args(compose, cnt):
             ipv4 = net_config_.get("ipv4_address", None)
             ipv6 = net_config_.get("ipv6_address", None)
             # custom extension; not supported by docker-compose v3
-            mac = net_config_.get("podman.mac_address", None)
+            mac = net_config_.get("x-podman.mac_address", None)
 
             # if a mac_address was specified on the container level, apply it to the first network
             # This works for Python > 3.6, because dict insert ordering is preserved, so we are

--- a/pytests/test_get_net_args.py
+++ b/pytests/test_get_net_args.py
@@ -196,8 +196,8 @@ class TestGetNetArgs(unittest.TestCase):
         compose = get_networked_compose(num_networks=2)
         container = get_minimal_container()
         container["networks"] = {
-            "net0": {"podman.mac_address": mac0},
-            "net1": {"podman.mac_address": mac1},
+            "net0": {"x-podman.mac_address": mac0},
+            "net1": {"x-podman.mac_address": mac1},
         }
 
         expected_args = [
@@ -219,7 +219,7 @@ class TestGetNetArgs(unittest.TestCase):
         container = get_minimal_container()
         container["networks"] = {
             "net0": {"ipv4_address": ip4_0},
-            "net1": {"ipv4_address": ip4_1, "podman.mac_address": mac_0},
+            "net1": {"ipv4_address": ip4_1, "x-podman.mac_address": mac_0},
             "net2": {"ipv4_address": ip4_2},
         }
         container["mac_address"] = mac_1

--- a/tests/nets_test_ip/docker-compose.yml
+++ b/tests/nets_test_ip/docker-compose.yml
@@ -20,10 +20,10 @@ services:
         networks:
             shared-network:
                 ipv4_address: "172.19.1.10"
-                podman.mac_address: "02:01:01:00:01:01"
+                x-podman.mac_address: "02:01:01:00:01:01"
             internal-network:
                 ipv4_address: "172.19.2.10"
-                podman.mac_address: "02:01:01:00:02:01"
+                x-podman.mac_address: "02:01:01:00:02:01"
         volumes:
             - ./test1.txt:/var/www/html/index.txt:ro,z
     web2:


### PR DESCRIPTION
Docker compose documents x- prefix as standard vendor prefix.

https://github.com/compose-spec/compose-spec/pull/18


