### PR TITLE
docker compat: use hyphens to join container names

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -223,7 +223,7 @@ def fix_mount_dict(compose, mount_dict, srv_name):
             elif external:
                 vol["name"] = f"{source}"
             else:
-                vol["name"] = f"{compose.project_name}_{source}"
+                vol["name"] = f"{compose.project_name}-{source}"
     return mount_dict
 
 
@@ -351,7 +351,7 @@ def default_network_name_for_project(compose, net, is_ext):
 
     default_net_name_compat = compose.x_podman.get("default_net_name_compat", False)
     if default_net_name_compat is True:
-        return f"{compose.project_name.replace('-', '')}_{net}"
+        return f"{compose.project_name.replace('-', '')}-{net}"
     return f"{compose.project_name}_{net}"
 
 
@@ -369,7 +369,7 @@ def transform(args, project_name, given_containers):
         pod_name = None
         pods = []
     else:
-        pod_name = f"pod_{project_name}"
+        pod_name = f"pod-{project_name}"
         pod = {"name": pod_name}
         pods = [pod]
     containers = []
@@ -1979,7 +1979,7 @@ class PodmanCompose:
 
             container_names_by_service[service_name] = []
             for num in range(1, replicas + 1):
-                name0 = f"{project_name}_{service_name}_{num}"
+                name0 = f"{project_name}-{service_name}-{num}"
                 if num == 1:
                     name = service_desc.get("container_name", name0)
                 else:
@@ -1995,7 +1995,7 @@ class PodmanCompose:
                 x_podman = service_desc.get("x-podman", None)
                 rootfs_mode = x_podman is not None and x_podman.get("rootfs", None) is not None
                 if "image" not in cnt and not rootfs_mode:
-                    cnt["image"] = f"{project_name}_{service_name}"
+                    cnt["image"] = f"{project_name}-{service_name}"
                 labels = norm_as_list(cnt.get("labels", None))
                 cnt["ports"] = norm_ports(cnt.get("ports", None))
                 labels.extend(podman_compose_labels)
@@ -2764,7 +2764,7 @@ async def compose_run(compose, args):
 
 def compose_run_update_container_from_args(compose, cnt, args):
     # adjust one-off container options
-    name0 = "{}_{}_tmp{}".format(compose.project_name, args.service, random.randrange(0, 65536))
+    name0 = "{}-{}-tmp{}".format(compose.project_name, args.service, random.randrange(0, 65536))
     cnt["name"] = args.name or name0
     if args.entrypoint:
         cnt["entrypoint"] = args.entrypoint

--- a/tests/integration/test_podman_compose_deps.py
+++ b/tests/integration/test_podman_compose_deps.py
@@ -26,7 +26,7 @@ class TestComposeDeps(unittest.TestCase, RunSubprocessMixin):
                 "wget -O - http://web:8000/hosts",
             ])
             self.assertIn(b"HTTP request sent, awaiting response... 200 OK", output)
-            self.assertIn(b"deps_web_1", output)
+            self.assertIn(b"deps-web-1", output)
         finally:
             self.run_subprocess_assert_returncode([
                 podman_compose_path(),

--- a/tests/integration/test_podman_compose_extends_w_empty_service.py
+++ b/tests/integration/test_podman_compose_extends_w_empty_service.py
@@ -29,7 +29,7 @@ class TestComposeExtendsWithEmptyService(unittest.TestCase, RunSubprocessMixin):
                 compose_yaml_path(),
                 "ps",
             ])
-            self.assertIn("extends_w_empty_service_web_1", str(output))
+            self.assertIn("extends_w_empty_service-web-1", str(output))
         finally:
             self.run_subprocess_assert_returncode([
                 podman_compose_path(),

--- a/tests/integration/test_podman_compose_extends_w_file.py
+++ b/tests/integration/test_podman_compose_extends_w_file.py
@@ -29,8 +29,8 @@ class TestComposeExtendsWithFile(unittest.TestCase, RunSubprocessMixin):
                 compose_yaml_path(),
                 "ps",
             ])
