### PR TITLE
podman_compose.py: support "platform" property in the build command

### DIFF
--- a/newsfragments/build-platform.feature
+++ b/newsfragments/build-platform.feature
@@ -1,0 +1,1 @@
+Added support for "platform" property in the build command.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2375,6 +2375,8 @@ async def build_one(compose, args, cnt):
     if not os.path.exists(dockerfile):
         raise OSError("Dockerfile not found in " + ctx)
     build_args = ["-f", dockerfile, "-t", cnt["image"]]
+    if "platform" in cnt:
+        build_args.extend(["--platform", cnt["platform"]])
     for secret in build_desc.get("secrets", []):
         build_args.extend(get_secret_args(compose, cnt, secret, podman_is_building=True))
     for tag in build_desc.get("tags", []):


### PR DESCRIPTION
This was already added to container_to_args() in https://github.com/containers/podman-compose/pull/470 which is used for the 'up' and 'run' commands.

Definition in the schema: https://github.com/compose-spec/compose-spec/blob/main/schema/compose-spec.json#L329

Should I add a unit test? Are there any for the build command already?