### PR TITLE
Support changing io.podman label domain namespace

### DIFF
--- a/newsfragments/label_domain.feature
+++ b/newsfragments/label_domain.feature
@@ -1,0 +1,1 @@
+Added support to change default resource label prefix from io.podman via --label-domain cli arg


### PR DESCRIPTION
Add global cli flag `--label-domain` and env var `COMPOSE_LABEL_DOMAIN` (default `io.podman`).
If set, it changes the out-of-spec root domain set and filtered for alongside the spec-mandated `com.docker.compose`.

### Related:
- Resolves https://github.com/containers/podman-compose/issues/1013
- Based on https://github.com/containers/podman-compose/pull/1014

#### Compose spec
  - https://github.com/compose-spec/compose-spec/blob/main/05-services.md#labels
  - https://github.com/compose-spec/compose-spec/blob/main/02-model.md#the-compose-application-model

