### PR TITLE
tests/integration: Automate manual `extends_w_file` test

### DIFF
--- a/tests/integration/extends_w_file/Dockerfile
+++ b/tests/integration/extends_w_file/Dockerfile
@@ -1,0 +1,1 @@
+FROM nopush/podman-compose-test as base

--- a/tests/integration/test_podman_compose_extends_w_empty_service.py
+++ b/tests/integration/test_podman_compose_extends_w_empty_service.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: GPL-2.0
+
+import os
+import unittest
+
+from tests.integration.test_podman_compose import podman_compose_path
+from tests.integration.test_podman_compose import test_path
+from tests.integration.test_utils import RunSubprocessMixin
+
+
+def compose_yaml_path():
+    return os.path.join(os.path.join(test_path(), "extends_w_empty_service"), "docker-compose.yml")
+
+
+class TestComposeExtendsWithEmptyService(unittest.TestCase, RunSubprocessMixin):
+    def test_extends_w_empty_service(self):
+        try:
+            self.run_subprocess_assert_returncode(
+                [
+                    podman_compose_path(),
+                    "-f",
+                    compose_yaml_path(),
+                    "up",
+                ],
+            )
+            output, _ = self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path(),
+                "ps",
+            ])
+            self.assertIn("extends_w_empty_service_web_1", str(output))
+        finally:
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path(),
+                "down",
+            ])

--- a/tests/integration/test_podman_compose_extends_w_file.py
+++ b/tests/integration/test_podman_compose_extends_w_file.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: GPL-2.0
+
+import os
+import unittest
+
+from tests.integration.test_podman_compose import podman_compose_path
+from tests.integration.test_podman_compose import test_path
+from tests.integration.test_utils import RunSubprocessMixin
+
+
+def compose_yaml_path():
+    return os.path.join(os.path.join(test_path(), "extends_w_file"), "docker-compose.yml")
+
+
+class TestComposeExtendsWithFile(unittest.TestCase, RunSubprocessMixin):
+    def test_extends_w_file(self):  # when file is Dockerfile for building the image
+        try:
+            self.run_subprocess_assert_returncode(
+                [
+                    podman_compose_path(),
+                    "-f",
+                    compose_yaml_path(),
+                    "up",
+                ],
+            )
+            output, _ = self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path(),
+                "ps",
+            ])
+            self.assertIn("extends_w_file_web_1", str(output))
+            self.assertIn("extends_w_file_important_web_1", str(output))
+        finally:
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path(),
+                "down",
+            ])


### PR DESCRIPTION
This PR automates manual `extends_w_file` test.
It is a partial fix for https://github.com/containers/podman-compose/issues/983.