### PR TITLE
Allow providing default value for `--in-pod=` using environment variable

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1943,7 +1943,7 @@ class PodmanCompose:
             help="pod creation",
             metavar="in_pod",
             type=str,
-            default="true",
+            default=os.getenv("PODMAN_COMPOSE_USE_PODS", "true"),
         )
         parser.add_argument(
             "--pod-args",


### PR DESCRIPTION
With the new default of true, it is quite unergonomic and error prone to have to pass `--in-pod=` everywhere. This simple change allows providing default value using environment variable.

This should help mitigate https://github.com/containers/podman-compose/issues/795.