### PR TITLE
Load .env from Compose file's directory and cwd

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1798,8 +1798,14 @@ class PodmanCompose:
         # env-file is relative to the CWD
         dotenv_dict = {}
         if args.env_file:
+            # Load .env from the Compose file's directory to preserve
+            # behavior prior to 1.1.0 and to match with Docker Compose (v2).
+            if ".env" == args.env_file:
+                project_dotenv_file = os.path.realpath(os.path.join(dirname, ".env"))
+                if os.path.exists(project_dotenv_file):
+                    dotenv_dict.update(dotenv_to_dict(project_dotenv_file))
             dotenv_path = os.path.realpath(args.env_file)
-            dotenv_dict = dotenv_to_dict(dotenv_path)
+            dotenv_dict.update(dotenv_to_dict(dotenv_path))
 
         # TODO: remove next line
         os.chdir(dirname)

--- a/tests/env-file-tests/.env
+++ b/tests/env-file-tests/.env
@@ -1,0 +1,2 @@
+ZZVAR1='This value is overwritten by env-file-tests/.env'
+ZZVAR3='This value is loaded from env-file-tests/.env'

--- a/tests/env-file-tests/.gitignore
+++ b/tests/env-file-tests/.gitignore
@@ -1,0 +1,4 @@
+# This overrides the repository root .gitignore (ignoring all .env).
+# The .env files in this directory are important for the test cases.
+!.env
+!project/.env

--- a/tests/env-file-tests/README.md
+++ b/tests/env-file-tests/README.md
@@ -25,3 +25,13 @@ based on environment variable precedent this command should give podman-rocks-32
 ```
 ZZVAR1=podman-rocks-321 podman-compose -f $(pwd)/project/container-compose.yaml --env-file $(pwd)/env-files/project-1.env up
 ```
+
+_The below test should print three environment variables_
+
+```
+podman-compose -f $(pwd)/project/container-compose.load-.env-in-project.yaml run --rm app
+
+ZZVAR1=This value is overwritten by env-file-tests/.env
+ZZVAR2=This value is loaded from .env in project/ directory
+ZZVAR3=This value is loaded from env-file-tests/.env
+```

--- a/tests/env-file-tests/project/.env
+++ b/tests/env-file-tests/project/.env
@@ -1,0 +1,2 @@
+ZZVAR1='This value is loaded but should be overwritten'
+ZZVAR2='This value is loaded from .env in project/ directory'

--- a/tests/env-file-tests/project/container-compose.load-.env-in-project.yaml
+++ b/tests/env-file-tests/project/container-compose.load-.env-in-project.yaml
@@ -1,0 +1,11 @@
+services:
+  app:
+    image: busybox
+    command: ["/bin/busybox", "sh", "-c", "env | grep ZZ"]
+    tmpfs:
+      - /run
+      - /tmp
+    environment:
+      ZZVAR1: $ZZVAR1
+      ZZVAR2: $ZZVAR2
+      ZZVAR3: $ZZVAR3


### PR DESCRIPTION
This commit loads dotenv `.env` (exactly that name) from the following location (the later takes precedence):

- The `.env` file in the Compose file's directory.
- The `.env` file in the current working directory (invoking podman-compose).

This preserves the behavior prior to 1.1.0 and to match with Docker Compose CLI.

Fix: https://github.com/containers/podman-compose/issues/937


## Contributor Checklist:

If this PR adds a new feature that improves compatibility with docker-compose, please add a link
to the exact part of compose spec that the PR touches.

All changes require additional unit tests.
