### PR TITLE
Migrate x-podman dictionary on container root to x-podman.* fields

### DIFF
--- a/docs/Extensions.md
+++ b/docs/Extensions.md
@@ -1,6 +1,30 @@
 # Podman specific extensions to the docker-compose format
 
-Podman-compose supports the following extension to the docker-compose format.
+Podman-compose supports the following extension to the docker-compose format. These extensions
+are generally specified under fields with "x-podman" prefix in the compose file.
+
+## Container management
+
+The following extension keys are available under container configuration:
+
+* `x-podman.uidmap` - Run the container in a new user namespace using the supplied UID mapping.
+
+* `x-podman.gidmap` - Run the container in a new user namespace using the supplied GID mapping.
+
+* `x-podman.rootfs` - Run the container without requiring any image management; the rootfs of the
+container is assumed to be managed externally.
+
+For example, the following docker-compose.yml allows running a podman container with externally managed rootfs.
+```yml
+version: "3"
+services:
+    my_service:
+        command: ["/bin/busybox"]
+        x-podman.rootfs: "/path/to/rootfs"
+```
+
+For explanations of these extensions, please refer to the [Podman Documentation](https://docs.podman.io/).
+
 
 ## Per-network MAC-addresses
 
@@ -65,27 +89,3 @@ In addition, podman-compose supports the following podman-specific values for `n
 
 The options to the network modes are passed to the `--network` option of the `podman create` command
 as-is.
-
-# Service management
-
-Podman-compose extends the compose specification to support some unique features of Podman. These extensions can be specified in the compose file under the "x-podman" field.
-
-Currently, podman-compose supports the following extensions:
-
-* `uidmap` - Run the container in a new user namespace using the supplied UID mapping.
-
-* `gidmap` - Run the container in a new user namespace using the supplied GID mapping.
-
-* `rootfs` - Run the container without requiring any image management; the rootfs of the container is assumed to be managed externally.
-
-For example, the following docker-compose.yml allows running a podman container with externally managed rootfs.
-```yml
-version: "3"
-services:
-    my_service:
-      command: ["/bin/busybox"]
-      x-podman:
-        rootfs: "/path/to/rootfs"
-```
-
-For explanations of these extensions, please refer to the [Podman Documentation](https://docs.podman.io/).

--- a/pytests/test_container_to_args.py
+++ b/pytests/test_container_to_args.py
@@ -162,14 +162,21 @@ class TestContainerToArgs(unittest.IsolatedAsyncioTestCase):
             ],
         )
 
+    async def test_uidmaps_extension_old_path(self):
+        c = create_compose_mock()
+
+        cnt = get_minimal_container()
+        cnt['x-podman'] = {'uidmaps': ['1000:1000:1']}
+
+        with self.assertRaises(ValueError):
+            await container_to_args(c, cnt)
+
     async def test_rootfs_extension(self):
         c = create_compose_mock()
 
         cnt = get_minimal_container()
         del cnt["image"]
-        cnt["x-podman"] = {
-            "rootfs": "/path/to/rootfs",
-        }
+        cnt["x-podman.rootfs"] = "/path/to/rootfs"
 
         args = await container_to_args(c, cnt)
         self.assertEqual(

--- a/pytests/test_container_to_args.py
+++ b/pytests/test_container_to_args.py
@@ -171,6 +171,50 @@ class TestContainerToArgs(unittest.IsolatedAsyncioTestCase):
         with self.assertRaises(ValueError):
             await container_to_args(c, cnt)
 
+    async def test_uidmaps_extension(self):
+        c = create_compose_mock()
+
+        cnt = get_minimal_container()
+        cnt['x-podman.uidmaps'] = ['1000:1000:1', '1001:1001:2']
+
+        args = await container_to_args(c, cnt)
+        self.assertEqual(
+            args,
+            [
+                "--name=project_name_service_name1",
+                "-d",
+                "--network=bridge",
+                "--network-alias=service_name",
+                '--uidmap',
+                '1000:1000:1',
+                '--uidmap',
+                '1001:1001:2',
+                "busybox",
+            ],
+        )
+
+    async def test_gidmaps_extension(self):
+        c = create_compose_mock()
+
+        cnt = get_minimal_container()
+        cnt['x-podman.gidmaps'] = ['1000:1000:1', '1001:1001:2']
+
+        args = await container_to_args(c, cnt)
+        self.assertEqual(
+            args,
+            [
+                "--name=project_name_service_name1",
+                "-d",
+                "--network=bridge",
+                "--network-alias=service_name",
+                '--gidmap',
+                '1000:1000:1',
+                '--gidmap',
+                '1001:1001:2',
+                "busybox",
+            ],
+        )
+
     async def test_rootfs_extension(self):
         c = create_compose_mock()
 


### PR DESCRIPTION
This makes all podman-specific extensions configuration consistent.