### PR TITLE
Updates handling of scale/replicas parameter in CLI and compose file

### DIFF
--- a/newsfragments/267.bugfix
+++ b/newsfragments/267.bugfix
@@ -1,0 +1,1 @@
+- Fixed the --scale flag as described in issue #267 [Podman not supporting --scale flag]

--- a/tests/integration/service_scale/scaleup_cli/docker-compose.yml
+++ b/tests/integration/service_scale/scaleup_cli/docker-compose.yml
@@ -1,0 +1,6 @@
+name: podman-compose
+
+services:
+  service1:
+    image: docker.io/library/busybox:latest
+    tty: true

--- a/tests/integration/service_scale/scaleup_deploy_replicas_parameter/docker-compose.yml
+++ b/tests/integration/service_scale/scaleup_deploy_replicas_parameter/docker-compose.yml
@@ -1,0 +1,9 @@
+name: podman-compose
+
+services:
+  service1:
+    image: docker.io/library/busybox:latest
+    tty: true
+    deploy:
+      mode: replicated
+      replicas: 2

--- a/tests/integration/service_scale/scaleup_scale_parameter/docker-compose.yml
+++ b/tests/integration/service_scale/scaleup_scale_parameter/docker-compose.yml
@@ -1,0 +1,7 @@
+name: podman-compose
+
+services:
+  service1:
+    image: docker.io/library/busybox:latest
+    tty: true
+    scale: 2

--- a/tests/integration/service_scale/test_podman_compose_scale.py
+++ b/tests/integration/service_scale/test_podman_compose_scale.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: GPL-2.0
+
+import os
+import unittest
+
+from tests.integration.test_utils import RunSubprocessMixin
+from tests.integration.test_utils import podman_compose_path
+from tests.integration.test_utils import test_path
+
+
+def compose_yaml_path(test_ref_folder):
+    return os.path.join(test_path(), "service_scale", test_ref_folder, "docker-compose.yml")
+
+
+class TestComposeScale(unittest.TestCase, RunSubprocessMixin):
+    # scale-up using `scale` prarmeter in docker-compose.yml
+    def test_scaleup_scale_parameter(self):
+        try:
+            output, _, return_code = self.run_subprocess([
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path("scaleup_scale_parameter"),
+                "up",
+                "-d",
+            ])
+            self.assertEqual(return_code, 0)
+            output, _, return_code = self.run_subprocess([
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path("scaleup_scale_parameter"),
+                "ps",
+                "-q",
+            ])
+            self.assertEqual(len(output.splitlines()), 2)
+        finally:
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path("scaleup_scale_parameter"),
+                "down",
+                "-t",
+                "0",
+            ])
+
+    # scale-up using `deploy => replicas` prarmeter in docker-compose.yml
+    def test_scaleup_deploy_replicas_parameter(self):
+        try:
+            output, _, return_code = self.run_subprocess([
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path('scaleup_deploy_replicas_parameter'),
+                "up",
+                "-d",
+            ])
+            self.assertEqual(return_code, 0)
+            output, _, return_code = self.run_subprocess([
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path("scaleup_scale_parameter"),
+                "ps",
+                "-q",
+            ])
+            self.assertEqual(len(output.splitlines()), 2)
+        finally:
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path('scaleup_deploy_replicas_parameter'),
+                "down",
+                "-t",
+                "0",
+            ])
+
+    # scale-up using `--scale <SERVICE>=<number of replicas>` argument in CLI
+    def test_scaleup_cli(self):
+        try:
+            output, _, return_code = self.run_subprocess([
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path('scaleup_cli'),
+                "up",
+                "-d",
+            ])
+            self.assertEqual(return_code, 0)
+            output, _, return_code = self.run_subprocess([
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path('scaleup_cli'),
+                "up",
+                "-d",
+                "--scale",
+                "service1=2",
+            ])
+            self.assertEqual(return_code, 0)
+            output, _, return_code = self.run_subprocess([
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path("scaleup_scale_parameter"),
+                "ps",
+                "-q",
+            ])
+            self.assertEqual(len(output.splitlines()), 2)
+        finally:
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path('scaleup_cli'),
+                "down",
+                "-t",
+                "0",
+            ])


