### PR TITLE
Throw a readable error on too old Python

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -7,7 +7,7 @@
 # https://docs.docker.com/compose/django/
 # https://docs.docker.com/compose/wordpress/
 # TODO: podman pod logs --color -n -f pod_testlogs
-from __future__ import annotations
+from __future__ import annotations  # If you see an error here, use Python 3.7 or greater
 
 import argparse
 import asyncio.exceptions


### PR DESCRIPTION
podman-compose v1.0.6 is the last to support Python3.6. When newer podman-compose version is used with too old Python, podman-compose gives only a confusing error. This commit gives a clear message to use upgraded Python version.
A descriptive error can not be thrown, as line "from __future__ imports" must occur at the beginning of the file, but older Python (older than Python3.7) does not recognize __future__ and throws an errorimmediately.
Therefore, a comment is used to inform the user to update his Python version.
Fixes https://github.com/containers/podman-compose/issues/982.