### PR TITLE
Provide support for cache_from and cache_to fields

### DIFF
--- a/newsfragments/cache-fields-support.feature
+++ b/newsfragments/cache-fields-support.feature
@@ -1,0 +1,1 @@
+Added support for cache_from and cache_to fields in build section.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2519,6 +2519,10 @@ def container_to_build_args(compose, cnt, args, path_exists):
             "--build-arg",
             build_arg,
         ))
+    for cache_img in build_desc.get("cache_from", []):
+        build_args.extend(["--cache-from", cache_img])
+    for cache_img in build_desc.get("cache_to", []):
+        build_args.extend(["--cache-to", cache_img])
     build_args.append(ctx)
     return build_args
 

--- a/tests/unit/test_container_to_build_args.py
+++ b/tests/unit/test_container_to_build_args.py
@@ -126,3 +126,33 @@ class TestContainerToBuildArgs(unittest.TestCase):
                 '.',
             ],
         )
+
+    def test_caches(self):
+        c = create_compose_mock()
+
+        cnt = get_minimal_container()
+        cnt['build']['cache_from'] = ['registry/image1', 'registry/image2']
+        cnt['build']['cache_to'] = ['registry/image3', 'registry/image4']
+        args = get_minimal_args()
+
+        args = container_to_build_args(c, cnt, args, lambda path: True)
+        self.assertEqual(
+            args,
+            [
+                '-f',
+                './Containerfile',
+                '-t',
+                'new-image',
+                '--no-cache',
+                '--pull-always',
+                '--cache-from',
+                'registry/image1',
+                '--cache-from',
+                'registry/image2',
+                '--cache-to',
+                'registry/image3',
+                '--cache-to',
+                'registry/image4',
+                '.',
+            ],
+        )


### PR DESCRIPTION
Currently the fields cache_from and cache_to on the build are ignored. This PR provides support for them in the build block, just by propagating them to the call to podman.
