### PR TITLE
Minimum Python version 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
 
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install dependencies
       run: |
         set -e
-        apt update && apt install -y podman
+        apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y podman
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -r test-requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -17,11 +17,10 @@ setup(
     classifiers=[
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Intended Audience :: Developers",
         "Operating System :: OS Independent",
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
Suggesting to drop advertised support for Python 3.7 and 3.8, increasing minimum supported version to 3.9.

- Python 3.7 went EOL 2023-06-27 and is already untested.
- Python 3.8 is nearing EOL (ETA 2024-10).
- 3.9 matches distro versions of:
  - Debian bullseye (oldstable)
  - At least down to Fedora 37

(I'd personally go as far as suggesting bumping as far as 3.10 or even 3.11 (Debian stable/Fedora 38) as the type annotation features there could be nice. Starting with this more conservative change to take the temperature on how conservative podman-compose intends to be wrt runtime backwards-compatibility :))