### PR TITLE
remove incorrect os.chdir, handle relative extends/includes

### DIFF
--- a/newsfragments/1125.bugfix
+++ b/newsfragments/1125.bugfix
@@ -1,0 +1,1 @@
+- Fix handling of relative includes and extends


### PR DESCRIPTION
Running `docker-compose -f containers/base` resulted in a `FileNotFoundError`. However, it worked after `cd containers` and then running `docker-compose -f base`. It appears that the removal of `chdir` operation was overlooked.