### PR TITLE
Support network level mac_address attribute

### DIFF
--- a/docs/Extensions.md
+++ b/docs/Extensions.md
@@ -38,6 +38,12 @@ Podman-compose in addition supports the specification of MAC addresses on a per-
 is done by adding a `x-podman.mac_address` key to the network configuration in the container. The
 value of the `x-podman.mac_address` key is the MAC address to be used for the network interface.
 
+Note that the [compose spec](https://github.com/compose-spec/compose-spec/blob/main/05-services.md#mac_address)
+now supports `mac_address` on the network level, so we recommend using
+the standard `mac_address` key for setting the MAC address. The
+`x-podman.mac_address` is still supported for backwards compatibility.
+
+
 Specifying a MAC address for the container and for individual networks at the same time is not
 supported.
 
@@ -69,7 +75,7 @@ services:
         x-podman.mac_address: "02:aa:aa:aa:aa:aa"
       net1:
         ipv4_address: "192.168.1.10"
-        x-podman.mac_address: "02:bb:bb:bb:bb:bb"
+        mac_address: "02:bb:bb:bb:bb:bb" # mac_address is supported
 ```
 
 ## Podman-specific network modes

--- a/newsfragments/network_level_mac_address.feature
+++ b/newsfragments/network_level_mac_address.feature
@@ -1,0 +1,1 @@
+Support network level mac_address attribute.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -966,7 +966,7 @@ def get_net_args_from_networks(compose, cnt):
     # specified on the network level as well
     if mac_address is not None:
         for net_config in multiple_nets.values():
-            network_mac = net_config.get("x-podman.mac_address")
+            network_mac = net_config.get("mac_address", net_config.get("x-podman.mac_address"))
             if network_mac is not None:
                 raise RuntimeError(
                     f"conflicting mac addresses {mac_address} and {network_mac}:"
@@ -983,8 +983,10 @@ def get_net_args_from_networks(compose, cnt):
 
         ipv4 = net_config_.get("ipv4_address")
         ipv6 = net_config_.get("ipv6_address")
-        # custom extension; not supported by docker-compose v3
-        mac = net_config_.get("x-podman.mac_address")
+        # Note: mac_address is supported by compose spec now, and x-podman.mac_address
+        # is only for backward compatibility
+        # https://github.com/compose-spec/compose-spec/blob/main/05-services.md#mac_address
+        mac = net_config_.get("mac_address", net_config_.get("x-podman.mac_address"))
         aliases_on_net = norm_as_list(net_config_.get("aliases", []))
 
         # if a mac_address was specified on the container level, apply it to the first network

--- a/tests/integration/nets_test_ip/docker-compose.yml
+++ b/tests/integration/nets_test_ip/docker-compose.yml
@@ -23,7 +23,7 @@ services:
                 x-podman.mac_address: "02:01:01:00:01:01"
             internal-network:
                 ipv4_address: "172.19.2.10"
-                x-podman.mac_address: "02:01:01:00:02:01"
+                mac_address: "02:01:01:00:02:01"
         volumes:
             - ./test1.txt:/var/www/html/index.txt:ro,z
     web2:

--- a/tests/unit/test_get_net_args.py
+++ b/tests/unit/test_get_net_args.py
@@ -149,11 +149,15 @@ class TestGetNetArgs(unittest.TestCase):
         args = get_net_args(compose, container)
         self.assertListEqual(expected_args, args)
 
-    def test_mac_on_network(self):
+    @parameterized.expand([
+        "mac_address",
+        "x-podman.mac_address",
+    ])
+    def test_mac_on_network(self, mac_attr):
         mac = "00:11:22:33:44:55"
         compose = get_networked_compose()
         container = get_minimal_container()
-        container["networks"] = {"net0": {"x-podman.mac_address": mac}}
+        container["networks"] = {"net0": {mac_attr: mac}}
 
         expected_args = [
             f"--network={PROJECT_NAME}_net0:mac={mac},alias={SERVICE_NAME}",


### PR DESCRIPTION
Note that the [compose spec](https://github.com/compose-spec/compose-spec/blob/main/05-services.md#mac_address)
now supports `mac_address` on the network level, so we recommend using
the standard `mac_address` key for setting the MAC address. The
`x-podman.mac_address` is still supported for backwards compatibility.

