### PR TITLE
Add support for multi-line environment files

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1072,7 +1072,11 @@ async def container_to_args(compose, cnt, detached=True):
             if not required:
                 continue
             raise ValueError("Env file at {} does not exist".format(i))
-        podman_args.extend(["--env-file", i])
+        dotenv_dict = {}
+        dotenv_dict = dotenv_to_dict(i)
+        env = norm_as_list(dotenv_dict)
+        for e in env:
+            podman_args.extend(["-e", e])
     env = norm_as_list(cnt.get("environment", {}))
     for e in env:
         podman_args.extend(["-e", e])

--- a/pytests/test_container_to_args.py
+++ b/pytests/test_container_to_args.py
@@ -352,6 +352,15 @@ class TestContainerToArgs(unittest.IsolatedAsyncioTestCase):
             ],
         )
 
+    async def test_env_file_obj_required_non_existent_path(self):
+        c = create_compose_mock()
+
+        cnt = get_minimal_container()
+        cnt['env_file'] = {'path': 'not-exists', 'required': True}
+
+        with self.assertRaises(ValueError):
+            await container_to_args(c, cnt)
+
     async def test_env_file_obj_optional(self):
         c = create_compose_mock()
 

--- a/pytests/test_container_to_args.py
+++ b/pytests/test_container_to_args.py
@@ -251,8 +251,12 @@ class TestContainerToArgs(unittest.IsolatedAsyncioTestCase):
             [
                 "--name=project_name_service_name1",
                 "-d",
-                "--env-file",
-                env_file,
+                "-e",
+                "ZZVAR1=podman-rocks-123",
+                "-e",
+                "ZZVAR2=podman-rocks-124",
+                "-e",
+                "ZZVAR3=podman-rocks-125",
                 "--network=bridge",
                 "--network-alias=service_name",
                 "busybox",
@@ -268,7 +272,7 @@ class TestContainerToArgs(unittest.IsolatedAsyncioTestCase):
         with self.assertRaises(ValueError):
             await container_to_args(c, cnt)
 
-    async def test_env_file_str_arr(self):
+    async def test_env_file_str_array_one_path(self):
         c = create_compose_mock()
 
         cnt = get_minimal_container()
@@ -281,8 +285,42 @@ class TestContainerToArgs(unittest.IsolatedAsyncioTestCase):
             [
                 "--name=project_name_service_name1",
                 "-d",
-                "--env-file",
-                env_file,
+                "-e",
+                "ZZVAR1=podman-rocks-123",
+                "-e",
+                "ZZVAR2=podman-rocks-124",
+                "-e",
+                "ZZVAR3=podman-rocks-125",
+                "--network=bridge",
+                "--network-alias=service_name",
+                "busybox",
+            ],
+        )
+
+    async def test_env_file_str_array_two_paths(self):
+        c = create_compose_mock()
+
+        cnt = get_minimal_container()
+        env_file = path.realpath('tests/env-file-tests/env-files/project-1.env')
+        env_file_2 = path.realpath('tests/env-file-tests/env-files/project-2.env')
+        cnt['env_file'] = [env_file, env_file_2]
+
+        args = await container_to_args(c, cnt)
+        self.assertEqual(
+            args,
+            [
+                "--name=project_name_service_name1",
+                "-d",
+                "-e",
+                "ZZVAR1=podman-rocks-123",
+                "-e",
+                "ZZVAR2=podman-rocks-124",
+                "-e",
+                "ZZVAR3=podman-rocks-125",
+                "-e",
+                "ZZVAR1=podman-rocks-223",
+                "-e",
+                "ZZVAR2=podman-rocks-224",
                 "--network=bridge",
                 "--network-alias=service_name",
                 "busybox",
@@ -302,8 +340,12 @@ class TestContainerToArgs(unittest.IsolatedAsyncioTestCase):
             [
                 "--name=project_name_service_name1",
                 "-d",
-                "--env-file",
-                env_file,
+                "-e",
+                "ZZVAR1=podman-rocks-123",
+                "-e",
+                "ZZVAR2=podman-rocks-124",
+                "-e",
+                "ZZVAR3=podman-rocks-125",
                 "--network=bridge",
                 "--network-alias=service_name",
                 "busybox",

--- a/tests/env-file-tests/env-files/project-1.env
+++ b/tests/env-file-tests/env-files/project-1.env
@@ -1,1 +1,3 @@
 ZZVAR1=podman-rocks-123
+ZZVAR2=podman-rocks-124
+ZZVAR3=podman-rocks-125

--- a/tests/env-file-tests/env-files/project-2.env
+++ b/tests/env-file-tests/env-files/project-2.env
@@ -1,0 +1,2 @@
+ZZVAR1=podman-rocks-223
+ZZVAR2=podman-rocks-224


### PR DESCRIPTION
This PR adds support for several multi-line environment files.
PR fixes issue https://github.com/containers/podman-compose/issues/908.
Credit for actual solution goes to @hedayat. I only added tests as code reviewer @p12tic  requested.

From https://github.com/containers/podman-compose/pull/909:
"TBH, I don't find the part of compose spec which specifies this. Actually, it might not be according to the spec. However, this is what docker compose supports... !"
