### PR TITLE
Remove references to nonexistent devel and stable branches

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,8 +13,6 @@ A clear and concise description of what the bug is.
 Please make sure it's not a bug in podman (in that case report it to podman)
 or your understanding of docker-compose or how rootless containers work (for example, it's normal for rootless container not to be able to listen for port less than 1024 like 80)
 
-please try to reproduce the bug in latest devel branch
-
 **To Reproduce**
 Steps to reproduce the behavior:
 1. what is the content of the current working directory (ex. `docker-compose.yml`, `.env`, `Dockerfile`, ...etc.)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,11 +8,6 @@
 - Developers that want to fix bugs,
 - Developers that want to implement new functionalities or enhancements.
 
-## Branches
-
-Please request your pull request to be merged into the `devel` branch.
-Changes to the `stable` branch are managed by the repository maintainers.
-
 ## Development environment setup
 
 Note: Some steps are OPTIONAL but all are RECOMMENDED.
@@ -68,8 +63,7 @@ Note: Some steps are OPTIONAL but all are RECOMMENDED.
    - In the commit message, reference the Issue ID that your code fixes and a brief description of
      the changes.
      Example: `Fixes #516: Allow empty network`
-9. Open a pull request to `containers/podman-compose:devel` and wait for a maintainer to review your
-   work.
+9. Open a pull request to `containers/podman-compose` and wait for a maintainer to review your work.
 
 ## Adding new commands
 


### PR DESCRIPTION
The devel and staging branches referenced in [CONTRIBUTING.md](https://github.com/containers/podman-compose/blob/b6eadd56b195a4ede6fe3cff8b0c1207532bb98c/CONTRIBUTING.md) and [.github/ISSUE_TEMPLATE/bug_report.md](https://github.com/containers/podman-compose/blob/b6eadd56b195a4ede6fe3cff8b0c1207532bb98c/.github/ISSUE_TEMPLATE/bug_report.md) no longer exist.

Closes #894