### PR DESCRIPTION
# Purpose
Addresses issue: #267

## Contributor Checklist:

> If this PR adds a new feature that improves compatibility with docker-compose, please add a link
to the exact part of compose spec that the PR touches.

This PR attempts to address missing (the code to accommodate this was already present, just broken) `--scale <SERVICE_NAME>=<NUMBER_OF_REPLICAS>` option for `podman-compose up`:
https://docs.docker.com/reference/cli/docker/compose/up/#options


All changes require additional unit tests.

# Testing
**Test file**:
```docker-compose.yaml
name: podman-compose

services:
  app:
    image: docker.io/library/busybox:latest
    tty: true
    # scale: 3
    # deploy:
    #   mode: replicated
    #   replicas: 2

  app1:
    image: docker.io/library/busybox:latest
    tty: true
    depends_on:
      - app

  app2:
    image: docker.io/library/busybox:latest
    tty: true

  app3:
    image: docker.io/library/busybox:latest
    tty: true

```

**With compose file**:
```
$ python ./podman_compose.py -f ./test.yml up -d
1283f00b651460df07514d3be6d01e0ea76529782ead0292c977077b72229937
d3b036808fff09a6e107c3ba769ad03a2c024d148581a24bdd5e3128b952d976
663cb01d16c4e7194145b63a306d6e225f7c05b1ff97103ae8e2df57144233b7
8dd9e7f5588ec2d1ecd16565cdf371be8fce87442f902e48bec7bf97276026b4

$ python ./podman_compose.py -f ./test.yml ps
CONTAINER ID  IMAGE                             COMMAND     CREATED        STATUS        PORTS       NAMES
d3b036808fff  docker.io/library/busybox:latest  sh          7 seconds ago  Up 7 seconds              podman-compose_app_1
663cb01d16c4  docker.io/library/busybox:latest  sh          6 seconds ago  Up 6 seconds              podman-compose_app_2
8dd9e7f5588e  docker.io/library/busybox:latest  sh          5 seconds ago  Up 5 seconds              podman-compose_app_3

$ python ./podman_compose.py -f ./test.yml down
podman-compose_app_1
podman-compose_app_3
podman-compose_app_2
podman-compose_app_3
podman-compose_app_2
podman-compose_app_1
1283f00b651460df07514d3be6d01e0ea76529782ead0292c977077b72229937
podman-compose_default
```

**Scale existing services using CLI**:
```bash
$ python ./podman_compose.py -f ./test.yml up -d --scale app=3
5a76ea112148b71be792cd4c9e77f7b505cbdc2432118eaa2bff8003753b1bb9
ca5b2c05a5198392d64560b63a57e8db0cf2ecdb7f1171f10e800824cc1974d3
8f835d6759a2614c59ee7d21abd0859e6cc96ffec06bdceae3dc55ab096bd488
1fbc4958fa4439d8e0349459f77f1d59026ed3414b815026992611ee8518e141

$ python ./podman_compose.py -f ./test.yml ps
CONTAINER ID  IMAGE                             COMMAND     CREATED        STATUS        PORTS       NAMES
ca5b2c05a519  docker.io/library/busybox:latest  sh          5 seconds ago  Up 5 seconds              podman-compose_app_1
8f835d6759a2  docker.io/library/busybox:latest  sh          4 seconds ago  Up 4 seconds              podman-compose_app_2
1fbc4958fa44  docker.io/library/busybox:latest  sh          3 seconds ago  Up 3 seconds              podman-compose_app_3

$ python ./podman_compose.py -f ./test.yml down
podman-compose_app_3
podman-compose_app_2
podman-compose_app_1
podman-compose_app_3
podman-compose_app_2
podman-compose_app_1
5a76ea112148b71be792cd4c9e77f7b505cbdc2432118eaa2bff8003753b1bb9
podman-compose_default
```

# To-Do
- [x] Scale-up with CLI works (although with errors on command line, which should be warnings). But, Scale-down doesn't work.
=> That part of code yet needs to be addressed, may be through a separate issue.
- [x] Command `down` (to destroy the scaled containers/replicas) works only based on value assigned in compose yaml file. This instead, needs to be addressed to stop all running replicas.
=> Done
