### PR TITLE
Revert "Use defined environment variables in the image build process"

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2408,10 +2408,6 @@ async def build_one(compose, args, cnt):
         build_args.append("--pull-always")
     elif getattr(args, "pull", None):
         build_args.append("--pull")
-    env = dict(cnt.get("environment", {}))
-    for name, value in env.items():
-        build_args += ["--env", f"{name}" if value is None else f"{name}={value}"]
-
     args_list = norm_as_list(build_desc.get("args", {}))
     for build_arg in args_list + args.build_arg:
         build_args.extend((


### PR DESCRIPTION
This reverts commit 901adf47d0a0a00a12bdeb3b9d92c74a90ff98aa. fixes #985 and #931

Demonstration of the bug - the variable RUN should not be available during build-time, only run time:

```
% ls
Dockerfile		docker-compose.yaml
% cat Dockerfile 
FROM alpine:latest
RUN mkdir /app && echo "See how I $RUN" > /app/message
CMD ["cat", "/app/message"]

% cat docker-compose.yaml 
services:
  test:
    build:
      context: .
    environment:
      RUN: sheep

% docker-compose up
[+] Running 1/0
 ✔ Container podman-test-test-1  Created                                                                                                                                          0.1s 
Attaching to test-1
test-1  | See how I 
test-1 exited with code 0

% podman-compose up
adcea6dff681c84fd05d03021aa474acb44734da127b748770819f5c711b1b73
a6b7ea09b7227beb66729f22e6d523bf423b3747fc7ced883a81b10f7998225b
[test] | See how I sheep
% 

```