### PR TITLE
Add quiet flag to podman-compose config

### DIFF
--- a/newsfragments/1152-config-quiet.feature
+++ b/newsfragments/1152-config-quiet.feature
@@ -1,0 +1,1 @@
+- Add a `--quiet` flag to the `config` command to suppress output.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -3136,9 +3136,11 @@ async def compose_logs(compose, args):
 async def compose_config(compose, args):
     if args.services:
         for service in compose.services:
-            print(service)
+            if not args.quiet:
+                print(service)
         return
-    print(compose.merged_yaml)
+    if not args.quiet:
+        print(compose.merged_yaml)
 
 
 @cmd_run(podman_compose, "port", "Prints the public port for a port binding.")
@@ -3671,6 +3673,12 @@ def compose_config_parse(parser):
     )
     parser.add_argument(
         "--services", help="Print the service names, one per line.", action="store_true"
+    )
+    parser.add_argument(
+        "-q",
+        "--quiet",
+        help="Do not print config, only parse.",
+        action="store_true",
     )
 
 

--- a/tests/integration/profile/test_podman_compose_config.py
+++ b/tests/integration/profile/test_podman_compose_config.py
@@ -80,3 +80,20 @@ class TestComposeConfig(unittest.TestCase, RunSubprocessMixin):
             actual_services[service] = service in actual_output
 
         self.assertEqual(expected_services, actual_services)
+
+    def test_config_quiet(self):
+        """
+        Tests podman-compose config command with the --quiet flag.
+        """
+        config_cmd = [
+            "coverage",
+            "run",
+            podman_compose_path(),
+            "-f",
+            profile_compose_file(),
+            "config",
+            "--quiet",
+        ]
+
+        out, _ = self.run_subprocess_assert_returncode(config_cmd)
+        self.assertEqual(out.decode("utf-8"), "")


### PR DESCRIPTION
This skips printing and is useful for validating config files.

This is present in `docker-compose` and `docker compose` as well: https://docs.docker.com/reference/cli/docker/compose/config/

Do you think this warrants news? I could add that, but it seems pretty minor.

Also, since it is testing the print, the unit test didn't make sense. I added an integration test instead.