### PR TITLE
Restore support for alt dockerfiles (removing hardcoded "Dockerfile")

### DIFF
--- a/newsfragments/978.bugfix
+++ b/newsfragments/978.bugfix
@@ -1,0 +1,1 @@
+Fixed support for de-facto alternative `Dockerfile` names (e.g. `Containerfile`)

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1527,12 +1527,8 @@ def normalize_service_final(service: dict, project_dir: str) -> dict:
         build = service["build"]
         context = build if is_str(build) else build.get("context", ".")
         context = os.path.normpath(os.path.join(project_dir, context))
-        dockerfile = (
-            "Dockerfile" if is_str(build) else service["build"].get("dockerfile", "Dockerfile")
-        )
         if not is_dict(service["build"]):
             service["build"] = {}
-        service["build"]["dockerfile"] = dockerfile
         service["build"]["context"] = context
     return service
 

--- a/tests/unit/test_normalize_final_build.py
+++ b/tests/unit/test_normalize_final_build.py
@@ -22,7 +22,7 @@ class TestNormalizeFinalBuild(unittest.TestCase):
         (
             {"build": "."},
             {
-                "build": {"context": cwd, "dockerfile": "Dockerfile"},
+                "build": {"context": cwd},
             },
         ),
         (
@@ -30,7 +30,6 @@ class TestNormalizeFinalBuild(unittest.TestCase):
             {
                 "build": {
                     "context": os.path.normpath(os.path.join(cwd, "../relative")),
-                    "dockerfile": "Dockerfile",
                 },
             },
         ),
@@ -39,7 +38,6 @@ class TestNormalizeFinalBuild(unittest.TestCase):
             {
                 "build": {
                     "context": os.path.normpath(os.path.join(cwd, "./relative")),
-                    "dockerfile": "Dockerfile",
                 },
             },
         ),
@@ -48,7 +46,6 @@ class TestNormalizeFinalBuild(unittest.TestCase):
             {
                 "build": {
                     "context": "/workspace/absolute",
-                    "dockerfile": "Dockerfile",
                 },
             },
         ),
@@ -74,7 +71,6 @@ class TestNormalizeFinalBuild(unittest.TestCase):
             {
                 "build": {
                     "context": cwd,
-                    "dockerfile": "Dockerfile",
                 },
             },
         ),
@@ -135,12 +131,12 @@ class TestNormalizeFinalBuild(unittest.TestCase):
         (
             {},
             {"build": "."},
-            {"build": {"context": cwd, "dockerfile": "Dockerfile"}},
+            {"build": {"context": cwd}},
         ),
         (
             {"build": "."},
             {},
-            {"build": {"context": cwd, "dockerfile": "Dockerfile"}},
+            {"build": {"context": cwd}},
         ),
         (
             {"build": "/workspace/absolute"},
@@ -148,19 +144,18 @@ class TestNormalizeFinalBuild(unittest.TestCase):
             {
                 "build": {
                     "context": os.path.normpath(os.path.join(cwd, "./relative")),
-                    "dockerfile": "Dockerfile",
                 }
             },
         ),
         (
             {"build": "./relative"},
             {"build": "/workspace/absolute"},
-            {"build": {"context": "/workspace/absolute", "dockerfile": "Dockerfile"}},
+            {"build": {"context": "/workspace/absolute"}},
         ),
         (
             {"build": "./relative"},
             {"build": "/workspace/absolute"},
-            {"build": {"context": "/workspace/absolute", "dockerfile": "Dockerfile"}},
+            {"build": {"context": "/workspace/absolute"}},
         ),
         (
             {"build": {"dockerfile": "test-dockerfile"}},


### PR DESCRIPTION
Resolves #977 
Resolves  #929 
This commit restores setting a build directory as a string and looking for all available dockerfile alt names.
I strongly believe this is a bugfix, not modifying a compatibilty feature, as this was working that way in the older version 1.0.6.

The code for checking all the dockerfile alt names is already there, but "Dockerfile" was hardcoded in the normalize function, instead of being set to None to allow further alt dockerfile names search later in build_one().

build_one() already supports dockerfile being set to None (and that is visibly supposed to be that way).

With this PR, having a podman-compose.yaml with:
`build: .`
No longer throws "No Dockerfile found in CTX" when using a Containerfile (or other alt name). 