### PR TITLE
Support building images from a Containerfile

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1527,12 +1527,8 @@ def normalize_service_final(service: dict, project_dir: str) -> dict:
         build = service["build"]
         context = build if is_str(build) else build.get("context", ".")
         context = os.path.normpath(os.path.join(project_dir, context))
-        dockerfile = (
-            "Dockerfile" if is_str(build) else service["build"].get("dockerfile", "Dockerfile")
-        )
         if not is_dict(service["build"]):
             service["build"] = {}
-        service["build"]["dockerfile"] = dockerfile
         service["build"]["context"] = context
     return service
 


### PR DESCRIPTION
In `normalize_service_final`, podman-compose would arbitrarily set the name of the Containerfile to
"Dockerfile". This made the logic in `build_one` that looks for a number of different names a no-op
(because by the time `build_one` is called, the container dictionary already had an explicit
"Dockerfile").

Podman-compose should support building with a Containerfile (and should probably *prefer* that).

This commit modifies `normalize_service_final` so that it no longer explicitly sets the `dockerfile`
attribute. This allows the existing logic to find the correct file.

Closes #977
