### PR TITLE
Don't resolve links to compose file

### DIFF
--- a/newsfragments/dont-resolve-links-to-compose-file.bugfix
+++ b/newsfragments/dont-resolve-links-to-compose-file.bugfix
@@ -1,0 +1,1 @@
+Fix compatibility with docker-compose in how symlinks to docker-compose.yml are handled.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1785,7 +1785,6 @@ class PodmanCompose:
             sys.exit(1)
         # make absolute
         relative_files = files
-        files = list(map(os.path.realpath, files))
         filename = files[0]
         project_name = args.project_name
         # no_ansi = args.no_ansi

--- a/tests/integration/filesystem/compose_symlink/docker-compose.yml
+++ b/tests/integration/filesystem/compose_symlink/docker-compose.yml
@@ -1,0 +1,1 @@
+../compose_symlink_dest/docker-compose.yml

--- a/tests/integration/filesystem/compose_symlink/file
+++ b/tests/integration/filesystem/compose_symlink/file
@@ -1,0 +1,1 @@
+data_compose_symlink

--- a/tests/integration/filesystem/compose_symlink_dest/docker-compose.yml
+++ b/tests/integration/filesystem/compose_symlink_dest/docker-compose.yml
@@ -1,0 +1,7 @@
+version: "3"
+services:
+  container1:
+    image: nopush/podman-compose-test
+    command: ["/bin/busybox", "cat", "/file"]
+    volumes:
+      - "./file:/file"

--- a/tests/integration/filesystem/compose_symlink_dest/file
+++ b/tests/integration/filesystem/compose_symlink_dest/file
@@ -1,0 +1,1 @@
+data_compose_symlink_dest

--- a/tests/integration/filesystem/test_filesystem.py
+++ b/tests/integration/filesystem/test_filesystem.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: GPL-2.0
+
+
+import os
+import unittest
+
+from tests.integration.test_podman_compose import podman_compose_path
+from tests.integration.test_podman_compose import test_path
+from tests.integration.test_utils import RunSubprocessMixin
+
+
+class TestFilesystem(unittest.TestCase, RunSubprocessMixin):
+    def test_compose_symlink(self):
+        """The context of podman-compose.yml should come from the same directory as the file even
+        if it is a symlink
+        """
+
+        compose_path = os.path.join(test_path(), "filesystem/compose_symlink/docker-compose.yml")
+
+        try:
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_path,
+                "up",
+                "-d",
+                "container1",
+            ])
+
+            out, _ = self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_path,
+                "logs",
+                "container1",
+            ])
+
+            # BUG: figure out why cat is called twice
+            self.assertEqual(out, b'data_compose_symlink\ndata_compose_symlink\n')
+
+        finally:
+            out, _ = self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_path,
+                "down",
+            ])


### PR DESCRIPTION
docker-compose uses the path to the compose file even if it's symlink to get the context directory.