### PR TITLE
 github/workflows: Fix automatic codespelling update

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -1,0 +1,1 @@
+assertIn

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -18,3 +18,5 @@ jobs:
         uses: actions/checkout@v4
       - name: Codespell
         uses: codespell-project/actions-codespell@v2
+        with:
+            ignore_words_file: .codespellignore


### PR DESCRIPTION
GitHub action actions-codespell@v2 uses codespell[toml]>=2.2.4 as a dependency. 
Since specific version of codespell can not be chosen by a user of this action, newer versions of codespell can break tests as it happens in podman-compose.
There is a feature request in codespell-project/actions-codespell to add a possibility to specify the version of Codespell : https://github.com/codespell-project/actions-codespell/issues/70.
For now, this PR  adds a workaroud for breaking tests: adds ignore_words_file. 
FR fixes https://github.com/containers/podman-compose/issues/951.
