### PR TITLE
Remove chdir in _parse_compose_file

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1925,9 +1925,6 @@ class PodmanCompose:
             dotenv_path = os.path.realpath(args.env_file)
             dotenv_dict.update(dotenv_to_dict(dotenv_path))
 
-        # TODO: remove next line
-        os.chdir(dirname)
-
         os.environ.update({
             key: value for key, value in dotenv_dict.items() if key.startswith("PODMAN_")
         })


### PR DESCRIPTION
This change follows the instructions in a `TODO`, and removes a `chdir` in `podman_compose.py`. Fixes #1109.
