### PR TITLE
Add support for disable_dns, dns and ignore on network creation

### DIFF
--- a/docs/Extensions.md
+++ b/docs/Extensions.md
@@ -32,6 +32,18 @@ For explanations of these extensions, please refer to the [Podman Documentation]
 The following extension keys are available under network configuration:
 
 * `x-podman.disable-dns` - Disable the DNS plugin for the network when set to 'true'.
+* `x-podman.dns` - Set nameservers for the network using supplied addresses (cannot be used with x-podman.disable-dns`).
+
+For example, the following docker-compose.yml allows all containers on the same network to use the
+specified nameservers:
+```yml
+version: "3"
+network:
+  my_network:
+    x-podman.dns:
+      - "10.1.2.3"
+      - "10.1.2.4"
+```
 
 For explanations of these extensions, please refer to the
 [Podman network create command Documentation](https://docs.podman.io/en/latest/markdown/podman-network-create.1.html).

--- a/docs/Extensions.md
+++ b/docs/Extensions.md
@@ -27,6 +27,14 @@ services:
 
 For explanations of these extensions, please refer to the [Podman Documentation](https://docs.podman.io/).
 
+## Network management
+
+The following extension keys are available under network configuration:
+
+* `x-podman.disable-dns` - Disable the DNS plugin for the network when set to 'true'.
+
+For explanations of these extensions, please refer to the
+[Podman network create command Documentation](https://docs.podman.io/en/latest/markdown/podman-network-create.1.html).
 
 ## Per-network MAC-addresses
 

--- a/newsfragments/x-podman.disable-dns.feature
+++ b/newsfragments/x-podman.disable-dns.feature
@@ -1,0 +1,1 @@
+- Add support for 'x-podman.disable-dns' to allow disabling DNS plugin on defined networks.

--- a/newsfragments/x-podman.dns.feature
+++ b/newsfragments/x-podman.dns.feature
@@ -1,0 +1,1 @@
+- Add support for 'x-podman.dns' to allow setting DNS nameservers for defined networks.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -833,6 +833,8 @@ def get_network_create_args(net_desc, proj_name, net_name):
     ipam_config_ls = ipam.get("config", [])
     if net_desc.get("enable_ipv6"):
         args.append("--ipv6")
+    if net_desc.get("x-podman.disable_dns"):
+        args.append("--disable-dns")
 
     if isinstance(ipam_config_ls, dict):
         ipam_config_ls = [ipam_config_ls]

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -835,6 +835,11 @@ def get_network_create_args(net_desc, proj_name, net_name):
         args.append("--ipv6")
     if net_desc.get("x-podman.disable_dns"):
         args.append("--disable-dns")
+    if net_desc.get("x-podman.dns"):
+        args.extend((
+            "--dns",
+            ",".join(norm_as_list(net_desc.get("x-podman.dns"))),
+        ))
 
     if isinstance(ipam_config_ls, dict):
         ipam_config_ls = [ipam_config_ls]

--- a/tests/unit/test_get_network_create_args.py
+++ b/tests/unit/test_get_network_create_args.py
@@ -201,3 +201,27 @@ class TestGetNetworkCreateArgs(unittest.TestCase):
         ]
         args = get_network_create_args(net_desc, proj_name, net_name)
         self.assertEqual(args, expected_args)
+
+    def test_disable_dns(self):
+        net_desc = {
+            "labels": [],
+            "internal": False,
+            "driver": None,
+            "driver_opts": {},
+            "ipam": {"config": []},
+            "enable_ipv6": False,
+            "x-podman.disable_dns": True,
+        }
+        proj_name = "test_project"
+        net_name = "test_network"
+        expected_args = [
+            "create",
+            "--label",
+            f"io.podman.compose.project={proj_name}",
+            "--label",
+            f"com.docker.compose.project={proj_name}",
+            "--disable-dns",
+            net_name,
+        ]
+        args = get_network_create_args(net_desc, proj_name, net_name)
+        self.assertEqual(args, expected_args)

--- a/tests/unit/test_get_network_create_args.py
+++ b/tests/unit/test_get_network_create_args.py
@@ -225,3 +225,53 @@ class TestGetNetworkCreateArgs(unittest.TestCase):
         ]
         args = get_network_create_args(net_desc, proj_name, net_name)
         self.assertEqual(args, expected_args)
+
+    def test_dns_string(self):
+        net_desc = {
+            "labels": [],
+            "internal": False,
+            "driver": None,
+            "driver_opts": {},
+            "ipam": {"config": []},
+            "enable_ipv6": False,
+            "x-podman.dns": "192.168.1.2",
+        }
+        proj_name = "test_project"
+        net_name = "test_network"
+        expected_args = [
+            "create",
+            "--label",
+            f"io.podman.compose.project={proj_name}",
+            "--label",
+            f"com.docker.compose.project={proj_name}",
+            "--dns",
+            "192.168.1.2",
+            net_name,
+        ]
+        args = get_network_create_args(net_desc, proj_name, net_name)
+        self.assertEqual(args, expected_args)
+
+    def test_dns_list(self):
+        net_desc = {
+            "labels": [],
+            "internal": False,
+            "driver": None,
+            "driver_opts": {},
+            "ipam": {"config": []},
+            "enable_ipv6": False,
+            "x-podman.dns": ["192.168.1.2", "192.168.1.3"],
+        }
+        proj_name = "test_project"
+        net_name = "test_network"
+        expected_args = [
+            "create",
+            "--label",
+            f"io.podman.compose.project={proj_name}",
+            "--label",
+            f"com.docker.compose.project={proj_name}",
+            "--dns",
+            "192.168.1.2,192.168.1.3",
+            net_name,
+        ]
+        args = get_network_create_args(net_desc, proj_name, net_name)
+        self.assertEqual(args, expected_args)


### PR DESCRIPTION
This patch adds options to enhance definition of networks which are not available in the docker-compose spec but are useful for creating temporary clusters for experiments and research.

It adds support for setting DNS entries for the network or disable DNS for the network.