-            self.assertIn("extends_w_file_web_1", str(output))
-            self.assertIn("extends_w_file_important_web_1", str(output))
+            self.assertIn("extends_w_file-web-1", str(output))
+            self.assertIn("extends_w_file-important_web-1", str(output))
         finally:
             self.run_subprocess_assert_returncode([
                 podman_compose_path(),

--- a/tests/integration/test_podman_compose_extends_w_file_subdir.py
+++ b/tests/integration/test_podman_compose_extends_w_file_subdir.py
@@ -29,7 +29,7 @@ class TestComposeExtendsWithFileSubdir(unittest.TestCase, RunSubprocessMixin):
                 compose_yaml_path(),
                 "ps",
             ])
-            self.assertIn("extends_w_file_subdir_web_1", str(output))
+            self.assertIn("extends_w_file_subdir-web-1", str(output))
         finally:
             self.run_subprocess_assert_returncode([
                 podman_compose_path(),

--- a/tests/integration/test_podman_compose_ipam_default.py
+++ b/tests/integration/test_podman_compose_ipam_default.py
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: GPL-2.0
+# SPDt-License-Identifier: GPL-2.0
 
 import json
 import os
@@ -34,7 +34,7 @@ class TestComposeIpamDefault(unittest.TestCase, RunSubprocessMixin):
                 [
                     "podman",
                     "inspect",
-                    "ipam_default_testipam_1",
+                    "ipam_default-testipam-1",
                 ],
             )
             network_info = json.loads(output.decode('utf-8'))[0]

--- a/tests/integration/test_podman_compose_multicompose.py
+++ b/tests/integration/test_podman_compose_multicompose.py
@@ -38,14 +38,14 @@ class TestComposeMulticompose(unittest.TestCase, RunSubprocessMixin):
                 os.path.join(os.path.join(test_path(), "multicompose"), "d2/docker-compose.yml"),
                 "ps",
             ])
-            self.assertIn(b"d1_web1_1", output)
-            self.assertIn(b"d1_web2_1", output)
+            self.assertIn(b"d1-web1-1", output)
+            self.assertIn(b"d1-web2-1", output)
 
             output, _ = self.run_subprocess_assert_returncode([
                 "podman",
                 "exec",
                 "-ti",
-                "d1_web1_1",
+                "d1-web1-1",
                 "sh",
                 "-c",
                 "set",
@@ -58,7 +58,7 @@ class TestComposeMulticompose(unittest.TestCase, RunSubprocessMixin):
                 "podman",
                 "exec",
                 "-ti",
-                "d1_web2_1",
+                "d1-web2-1",
                 "sh",
                 "-c",
                 "set",
@@ -70,7 +70,7 @@ class TestComposeMulticompose(unittest.TestCase, RunSubprocessMixin):
                 "podman",
                 "exec",
                 "-ti",
-                "d1_web1_1",
+                "d1-web1-1",
                 "sh",
                 "-c",
                 "cat /var/www/html/index.txt",
@@ -82,7 +82,7 @@ class TestComposeMulticompose(unittest.TestCase, RunSubprocessMixin):
                 "podman",
                 "exec",
                 "-ti",
-                "d1_web2_1",
+                "d1-web2-1",
                 "sh",
                 "-c",
                 "cat /var/www/html/index.txt",

--- a/tests/integration/test_podman_compose_nets_test1.py
+++ b/tests/integration/test_podman_compose_nets_test1.py
@@ -34,8 +34,8 @@ class TestComposeNetsTest1(unittest.TestCase, RunSubprocessMixin):
                 compose_yaml_path(),
                 "ps",
             ])
