### PR TITLE
Handle SIGINT when running "up" command to shutdown gracefully

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2776,7 +2776,15 @@ async def compose_up(compose: PodmanCompose, args):
     tasks = set()
 
     loop = asyncio.get_event_loop()
-    loop.add_signal_handler(signal.SIGINT, lambda: [t.cancel("User exit") for t in tasks])
+
+    async def handle_sigint():
+        log.info("Caught SIGINT, shutting down...")
+        down_args = argparse.Namespace(**dict(args.__dict__, volumes=False))
+        await compose.commands["down"](compose, down_args)
+        for task in tasks:
+            task.cancel()
+
+    loop.add_signal_handler(signal.SIGINT, lambda: asyncio.create_task(handle_sigint()))
 
     for i, cnt in enumerate(compose.containers):
         # Add colored service prefix to output by piping output through sed

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2778,11 +2778,16 @@ async def compose_up(compose: PodmanCompose, args):
     loop = asyncio.get_event_loop()
 
     async def handle_sigint():
-        log.info("Caught SIGINT, shutting down...")
-        down_args = argparse.Namespace(**dict(args.__dict__, volumes=False))
-        await compose.commands["down"](compose, down_args)
-        for task in tasks:
-            task.cancel()
+        log.info("Caught SIGINT or Ctrl+C, shutting down...")
+        try:
+            log.info("Shutting down gracefully, please wait...")
+            down_args = argparse.Namespace(**dict(args.__dict__, volumes=False))
+            await compose.commands["down"](compose, down_args)
+        except Exception as e:
+            log.error(f"Error during shutdown: {e}")
+        finally:
+            for task in tasks:
+                task.cancel()
 
     loop.add_signal_handler(signal.SIGINT, lambda: asyncio.create_task(handle_sigint()))
 


### PR DESCRIPTION
This pull request enhances the podman compose behavior by handling the` Ctrl+C` (SIGINT) signal more gracefully. When `Ctrl+C` is pressed during the execution of podman compose up, it runs the `down` command to make sure containers shut down gracefully.

**Solves:** #51, #112, #411, #436, #457, #543, #676