### PR TITLE
feature(ansi-cli-param): improves compatibility of podman compose with docker-compose

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         # supported by your project here, or alternatively use
         # pre-commit's default_language_version, see
         # https://pre-commit.com/#top_level-default_language_version
-        language_version: python3.10
+        language_version: python3.12
         types: [python]
         args: [
           "--check",  # Don't apply changes automatically

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,11 @@ repos:
     hooks:
       - id: flake8
         types: [python]
+        args:
+          [
+            "--ignore",
+            "E231"
+          ]
   - repo: local
     hooks:
       - id: pylint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
         args:
           [
             "--ignore",
-            "E231"
+            "E222,E231,E272,E713,W503"
           ]
   - repo: local
     hooks:

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2286,7 +2286,16 @@ class PodmanCompose:
             )  # pylint: disable=protected-access
             for cmd_parser in cmd._parse_args:  # pylint: disable=protected-access
                 cmd_parser(subparser)
+
         self.global_args = parser.parse_args(argv)
+
+        if self.global_args.ansi:
+            if self.global_args.ansi == "never":
+                self.global_args.no_ansi = True
+            # if an option is added but we don't know how to handle it, fail!
+            else:
+                raise ValueError(f"Unsupported --ansi value: {self.global_args.ansi}.")
+
         if (
             self.global_args.in_pod is not None
             and self.global_args.in_pod.lower()
@@ -2388,8 +2397,15 @@ class PodmanCompose:
                 default=[],
             )
         parser.add_argument(
+            "--ansi",
+            help="Controls when to print ANSI control characters.",
+            choices=["never"],
+            type=str,
+            default=None,
+        )
+        parser.add_argument(
             "--no-ansi",
-            help="Do not print ANSI control characters",
+            help="Do not print ANSI control characters. Equivalent to `--ansi=never`.",
             action="store_true",
         )
         parser.add_argument(


### PR DESCRIPTION
Improves compatibility with docker-compose by adding --ansi param support to the docker_compose cli. 
See https://docs.docker.com/reference/cli/docker/compose/ `--ansi`

It should also close https://github.com/containers/podman-compose/issues/1077

I could not find tests `--no-ansi` and this change mainly forcibly sets its value. Any advise on testing it, given:

> All changes require additional unit tests.
