### PR TITLE
Fixes #398: exclude deps on up if --no-deps

### DIFF
--- a/newsfragments/398.bugfix
+++ b/newsfragments/398.bugfix
@@ -1,0 +1,1 @@
+- Fixed a bug that caused dependent containers to be started even with --no-deps

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1020,7 +1020,7 @@ def get_net_args_from_networks(compose, cnt):
     return net_args
 
 
-async def container_to_args(compose, cnt, detached=True):
+async def container_to_args(compose, cnt, detached=True, no_deps=False):
     # TODO: double check -e , --add-host, -v, --read-only
     dirname = compose.dirname
     pod = cnt.get("pod", "")
@@ -1035,7 +1035,7 @@ async def container_to_args(compose, cnt, detached=True):
     deps = []
     for dep_srv in cnt.get("_deps", []):
         deps.extend(compose.container_names_by_service.get(dep_srv.name, []))
-    if deps:
+    if deps and not no_deps:
         deps_csv = ",".join(deps)
         podman_args.append(f"--requires={deps_csv}")
     sec = norm_as_list(cnt.get("security_opt"))
@@ -2915,7 +2915,7 @@ async def compose_run(compose, args):
 
     compose_run_update_container_from_args(compose, cnt, args)
     # run podman
-    podman_args = await container_to_args(compose, cnt, args.detach)
+    podman_args = await container_to_args(compose, cnt, args.detach, args.no_deps)
     if not args.detach:
         podman_args.insert(1, "-i")
         if args.rm:

--- a/tests/integration/test_podman_compose_deps.py
+++ b/tests/integration/test_podman_compose_deps.py
@@ -35,6 +35,31 @@ class TestComposeBaseDeps(unittest.TestCase, RunSubprocessMixin):
                 "down",
             ])
 
+    def test_run_nodeps(self):
+        try:
+            output, error = self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path(),
+                "run",
+                "--rm",
+                "--no-deps",
+                "sleep",
+                "/bin/sh",
+                "-c",
+                "wget -O - http://web:8000/hosts || echo Failed to connect",
+            ])
+            self.assertNotIn(b"HTTP request sent, awaiting response... 200 OK", output)
+            self.assertNotIn(b"deps_web_1", output)
+            self.assertIn(b"Failed to connect", output)
+        finally:
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path(),
+                "down",
+            ])
+
 
 class TestComposeConditionalDeps(unittest.TestCase, RunSubprocessMixin):
     def test_deps_succeeds(self):

--- a/tests/integration/test_podman_compose_deps.py
+++ b/tests/integration/test_podman_compose_deps.py
@@ -60,6 +60,33 @@ class TestComposeBaseDeps(unittest.TestCase, RunSubprocessMixin):
                 "down",
             ])
 
+    def test_up_nodeps(self):
+        try:
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path(),
+                "up",
+                "--no-deps",
+                "--detach",
+                "sleep",
+            ])
+            output, error = self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path(),
+                "ps",
+            ])
+            self.assertNotIn(b"deps_web_1", output)
+            self.assertIn(b"deps_sleep_1", output)
+        finally:
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path(),
+                "down",
+            ])
+
 
 class TestComposeConditionalDeps(unittest.TestCase, RunSubprocessMixin):
     def test_deps_succeeds(self):


### PR DESCRIPTION
Fixes #398 by excluding dependent services if --no-deps is given on the command line.
