### PR TITLE
tests/integration: Automate manual `ipam_default` test

### DIFF
--- a/tests/integration/ipam_default/docker-compose.yaml
+++ b/tests/integration/ipam_default/docker-compose.yaml
@@ -1,6 +1,6 @@
 version: '3'
 
-# --ipam-driver must not be pass when driver is "default"
+# --ipam-driver must not be passed when driver is "default"
 networks:
   ipam_test_default:
     ipam:

--- a/tests/integration/test_podman_compose_ipam_default.py
+++ b/tests/integration/test_podman_compose_ipam_default.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: GPL-2.0
+
+import json
+import os
+import unittest
+
+from tests.integration.test_podman_compose import podman_compose_path
+from tests.integration.test_podman_compose import test_path
+from tests.integration.test_utils import RunSubprocessMixin
+
+
+def compose_yaml_path():
+    return os.path.join(os.path.join(test_path(), "ipam_default"), "docker-compose.yaml")
+
+
+class TestComposeIpamDefault(unittest.TestCase, RunSubprocessMixin):
+    def test_ipam_default(self):
+        try:
+            self.run_subprocess_assert_returncode(
+                [podman_compose_path(), "-f", compose_yaml_path(), "up", "-d"],
+            )
+
+            output, _ = self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path(),
+                "logs",
+            ])
+            # when container is created, its command echoes 'ipamtest'
+            # BUG: figure out why echo is called twice
+            self.assertIn("ipamtest", str(output))
+
+            output, _ = self.run_subprocess_assert_returncode(
+                [
+                    "podman",
+                    "inspect",
+                    "ipam_default_testipam_1",
+                ],
+            )
+            network_info = json.loads(output.decode('utf-8'))[0]
+            network_name = next(iter(network_info["NetworkSettings"]["Networks"].keys()))
+
+            output, _ = self.run_subprocess_assert_returncode([
+                "podman",
+                "network",
+                "inspect",
+                "{}".format(network_name),
+            ])
+            network_info = json.loads(output.decode('utf-8'))[0]
+            # bridge is the default network driver
+            self.assertEqual(network_info['driver'], "bridge")
+            self.assertEqual(network_info['ipam_options'], {'driver': 'host-local'})
+        finally:
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path(),
+                "down",
+            ])


### PR DESCRIPTION
This PR automates manual `ipam_default` test.
It is a partial fix for https://github.com/containers/podman-compose/issues/983.