### PR TITLE
Don't raise exception on inexistent services in 'down' command

### DIFF
--- a/newsfragments/compose_down_inexistent_service.bugfix
+++ b/newsfragments/compose_down_inexistent_service.bugfix
@@ -1,0 +1,1 @@
+- Fixed KeyError in case podman-compose down was called with an inexistent service

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2648,7 +2648,8 @@ def get_excluded(compose, args):
     if args.services:
         excluded = set(compose.services)
         for service in args.services:
-            if not args.no_deps:
+            # we need 'getattr' as compose_down_parse dose not configure 'no_deps'
+            if service in compose.services and not getattr(args, "no_deps", False):
                 excluded -= set(x.name for x in compose.services[service]["_deps"])
             excluded.discard(service)
     log.debug("** excluding: %s", excluded)


### PR DESCRIPTION
When running 'podman-compose down <service>', if service is not part of the compose, a KeyError exception was raised it function 'get_excluded'.

By only allowing evaluation of services that exist in the compose provides a cleaner and gentler exit for this case.