### PR TITLE
Don't create pods/container when registering systemd unit

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2122,8 +2122,6 @@ async def compose_systemd(compose, args):
                     f.write(f"{k}={v}\n")
         log.debug("writing [%s]: done.", fn)
         log.info("\n\ncreating the pod without starting it: ...\n\n")
-        process = await asyncio.create_subprocess_exec(script, ["up", "--no-start"])
-        log.info("\nfinal exit code is %d", process)
         username = getpass.getuser()
         print(
             f"""


### PR DESCRIPTION
Closes #922 by removing the side effect from the systemd register action.

## Contributor Checklist:
- this PR is outside of the scope of the compose spec as it is systemd related.
- no unit tests have been changes since the code that was removed wasn't tested before.
