### PR TITLE
implement --publish in docker-compose run

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2587,6 +2587,10 @@ def compose_run_update_container_from_args(compose, cnt, args):
                 del cnt[k]
             except KeyError:
                 pass
+    if args.publish:
+        ports = cnt.get("ports", [])
+        ports.extend(norm_ports(args.publish))
+        cnt["ports"] = ports
     if args.volume:
         # TODO: handle volumes
         volumes = clone(cnt.get("volumes", None) or [])

--- a/pytests/test_compose_run_update_container_from_args.py
+++ b/pytests/test_compose_run_update_container_from_args.py
@@ -35,6 +35,21 @@ class TestComposeRunUpdateContainerFromArgs(unittest.TestCase):
         }
         self.assertEqual(cnt, expected_cnt)
 
+    def test_publish_ports(self):
+        cnt = get_minimal_container()
+        compose = get_minimal_compose()
+        args = get_minimal_args()
+        args.publish = ["1111", "2222:2222"]
+
+        compose_run_update_container_from_args(compose, cnt, args)
+
+        expected_cnt = {
+            "name": "default_name",
+            "ports": ["1111", "2222:2222"],
+            "tty": True,
+        }
+        self.assertEqual(cnt, expected_cnt)
+
 
 def get_minimal_container():
     return {}
@@ -53,6 +68,7 @@ def get_minimal_args():
         name="default_name",
         rm=None,
         service=None,
+        publish=None,
         service_ports=None,
         user=None,
         volume=None,


### PR DESCRIPTION
### Documentation

docker-compose run options:
https://docs.docker.com/reference/cli/docker/compose/run/#options

> -p, --publish		Publish a container's port(s) to the host

### Explanations

Using the below `docker-compose.yml`:
```yml
version: '3.8'

services:
  netcat-server:
    image: alpine:latest
    command: sh -c "apk add --no-cache netcat-openbsd && nc -lk -p 12345"
```

The below `docker-compose run` command:
```sh
docker-compose run -p 12345:12345 netcat-server
```
publishes the port 12345 from the container to the host:
```sh
$ docker ps -a
CONTAINER ID   IMAGE           COMMAND                  CREATED          STATUS          PORTS                                           NAMES
0adac614c107   alpine:latest   "sh -c 'apk add --no…"   29 seconds ago   Up 29 seconds   0.0.0.0:12345->12345/tcp, :::12345->12345/tcp   src-netcat-server-run-79dad3a4579c
```

while the same using `podman-compose run`:
```sh
podman-compose run -p 12345:12345 netcat-server
```

does not publish the port:
```sh
$ podman ps -a
CONTAINER ID  IMAGE                            COMMAND               CREATED        STATUS        PORTS       NAMES
acc4cd67b10a  docker.io/library/alpine:latest  sh -c apk add --n...  7 seconds ago  Up 8 seconds              src_netcat-server_tmp59130
```

The changes in this pull request aims to add the implementation of the `--publish` options in `podman-compose run`, which was completely forgotten. `--publish` was added to the parser arguments:
https://github.com/containers/podman-compose/blob/2681566580b4eaadfc5e6000ad19e49e56006e2b/podman_compose.py#L3002-L3007
but then never used later (no occurences of `args.publish`).

These changes allow the expected behavior:
```sh
$ podman ps -a
CONTAINER ID  IMAGE                            COMMAND               CREATED       STATUS       PORTS                     NAMES
60e58363e0c0  docker.io/library/alpine:latest  sh -c apk add --n...  1 second ago  Up 1 second  0.0.0.0:12345->12345/tcp  src_netcat-server_tmp20781
```

The new block `if args.publish:` is stategically put after the block `if not args.service_ports:`, which is emptying `cnt['ports']` when `--service-ports` is not passed.
Otherwise the ports added by `--publish` would be immediately emptied when `--service-ports` is not passed, which is not what is expected :D.