### PR TITLE
Add a way to remove dashes in default network names

### DIFF
--- a/docs/Extensions.md
+++ b/docs/Extensions.md
@@ -91,6 +91,23 @@ The options to the network modes are passed to the `--network` option of the `po
 as-is.
 
 
+## Compatibility of default network names between docker-compose and podman-compose
+
+Current versions of podman-compose may produce different default external network names than
+docker-compose under certain conditions. Specifically, docker-compose removes dashes (`-` character)
+from project name.
+
+To enable compatibility between docker-compose and podman-compose, specify
+`default_net_name_compat: true` under global `x-podman` key:
+
+```
+x-podman:
+    default_net_name_compat: true
+```
+
+By default `default_net_name_compat` is `false`. This will change to `true` at some point and the
+setting will be removed.
+
 ## Custom pods management
 
 Podman-compose can have containers in pods. This can be controlled by extension key x-podman in_pod.

--- a/newsfragments/default_net_name_compat.feature
+++ b/newsfragments/default_net_name_compat.feature
@@ -1,0 +1,1 @@
+Added a way to get compatibility of default network names with docker compose. This is selected by setting `default_net_name_compat: true` on `x-podman` global dictionary.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -336,6 +336,11 @@ def norm_ulimit(inner_value):
     return inner_value
 
 
+def default_network_name_for_project(proj_name, net, is_ext):
+    # docker-compose removes dashes from project name when building network name
+    return net if is_ext else f"{proj_name}_{net}"
+
+
 # def tr_identity(project_name, given_containers):
 #    pod_name = f'pod_{project_name}'
 #    pod = dict(name=pod_name)
@@ -845,7 +850,7 @@ async def assert_cnt_nets(compose, cnt):
         net_desc = nets[net] or {}
         is_ext = net_desc.get("external", None)
         ext_desc = is_ext if is_dict(is_ext) else {}
-        default_net_name = net if is_ext else f"{proj_name}_{net}"
+        default_net_name = default_network_name_for_project(proj_name, net, is_ext)
         net_name = ext_desc.get("name", None) or net_desc.get("name", None) or default_net_name
         try:
             await compose.podman.output([], "network", ["exists", net_name])
@@ -934,7 +939,7 @@ def get_net_args(compose, cnt):
         net_desc = nets[net] or {}
         is_ext = net_desc.get("external", None)
         ext_desc = is_ext if is_dict(is_ext) else {}
-        default_net_name = net if is_ext else f"{proj_name}_{net}"
+        default_net_name = default_network_name_for_project(proj_name, net, is_ext)
         net_name = ext_desc.get("name", None) or net_desc.get("name", None) or default_net_name
         net_names.append(net_name)
     net_names_str = ",".join(net_names)
@@ -970,7 +975,7 @@ def get_net_args(compose, cnt):
             net_desc = nets[net_] or {}
             is_ext = net_desc.get("external", None)
             ext_desc = is_ext if is_dict(is_ext) else {}
-            default_net_name = net_ if is_ext else f"{proj_name}_{net_}"
+            default_net_name = default_network_name_for_project(proj_name, net_, is_ext)
             net_name = ext_desc.get("name", None) or net_desc.get("name", None) or default_net_name
 
             ipv4 = net_config_.get("ipv4_address", None)


### PR DESCRIPTION
This is the behavior exhibited by docker compose. The network names are user-visible through external networks, so previously anyone who migrated from docker-compose needed to change their configuration. Now it is possible to select compatibility via a flag in x-podman global dictionary.