### PR TITLE
Download and build podman-compose using docker/podman locally

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Build binary
+        run: |
+          mkdir -p release/
+          docker build -t podman-compose-bin -v "$PWD/release:/result" .
+          mv "$PWD/release/podman-compose" "$PWD/release/podman-compose-linux-x86"
+
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ./release/podman-compose-linux-x86
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# Use a base image with necessary build tools
+FROM python:3.11-slim AS builder
+
+# Install required packages for building
+RUN apt-get update && apt-get install -y \
+    gcc \
+    musl-dev \
+    build-essential \
+    python3-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the application code
+COPY . .
+
+# Install PyInstaller
+RUN pip install pyinstaller
+RUN pip install -r requirements.txt
+
+# Create a binary with PyInstaller
+RUN pyinstaller --onefile --clean podman_compose.py
+
+# Create /result dir in case it is not mounted
+RUN mkdir -p /result
+
+# Export binary
+RUN cp /app/dist/podman_compose /result/podman-compose

--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ pip3 install https://github.com/containers/podman-compose/archive/main.tar.gz
 brew install podman-compose
 ```
 
+### Generate binary using docker/podman locally
+This script will download the repo, generate the binary using [this Dockerfile](https://github.com/containers/podman-compose/blob/main/Dockerfile.md) and let the binary in the directory where you called this script.
+```bash
+sh -c "$(curl -sSL https://raw.githubusercontent.com/containers/podman-compose/main/scripts/download_and_build_podman-compose.sh)"
+```
+
 ### Manual
 
 ```bash

--- a/scripts/download_and_build_podman-compose.sh
+++ b/scripts/download_and_build_podman-compose.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Delete repository dir
+rm -rf podman-compose-src
+
+# Clone repository
+git clone https://github.com/containers/podman-compose podman-compose-src
+
+# Generate binary
+sh podman-compose-src/scripts/generate_binary_using_dockerfile.sh
+
+# Move binary outside repo's dir
+mv podman-compose-src/podman-compose .
+
+# Delete repository dir
+rm -rf podman-compose-src

--- a/scripts/generate_binary_using_dockerfile.sh
+++ b/scripts/generate_binary_using_dockerfile.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+
+# Find an available container tool (docker or podman)
+find_container_tool() {
+    if command -v docker > /dev/null 2>&1; then
+        echo "sudo docker"
+    elif command -v podman > /dev/null 2>&1; then
+        echo "podman"
+    else
+        echo "Error: Neither docker nor podman is available." >&2
+        exit 1
+    fi
+}
+
+# Determine which container tool to use
+CONTAINER_TOOL=$(find_container_tool)
+
+# Locate the directory containing dockerfile (root)
+PROJECT_ROOT_DIR="$(cd "$(dirname "$0")" && pwd)/.."
+
+# Check SELinux status and set appropriate mount option
+check_selinux() {
+    if command -v getenforce > /dev/null 2>&1; then
+        SELINUX_STATUS=$(getenforce)
+        if [ "$SELINUX_STATUS" = "Enforcing" ] || [ "$SELINUX_STATUS" = "Permissive" ]; then
+            echo ":z"
+        else
+            echo ""
+        fi
+    elif [ -f /sys/fs/selinux/enforce ]; then
+        if [ "$(cat /sys/fs/selinux/enforce)" = "1" ]; then
+            echo ":z"
+        else
+            echo ""
+        fi
+    else
+        echo ""
+    fi
+}
+
+# Get the SELinux option for volume mounts if SELinux is enforcing or permissive
+SELINUX=$(check_selinux)
+
+# Build binary
+$CONTAINER_TOOL image rm build-podman-compose
+
+if expr "$CONTAINER_TOOL" : '.*docker.*' >/dev/null; then
+    $CONTAINER_TOOL build -t build-podman-compose "$PROJECT_ROOT_DIR"
+    $CONTAINER_TOOL run --name build-podman-compose build-podman-compose
+    $CONTAINER_TOOL cp build-podman-compose:/result/podman-compose "$PROJECT_ROOT_DIR/podman-compose"
+    $CONTAINER_TOOL container stop build-podman-compose
+    $CONTAINER_TOOL container rm -f build-podman-compose
+else
+    $CONTAINER_TOOL build -v "$PROJECT_ROOT_DIR:/result$SELINUX" -t build-podman-compose "$PROJECT_ROOT_DIR"
+fi
+$CONTAINER_TOOL image rm python:3.11-slim
+$CONTAINER_TOOL image rm build-podman-compose


### PR DESCRIPTION
## Reason for this PR
As a user of Fedora Silverblue I found that the easiest ways to install podman-compose are:
- Open a toolbox/distrobox container, install there the python dependencies, use pyinstaller, generate a podman-compose binary and move it outside of the container to use it.
- Create a virtual env, install dependencies and use pyinstaller to compile it.
- Install Podman Desktop and let it install and manage podman-compose.
- [Not actually podman-compose] Manually set podman.socket and downloading docker-compose.

I just wanted to execute a single command and obtain a binary I can save on my home directory without modifying anything outside my $HOME.

## Changes
- Adds Dockerfile that compiles podman-compose and let the binary on /result.
- Adds a script to generate the binary and drop it on the current directory.
- Adds script to simplify this process so people can just "download" the binary by executing a single shell command.

## Usage
```bash
sh -c "$(curl -sSL https://raw.githubusercontent.com/containers/podman-compose/main/scripts/download_podman-compose.sh)"
```

> Using this approach, everything happens within the build steps of the Dockerfile, so no dependencies or temporary files should be left on your system.

Thanks in advance. Any suggestions are welcome.