### PR TITLE
github: Add verbose option to integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
         if [ -f test-requirements.txt ]; then pip install -r test-requirements.txt; fi
     - name: Run tests in tests/
       run: |
-        python -m unittest tests/*.py
+        python -m unittest -v tests/*.py
       env:
         TESTS_DEBUG: 1
     - name: Run tests in pytests/


### PR DESCRIPTION
Currently it is not possible to see which test output corresponds to which test exactly. After this PR, before each new test its test name is printed.
