### PR TITLE
Bug: replaced black with ruff on pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,9 @@
 repos:
-  - repo: https://github.com/psf/black
-    rev: 23.3.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.6
     hooks:
-      - id: black
-        # It is recommended to specify the latest version of Python
-        # supported by your project here, or alternatively use
-        # pre-commit's default_language_version, see
-        # https://pre-commit.com/#top_level-default_language_version
-        language_version: python3.10
+      - id: ruff
         types: [python]
-        args: [
-          "--check",  # Don't apply changes automatically
-        ]
   - repo: https://github.com/pycqa/flake8
     rev: 6.0.0
     hooks:

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1299,7 +1299,8 @@ class ServiceDependencyCondition(Enum):
         try:
             return docker_to_podman_cond[value]
         except KeyError:
-            raise ValueError(f"Value '{value}' is not a valid condition for a service dependency")  # pylint: disable=raise-missing-from
+            # pylint: disable-next=raise-missing-from
+            raise ValueError(f"Value '{value}' is not a valid condition for a service dependency")
 
 
 class ServiceDependency:

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,5 @@ version = attr: podman_compose.__version__
 [flake8]
 # The GitHub editor is 127 chars wide
 max-line-length=127
+# These are not being followed yet
+ignore=E222,E231,E272,E713,W503


### PR DESCRIPTION
## Contributor Checklist:

As black and ruff have a different idea on how the formatted code should look like, by using pre-commit, which is advised in the contributing guide, we block any contribution, as ruff is used in the ci format check and black is used in the pre-commit. This MR fixes this: https://github.com/containers/podman-compose/issues/1142
