### PR TITLE
First attempt at providing support for conditional dependencies

### DIFF
--- a/newsfragments/conditional-dependencies.feature
+++ b/newsfragments/conditional-dependencies.feature
@@ -1,0 +1,1 @@
+Added support for honoring the condition in the depends_on section of the service, if stated.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1337,7 +1337,7 @@ def flat_deps(services, with_extends=False):
             ext = srv.get("extends", {}).get("service", None)
             if ext:
                 if ext != name:
-                    deps.add(ext)
+                    deps.add(ServiceDependency(ext))
                 continue
         deps_ls = srv.get("depends_on", [])
         if isinstance(deps_ls, str):

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1348,6 +1348,7 @@ def flat_deps(services, with_extends=False):
             deps_ls = [ServiceDependency(k, v.get("condition")) for k, v in deps_ls.items()]
         else:
             raise RuntimeError("depends_on should be a string, a list of strings or a dict")
+        deps.update(deps_ls)
 
         # parse link to get service name and remove alias
         links_ls = srv.get("links", [])

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1354,7 +1354,7 @@ def flat_deps(services, with_extends=False):
         links_ls = srv.get("links", [])
         if not is_list(links_ls):
             links_ls = [links_ls]
-        deps.update([(c.split(":")[0] if ":" in c else c) for c in links_ls])
+        deps.update([ServiceDependency(c.split(":")[0] if ":" in c else c) for c in links_ls])
         for c in links_ls:
             if ":" in c:
                 dep_name, dep_alias = c.split(":")

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1323,7 +1323,7 @@ def flat_deps(services, with_extends=False):
             if not dep_srv:
                 continue
             # NOTE: avoid creating loops, A->B->A
-            if start_point in any(x.name for x in dep_srv["_deps"]):
+            if any(start_point == x.name for x in dep_srv["_deps"]):
                 continue
             new_deps = rec_deps(services, dep_name, start_point)
             deps.update(new_deps)

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1345,9 +1345,9 @@ def flat_deps(services, with_extends=False):
         elif isinstance(deps_ls, list):
             deps_ls = [ServiceDependency(t) for t in deps_ls]
         elif isinstance(deps_ls, dict):
-            deps_ls = [ServiceDependency(k, v.get("condition")) for k, v in deps.items()]
+            deps_ls = [ServiceDependency(k, v.get("condition")) for k, v in deps_ls.items()]
         else:
-            raise RuntimeError("depends_on should be a list of strings or a dict")
+            raise RuntimeError("depends_on should be a string, a list of strings or a dict")
 
         # parse link to get service name and remove alias
         links_ls = srv.get("links", [])

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1340,7 +1340,9 @@ def flat_deps(services, with_extends=False):
                     deps.add(ext)
                 continue
         deps_ls = srv.get("depends_on", [])
-        if isinstance(deps_ls, list):
+        if isinstance(deps_ls, str):
+            deps_ls = [ServiceDependency(dep_ls)]
+        elif isinstance(deps_ls, list):
             deps_ls = [ServiceDependency(t) for t in deps_ls]
         elif isinstance(deps_ls, dict):
             deps_ls = [ServiceDependency(k, v.get("condition")) for k, v in deps.items()]

--- a/tests/integration/deps/docker-compose-conditional.yaml
+++ b/tests/integration/deps/docker-compose-conditional.yaml
@@ -1,0 +1,22 @@
+version: "3.7"
+services:
+  web:
+    image: nopush/podman-compose-test
+    command: ["dumb-init", "/bin/busybox", "httpd", "-f", "-h", "/etc/", "-p", "8000"]
+    tmpfs:
+      - /run
+      - /tmp
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8000/hosts"]
+      interval: 30s # Time between health checks
+      timeout: 5s # Time to wait for a response
+      retries: 3 # Number of consecutive failures before marking as unhealthy
+  sleep:
+    image: nopush/podman-compose-test
+    command: ["dumb-init", "/bin/busybox", "sh", "-c", "sleep 3600"]
+    depends_on:
+      web:
+        condition: service_healthy
+    tmpfs:
+      - /run
+      - /tmp

--- a/tests/integration/test_podman_compose_deps.py
+++ b/tests/integration/test_podman_compose_deps.py
@@ -7,11 +7,11 @@ from tests.integration.test_podman_compose import test_path
 from tests.integration.test_utils import RunSubprocessMixin
 
 
-def compose_yaml_path():
-    return os.path.join(os.path.join(test_path(), "deps"), "docker-compose.yaml")
+def compose_yaml_path(suffix=""):
+    return os.path.join(os.path.join(test_path(), "deps"), f"docker-compose{suffix}.yaml")
 
 
-class TestComposeDeps(unittest.TestCase, RunSubprocessMixin):
+class TestComposeBaseDeps(unittest.TestCase, RunSubprocessMixin):
     def test_deps(self):
         try:
             output, error = self.run_subprocess_assert_returncode([
@@ -32,5 +32,31 @@ class TestComposeDeps(unittest.TestCase, RunSubprocessMixin):
                 podman_compose_path(),
                 "-f",
                 compose_yaml_path(),
+                "down",
+            ])
+
+
+class TestComposeConditionalDeps(unittest.TestCase, RunSubprocessMixin):
+    def test_deps(self):
+        suffix = "-conditional"
+        try:
+            output, error = self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path(suffix),
+                "run",
+                "--rm",
+                "sleep",
+                "/bin/sh",
+                "-c",
+                "wget -O - http://web:8000/hosts",
+            ])
+            self.assertIn(b"HTTP request sent, awaiting response... 200 OK", output)
+            self.assertIn(b"deps_web_1", output)
+        finally:
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path(suffix),
                 "down",
             ])


### PR DESCRIPTION
Currently all services dependencies are treated unconditionally. However, [docker-compose supports](https://docs.docker.com/compose/how-tos/startup-order/#control-startup) specifying three possible conditions (started, healthy, successfully finished). This PR attempts to provide such support, extending the existing unit tests for dependencies.
