### PR TITLE
Substitution with service environment

### DIFF
--- a/newsfragments/substitution-with-service-environment.feature
+++ b/newsfragments/substitution-with-service-environment.feature
@@ -1,0 +1,1 @@
+Add ability to substitute variables with the environment of the service.

--- a/tests/integration/env-tests/container-compose.yml
+++ b/tests/integration/env-tests/container-compose.yml
@@ -1,9 +1,10 @@
-version: '3'
+version: "3"
 
 services:
   env-test:
     image: busybox
     command: sh -c "export | grep ZZ"
     environment:
-    - ZZVAR1=myval1
-
+      ZZVAR1: myval1
+      ZZVAR2: 2-$ZZVAR1
+      ZZVAR3: 3-$ZZVAR2

--- a/tests/unit/test_rec_subs.py
+++ b/tests/unit/test_rec_subs.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: GPL-2.0
+# pylint: disable=protected-access
+
+import unittest
+
+from parameterized import parameterized
+
+from podman_compose import rec_subs
+
+
+class TestRecSubs(unittest.TestCase):
+    substitutions = [
+        # dict with environment variables
+        (
+            "service's environment is low priority",
+            {"environment": {"v1": "low priority", "actual-v1": "$v1"}},
+            {"environment": {"v1": "low priority", "actual-v1": "high priority"}},
+        ),
+        (
+            "service's environment can be used in other values",
+            {"environment": {"v100": "v1.0.0", "image": "abc:$v100"}},
+            {"environment": {"v100": "v1.0.0", "image": "abc:v1.0.0"}},
+        ),
+        (
+            "Non-variable should not be substituted",
+            {"environment": {"non_var": "$$v1", "vx": "$non_var"}, "image": "abc:$non_var"},
+            {"environment": {"non_var": "$v1", "vx": "$v1"}, "image": "abc:$v1"},
+        ),
+        # list
+        (
+            "Values in list are substituted",
+            ["$v1", "low priority"],
+            ["high priority", "low priority"],
+        ),
+        # str
+        (
+            "Value with ${VARIABLE} format",
+            "${v1}",
+            "high priority",
+        ),
+        (
+            "Value with ${VARIABLE:-default} format",
+            ["${v1:-default}", "${empty:-default}", "${not_exits:-default}"],
+            ["high priority", "default", "default"],
+        ),
+        (
+            "Value with ${VARIABLE-default} format",
+            ["${v1-default}", "${empty-default}", "${not_exits-default}"],
+            ["high priority", "", "default"],
+        ),
+        (
+            "Value $$ means $",
+            "$$v1",
+            "$v1",
+        ),
+    ]
+
+    @parameterized.expand(substitutions)
+    def test_rec_subs(self, desc, input, expected):
+        sub_dict = {"v1": "high priority", "empty": ""}
+        result = rec_subs(input, sub_dict)
+        self.assertEqual(result, expected, msg=desc)


### PR DESCRIPTION
This pr add the ability to substitute the variable with the service's environment.
This allows the use the service's environment within the service block itself.

For instance, in the provided example:

```yaml
services:
  app:
    image: "abc:${version}"
    build:
      context: .
      args:
        VERSION: "${version}"
    environment:
      version: v1.0
```

The `version` environment is defined within the `app` service and
it is then used to define the `image` and `VERSION` build argument
for the same service.
