### PR TITLE
Fix event loop handling for Windows platform in compose_up function

### DIFF
--- a/newsfragments/windows_not_implemented_error.bugfix
+++ b/newsfragments/windows_not_implemented_error.bugfix
@@ -1,0 +1,1 @@
+- Fixed NotImplementedError in case script is interrupted on Windows

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2776,9 +2776,11 @@ async def compose_up(compose: PodmanCompose, args):
         max_service_length = curr_length if curr_length > max_service_length else max_service_length
 
     tasks = set()
-
-    loop = asyncio.get_event_loop()
-    loop.add_signal_handler(signal.SIGINT, lambda: [t.cancel("User exit") for t in tasks])
+    if sys.platform == 'win32':
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+    else:
+        loop = asyncio.get_event_loop()
+        loop.add_signal_handler(signal.SIGINT, lambda: [t.cancel("User exit") for t in tasks])
 
     for i, cnt in enumerate(compose.containers):
         # Add colored service prefix to output by piping output through sed

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2776,9 +2776,7 @@ async def compose_up(compose: PodmanCompose, args):
         max_service_length = curr_length if curr_length > max_service_length else max_service_length
 
     tasks = set()
-    if sys.platform == 'win32':
-        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-    else:
+    if sys.platform != 'win32':
         loop = asyncio.get_event_loop()
         loop.add_signal_handler(signal.SIGINT, lambda: [t.cancel("User exit") for t in tasks])
 


### PR DESCRIPTION
Hi,
I tried to run podman-compose on Windows and always break the script because of NotImplementedError in asyncio/events.
After a fast search, I noted that Windows doesn't have support for signals, and I found a code solution to solve this issue in this stack overflow link: https://stackoverflow.com/questions/58014623/python-asyncio-notimplementederror


I added an if condition to check if it's a Windows system or not, not sure if the best way to compare, but it works.


