### PR TITLE
Implement pids_limit

### DIFF
--- a/newsfragments/1182-implement-pids-limit.feature
+++ b/newsfragments/1182-implement-pids-limit.feature
@@ -1,0 +1,1 @@
+- Add support for `pids_limit` and `deploy.resources.limits.pids`

--- a/tests/unit/test_container_to_args.py
+++ b/tests/unit/test_container_to_args.py
@@ -630,3 +630,67 @@ class TestContainerToArgs(unittest.IsolatedAsyncioTestCase):
                 "busybox",
             ],
         )
+
+    async def test_pids_limit_container_level(self):
+        c = create_compose_mock()
+        cnt = get_minimal_container()
+        cnt["pids_limit"] = 100
+
+        args = await container_to_args(c, cnt)
+        self.assertEqual(
+            args,
+            [
+                "--name=project_name_service_name1",
+                "-d",
+                "--network=bridge:alias=service_name",
+                "--pids-limit",
+                "100",
+                "busybox",
+            ],
+        )
+
+    async def test_pids_limit_deploy_section(self):
+        c = create_compose_mock()
+        cnt = get_minimal_container()
+        cnt["deploy"] = {"resources": {"limits": {"pids": 100}}}
+
+        args = await container_to_args(c, cnt)
+        self.assertEqual(
+            args,
+            [
+                "--name=project_name_service_name1",
+                "-d",
+                "--network=bridge:alias=service_name",
+                "--pids-limit",
+                "100",
+                "busybox",
+            ],
+        )
+
+    async def test_pids_limit_both_same(self):
+        c = create_compose_mock()
+        cnt = get_minimal_container()
+        cnt["pids_limit"] = 100
+        cnt["deploy"] = {"resources": {"limits": {"pids": 100}}}
+
+        args = await container_to_args(c, cnt)
+        self.assertEqual(
+            args,
+            [
+                "--name=project_name_service_name1",
+                "-d",
+                "--network=bridge:alias=service_name",
+                "--pids-limit",
+                "100",
+                "busybox",
+            ],
+        )
+
+    async def test_pids_limit_both_different(self):
+        c = create_compose_mock()
+        cnt = get_minimal_container()
+        cnt["pids_limit"] = 100
+        cnt["deploy"] = {"resources": {"limits": {"pids": 200}}}
+
+        with self.assertRaises(ValueError):
+            await container_to_args(c, cnt)


### PR DESCRIPTION
Implement pids_limit

Split from https://github.com/containers/podman-compose/pull/1181

Related issues: https://github.com/containers/podman-compose/issues/806

pids_limit spec:

https://github.com/compose-spec/compose-spec/blob/main/05-services.md#pids_limit and https://github.com/compose-spec/compose-spec/blob/main/deploy.md#pids