### PR TITLE
Do not close file descriptors when executing podman

### DIFF
--- a/newsfragments/do_not_close_fds.feature
+++ b/newsfragments/do_not_close_fds.feature
@@ -1,0 +1,4 @@
+- Do not close file descriptors when executing podman. This allows
+  externally created file descriptors to be passed to containers.
+  These file descriptors might have been created through
+  [systemd socket activation](https://github.com/containers/podman/blob/main/docs/tutorials/socket_activation.md#socket-activation-of-containers).

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1506,7 +1506,10 @@ class Podman:
 
             if log_formatter is not None:
                 p = await asyncio.create_subprocess_exec(
-                    *cmd_ls, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
+                    *cmd_ls,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    close_fds=False,
                 )  # pylint: disable=consider-using-with
 
                 # This is hacky to make the tasks not get garbage collected
@@ -1524,7 +1527,7 @@ class Podman:
                 err_t.add_done_callback(task_reference.discard)
 
             else:
-                p = await asyncio.create_subprocess_exec(*cmd_ls)  # pylint: disable=consider-using-with
+                p = await asyncio.create_subprocess_exec(*cmd_ls, close_fds=False)  # pylint: disable=consider-using-with
 
             try:
                 exit_code = await p.wait()


### PR DESCRIPTION
Do not close file descriptors when executing podman. This allows externally created file descriptors to be passed to containers. These file descriptors might have been created through systemd socket activation. See also
https://github.com/containers/podman/blob/main/docs/tutorials/socket_activation.md#socket-activation-of-containers
