### PR TITLE
Add hook to check for signoff in commit messages

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+default_install_hook_types: [pre-commit, commit-msg]
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.9.6
@@ -26,3 +27,8 @@ repos:
     rev: v2.2.5
     hooks:
     - id: codespell
+
+  - repo: https://github.com/gklein/check_signoff
+    rev: v1.0.5
+    hooks:
+      - id: check-signoff


### PR DESCRIPTION
Since this is checked on PR, it could also be checked at commit so users can avoid making commits to the tree without expected documentation.
