### PR TITLE
Discover tests instead of passing a list of files to unittest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,12 +28,12 @@ jobs:
         if [ -f test-requirements.txt ]; then pip install -r test-requirements.txt; fi
     - name: Run integration tests
       run: |
-        python -m unittest -v tests/integration/*.py
+        python -m unittest discover -v tests/integration
       env:
         TESTS_DEBUG: 1
     - name: Run unit tests
       run: |
-        coverage run --source podman_compose -m unittest tests/unit/*.py
+        coverage run --source podman_compose -m unittest discover tests/unit
     - name: Report coverage
       run: |
         coverage combine

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,8 +54,8 @@ Note: Some steps are OPTIONAL but all are RECOMMENDED.
 7. Run code coverage:
 
     ```shell
-    $ coverage run --source podman_compose -m unittest tests/unit/*.py
-    $ python -m unittest tests/integration/*.py
+    $ coverage run --source podman_compose -m unittest discover tests/unit
+    $ python3 -m unittest discover tests/integration
     $ coverage combine
     $ coverage report
     $ coverage html

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ that are meant to test as many cases as we can to make sure we are compatible
 run a unittest with following command
 
 ```shell
-python -m unittest pytests/*.py
+python3 -m unittest discover tests/unit
 ```
 
 # Contributing guide

--- a/tests/integration/test_podman_compose.py
+++ b/tests/integration/test_podman_compose.py
@@ -4,7 +4,7 @@ import os
 import unittest
 from pathlib import Path
 
-from .test_utils import RunSubprocessMixin
+from tests.integration.test_utils import RunSubprocessMixin
 
 
 def base_path():

--- a/tests/integration/test_podman_compose_additional_contexts.py
+++ b/tests/integration/test_podman_compose_additional_contexts.py
@@ -7,8 +7,8 @@ import os
 import subprocess
 import unittest
 
-from .test_podman_compose import podman_compose_path
-from .test_podman_compose import test_path
+from tests.integration.test_podman_compose import podman_compose_path
+from tests.integration.test_podman_compose import test_path
 
 
 def compose_yaml_path():

--- a/tests/integration/test_podman_compose_build_secrets.py
+++ b/tests/integration/test_podman_compose_build_secrets.py
@@ -7,8 +7,8 @@ import os
 import subprocess
 import unittest
 
-from .test_podman_compose import podman_compose_path
-from .test_podman_compose import test_path
+from tests.integration.test_podman_compose import podman_compose_path
+from tests.integration.test_podman_compose import test_path
 
 
 def compose_yaml_path():

--- a/tests/integration/test_podman_compose_build_ulimits.py
+++ b/tests/integration/test_podman_compose_build_ulimits.py
@@ -7,8 +7,8 @@ import os
 import subprocess
 import unittest
 
-from .test_podman_compose import podman_compose_path
-from .test_podman_compose import test_path
+from tests.integration.test_podman_compose import podman_compose_path
+from tests.integration.test_podman_compose import test_path
 
 
 def compose_yaml_path():

--- a/tests/integration/test_podman_compose_config.py
+++ b/tests/integration/test_podman_compose_config.py
@@ -12,9 +12,9 @@ import unittest
 
 from parameterized import parameterized
 
-from .test_podman_compose import podman_compose_path
-from .test_podman_compose import test_path
-from .test_utils import RunSubprocessMixin
+from tests.integration.test_podman_compose import podman_compose_path
+from tests.integration.test_podman_compose import test_path
+from tests.integration.test_utils import RunSubprocessMixin
 
 
 def profile_compose_file():

--- a/tests/integration/test_podman_compose_in_pod.py
+++ b/tests/integration/test_podman_compose_in_pod.py
@@ -3,7 +3,7 @@
 import os
 import unittest
 
-from .test_utils import RunSubprocessMixin
+from tests.integration.test_utils import RunSubprocessMixin
 
 
 def base_path():

--- a/tests/integration/test_podman_compose_include.py
+++ b/tests/integration/test_podman_compose_include.py
@@ -3,7 +3,7 @@
 import unittest
 from pathlib import Path
 
-from .test_utils import RunSubprocessMixin
+from tests.integration.test_utils import RunSubprocessMixin
 
 
 class TestPodmanComposeInclude(unittest.TestCase, RunSubprocessMixin):

--- a/tests/integration/test_podman_compose_networks.py
+++ b/tests/integration/test_podman_compose_networks.py
@@ -10,9 +10,9 @@ Tests the podman networking parameters
 import os
 import unittest
 
-from .test_podman_compose import podman_compose_path
-from .test_podman_compose import test_path
-from .test_utils import RunSubprocessMixin
+from tests.integration.test_podman_compose import podman_compose_path
+from tests.integration.test_podman_compose import test_path
+from tests.integration.test_utils import RunSubprocessMixin
 
 
 class TestPodmanComposeNetwork(RunSubprocessMixin, unittest.TestCase):

--- a/tests/integration/test_podman_compose_tests.py
+++ b/tests/integration/test_podman_compose_tests.py
@@ -10,9 +10,9 @@ Tests the podman compose up and down commands used to create and remove services
 import os
 import unittest
 
-from .test_podman_compose import podman_compose_path
-from .test_podman_compose import test_path
-from .test_utils import RunSubprocessMixin
+from tests.integration.test_podman_compose import podman_compose_path
+from tests.integration.test_podman_compose import test_path
+from tests.integration.test_utils import RunSubprocessMixin
 
 
 class TestPodmanCompose(unittest.TestCase, RunSubprocessMixin):

--- a/tests/integration/test_podman_compose_up_down.py
+++ b/tests/integration/test_podman_compose_up_down.py
@@ -12,9 +12,9 @@ import unittest
 
 from parameterized import parameterized
 
-from .test_podman_compose import podman_compose_path
-from .test_podman_compose import test_path
-from .test_utils import RunSubprocessMixin
+from tests.integration.test_podman_compose import podman_compose_path
+from tests.integration.test_podman_compose import test_path
+from tests.integration.test_utils import RunSubprocessMixin
 
 
 def profile_compose_file():

--- a/tests/unit/test_container_to_args_secrets.py
+++ b/tests/unit/test_container_to_args_secrets.py
@@ -6,9 +6,8 @@ import unittest
 from parameterized import parameterized
 
 from podman_compose import container_to_args
-
-from .test_container_to_args import create_compose_mock
-from .test_container_to_args import get_minimal_container
+from tests.unit.test_container_to_args import create_compose_mock
+from tests.unit.test_container_to_args import get_minimal_container
 
 
 def repo_root():

--- a/tests/unit/test_get_net_args.py
+++ b/tests/unit/test_get_net_args.py
@@ -3,8 +3,7 @@ import unittest
 from parameterized import parameterized
 
 from podman_compose import get_net_args
-
-from .test_container_to_args import create_compose_mock
+from tests.unit.test_container_to_args import create_compose_mock
 
 PROJECT_NAME = "test_project_name"
 SERVICE_NAME = "service_name"


### PR DESCRIPTION
Test discovery helps to avoid oversights when a test is added but not executed.