-            self.assertIn(b"nets_test1_web1_1", output)
-            self.assertIn(b"nets_test1_web2_1", output)
+            self.assertIn(b"nets_test1-web1-1", output)
+            self.assertIn(b"nets_test1-web2-1", output)
 
             response = requests.get('http://localhost:8001/index.txt')
             self.assertTrue(response.ok)
@@ -49,7 +49,7 @@ class TestComposeNetsTest1(unittest.TestCase, RunSubprocessMixin):
             output, _ = self.run_subprocess_assert_returncode([
                 "podman",
                 "inspect",
-                "nets_test1_web1_1",
+                "nets_test1-web1-1",
             ])
             container_info = json.loads(output.decode('utf-8'))[0]
 
@@ -70,7 +70,7 @@ class TestComposeNetsTest1(unittest.TestCase, RunSubprocessMixin):
             output, _ = self.run_subprocess_assert_returncode([
                 "podman",
                 "inspect",
-                "nets_test1_web2_1",
+                "nets_test1-web2-1",
             ])
             container_info = json.loads(output.decode('utf-8'))[0]
             self.assertEqual(

--- a/tests/integration/test_podman_compose_nets_test2.py
+++ b/tests/integration/test_podman_compose_nets_test2.py
@@ -34,8 +34,8 @@ class TestComposeNetsTest2(unittest.TestCase, RunSubprocessMixin):
                 compose_yaml_path(),
                 "ps",
             ])
-            self.assertIn(b"nets_test2_web1_1", output)
-            self.assertIn(b"nets_test2_web2_1", output)
+            self.assertIn(b"nets_test2-web1-1", output)
+            self.assertIn(b"nets_test2-web2-1", output)
 
             response = requests.get('http://localhost:8001/index.txt')
             self.assertTrue(response.ok)
@@ -49,13 +49,13 @@ class TestComposeNetsTest2(unittest.TestCase, RunSubprocessMixin):
             output, _ = self.run_subprocess_assert_returncode([
                 "podman",
                 "inspect",
-                "nets_test2_web1_1",
+                "nets_test2-web1-1",
             ])
             container_info = json.loads(output.decode('utf-8'))[0]
 
             # check if network got specific name from networks top-level element
             self.assertEqual(
-                list(container_info["NetworkSettings"]["Networks"].keys())[0], "nets_test2_mystack"
+                list(container_info["NetworkSettings"]["Networks"].keys())[0], "nets_test2-mystack"
             )
 
             # check if Host port is the same as prodvided by the service port
@@ -70,12 +70,12 @@ class TestComposeNetsTest2(unittest.TestCase, RunSubprocessMixin):
             output, _ = self.run_subprocess_assert_returncode([
                 "podman",
                 "inspect",
-                "nets_test2_web2_1",
+                "nets_test2-web2-1",
             ])
             container_info = json.loads(output.decode('utf-8'))[0]
 
             self.assertEqual(
-                list(container_info["NetworkSettings"]["Networks"].keys())[0], "nets_test2_mystack"
+                list(container_info["NetworkSettings"]["Networks"].keys())[0], "nets_test2-mystack"
             )
 
             self.assertEqual(

--- a/tests/integration/test_podman_compose_networks.py
+++ b/tests/integration/test_podman_compose_networks.py
@@ -63,8 +63,8 @@ class TestPodmanComposeNetwork(RunSubprocessMixin, unittest.TestCase):
             '"{{.Names}}"',
         ]
         out, _ = self.run_subprocess_assert_returncode(check_cmd)
-        self.assertIn(b"nets_test_ip_web1_1", out)
-        self.assertIn(b"nets_test_ip_web2_1", out)
+        self.assertIn(b"nets_test_ip-web1-1", out)
+        self.assertIn(b"nets_test_ip-web2-1", out)
 
         expected_wget = {
             "172.19.1.10": "test1",


### PR DESCRIPTION
docker-compose uses - not _ to join container names to project. not a huge thing, but for services making assumptions based on this it can catch off guard, and is easy to make the same.