### PR TITLE
tests/integration: Automate manual `seccomp` test

### DIFF
--- a/tests/integration/seccomp/default.json
+++ b/tests/integration/seccomp/default.json
@@ -1,0 +1,10 @@
+{
+	"defaultAction": "SCMP_ACT_ALLOW",
+	"syscalls": [
+		{
+			"name": "mkdir",
+			"action": "SCMP_ACT_ERRNO",
+			"args": []
+		}
+	]
+}

--- a/tests/integration/seccomp/docker-compose.yml
+++ b/tests/integration/seccomp/docker-compose.yml
@@ -2,11 +2,8 @@ version: "3"
 services:
   web1:
     image: busybox
-    command: httpd -f -p 80 -h /var/www/html
-    volumes:
-    - ./docker-compose.yml:/var/www/html/index.html
-    ports:
-      - "8080:80"
+    command: sh -c "mkdir /tmp_test"
     security_opt:
-      - seccomp:unconfined
-
+      # Currently only absolute path works, like this:
+      # - seccomp:/.../tests/integration/seccomp/default.json
+      - seccomp:./default.json

--- a/tests/integration/seccomp/test_podman_compose_seccomp.py
+++ b/tests/integration/seccomp/test_podman_compose_seccomp.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: GPL-2.0
+
+import os
+import unittest
+
+from tests.integration.test_utils import RunSubprocessMixin
+from tests.integration.test_utils import podman_compose_path
+from tests.integration.test_utils import test_path
+
+
+def compose_yaml_path():
+    return os.path.join(os.path.join(test_path(), "seccomp"), "docker-compose.yml")
+
+
+class TestComposeSeccomp(unittest.TestCase, RunSubprocessMixin):
+    @unittest.skip(
+        "Skip till security_opt seccomp from 'docker-compose.yml' will be able to accept a "
+        "relative path of 'default.json' file. Now test works as expected but only with the "
+        "absolute path."
+    )
+    # test if seccomp uses custom seccomp profile file 'default.json' where command mkdir is not
+    # allowed
+    def test_seccomp(self):
+        try:
+            output, _, return_code = self.run_subprocess(
+                [podman_compose_path(), "-f", compose_yaml_path(), "run", "--rm", "web1"],
+            )
+            self.assertEqual(return_code, 1)
+            self.assertIn(
+                b"mkdir: can't create directory '/tmp_test': Operation not permitted", output
+            )
+        finally:
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path(),
+                "down",
+                "-t",
+                "0",
+            ])


### PR DESCRIPTION
This PR automates manual `seccomp` test.
It is a partial fix for https://github.com/containers/podman-compose/issues/983.

The test is skipped for now though. Test works as expected, but `seccomp` only accepts absolute path. Using a relative path should be implemented. 
@p12tic maybe it makes sense to open an issue.