### PR TITLE
Fix service_healthy condition enforcing

### DIFF
--- a/newsfragments/1176.bugfix
+++ b/newsfragments/1176.bugfix
@@ -1,0 +1,1 @@
+- Fixed issue where short-lived containers would execute twice when using the up command in detached mode (#1176)

--- a/newsfragments/1178.bugfix
+++ b/newsfragments/1178.bugfix
@@ -1,0 +1,1 @@
+Fixed up command hangs on Podman versions earlier than 4.6.0 (#1178)

--- a/newsfragments/1183.bugfix
+++ b/newsfragments/1183.bugfix
@@ -1,0 +1,1 @@
+- Fixed issue in up command where service_healthy conditions weren't being enforced (#1183)

--- a/newsfragments/down-during-up-no-containers.bugfix
+++ b/newsfragments/down-during-up-no-containers.bugfix
@@ -1,0 +1,1 @@
+Skip running compose-down during up when there are no active containers

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2815,6 +2815,18 @@ async def check_dep_conditions(compose: PodmanCompose, deps: set) -> None:
         deps_cd = []
         for d in deps:
             if d.condition == condition:
+                if (
+                    d.condition
+                    in (ServiceDependencyCondition.HEALTHY, ServiceDependencyCondition.UNHEALTHY)
+                ) and strverscmp_lt(compose.podman_version, "4.6.0"):
+                    log.warning(
+                        "Ignored %s condition check due to podman %s doesn't support %s!",
+                        d.name,
+                        compose.podman_version,
+                        condition.value,
+                    )
+                    continue
+
                 deps_cd.extend(compose.container_names_by_service[d.name])
 
         if deps_cd:

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2891,7 +2891,7 @@ async def compose_up(compose: PodmanCompose, args):
         .splitlines()
     )
     diff_hashes = [i for i in hashes if i and i != compose.yaml_hash]
-    if args.force_recreate or len(diff_hashes):
+    if (args.force_recreate and len(hashes) > 0) or len(diff_hashes):
         log.info("recreating: ...")
         down_args = argparse.Namespace(**dict(args.__dict__, volumes=False, rmi=None))
         await compose.commands["down"](compose, down_args)

--- a/tests/integration/deps/docker-compose-conditional-healthy.yaml
+++ b/tests/integration/deps/docker-compose-conditional-healthy.yaml
@@ -1,0 +1,23 @@
+version: "3.7"
+services:
+  web:
+    image: nopush/podman-compose-test
+    command: ["dumb-init", "/bin/busybox", "httpd", "-f", "-h", "/etc/", "-p", "8000"]
+    tmpfs:
+      - /run
+      - /tmp
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8000/hosts"]
+      start_period: 10s # initialization time for containers that need time to bootstrap
+      interval: 10s # Time between health checks
+      timeout: 5s # Time to wait for a response
+      retries: 3 # Number of consecutive failures before marking as unhealthy
+  sleep:
+    image: nopush/podman-compose-test
+    command: ["dumb-init", "/bin/busybox", "sh", "-c", "sleep 3600"]
+    depends_on:
+      web:
+        condition: service_healthy
+    tmpfs:
+      - /run
+      - /tmp

--- a/tests/integration/deps/test_podman_compose_deps.py
+++ b/tests/integration/deps/test_podman_compose_deps.py
@@ -16,7 +16,7 @@ def compose_yaml_path(suffix=""):
 class TestComposeBaseDeps(unittest.TestCase, RunSubprocessMixin):
     def test_deps(self):
         try:
-            output, error = self.run_subprocess_assert_returncode([
+            output, _ = self.run_subprocess_assert_returncode([
                 podman_compose_path(),
                 "-f",
                 compose_yaml_path(),
@@ -39,7 +39,7 @@ class TestComposeBaseDeps(unittest.TestCase, RunSubprocessMixin):
 
     def test_run_nodeps(self):
         try:
-            output, error = self.run_subprocess_assert_returncode([
+            output, _ = self.run_subprocess_assert_returncode([
                 podman_compose_path(),
                 "-f",
                 compose_yaml_path(),
@@ -73,7 +73,7 @@ class TestComposeBaseDeps(unittest.TestCase, RunSubprocessMixin):
                 "--detach",
                 "sleep",
             ])
-            output, error = self.run_subprocess_assert_returncode([
+            output, _ = self.run_subprocess_assert_returncode([
                 podman_compose_path(),
                 "-f",
                 compose_yaml_path(),
@@ -146,7 +146,7 @@ class TestComposeConditionalDeps(unittest.TestCase, RunSubprocessMixin):
     def test_deps_succeeds(self):
         suffix = "-conditional-succeeds"
         try:
-            output, error = self.run_subprocess_assert_returncode([
+            output, _ = self.run_subprocess_assert_returncode([
                 podman_compose_path(),
                 "-f",
                 compose_yaml_path(suffix),
@@ -170,7 +170,7 @@ class TestComposeConditionalDeps(unittest.TestCase, RunSubprocessMixin):
     def test_deps_fails(self):
         suffix = "-conditional-fails"
         try:
-            output, error = self.run_subprocess_assert_returncode([
+            output, _ = self.run_subprocess_assert_returncode([
                 podman_compose_path(),
                 "-f",
                 compose_yaml_path(suffix),

--- a/tests/integration/extends/test_podman_compose_extends.py
+++ b/tests/integration/extends/test_podman_compose_extends.py
@@ -80,18 +80,25 @@ class TestComposeExteds(unittest.TestCase, RunSubprocessMixin):
                 "env1",
             ])
             lines = output.decode('utf-8').split('\n')
-            # HOSTNAME name is random string so is ignored in asserting
-            lines = sorted([line for line in lines if not line.startswith("HOSTNAME")])
+            # Test selected env variables to improve robustness
+            lines = sorted([
+                line
+                for line in lines
+                if line.startswith("BAR")
+                or line.startswith("BAZ")
+                or line.startswith("FOO")
+                or line.startswith("HOME")
+                or line.startswith("PATH")
+                or line.startswith("container")
+            ])
             self.assertEqual(
                 lines,
                 [
-                    '',
                     'BAR=local',
                     'BAZ=local',
                     'FOO=original',
                     'HOME=/root',
                     'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-                    'TERM=xterm',
                     'container=podman',
                 ],
             )

--- a/tests/integration/filesystem/test_podman_compose_filesystem.py
+++ b/tests/integration/filesystem/test_podman_compose_filesystem.py
@@ -35,8 +35,7 @@ class TestFilesystem(unittest.TestCase, RunSubprocessMixin):
                 "container1",
             ])
 
-            # BUG: figure out why cat is called twice
-            self.assertEqual(out, b'data_compose_symlink\ndata_compose_symlink\n')
+            self.assertEqual(out, b'data_compose_symlink\n')
 
         finally:
             out, _ = self.run_subprocess_assert_returncode([

--- a/tests/integration/nets_test1/test_podman_compose_nets_test1.py
+++ b/tests/integration/nets_test1/test_podman_compose_nets_test1.py
@@ -59,9 +59,13 @@ class TestComposeNetsTest1(unittest.TestCase, RunSubprocessMixin):
             )
 
             # check if Host port is the same as provided by the service port
+            self.assertIsNotNone(container_info['NetworkSettings']["Ports"].get("8001/tcp", None))
+            self.assertGreater(len(container_info['NetworkSettings']["Ports"]["8001/tcp"]), 0)
+            self.assertIsNotNone(
+                container_info['NetworkSettings']["Ports"]["8001/tcp"][0].get("HostPort", None)
+            )
             self.assertEqual(
-                container_info['NetworkSettings']["Ports"],
-                {"8001/tcp": [{"HostIp": "", "HostPort": "8001"}]},
+                container_info['NetworkSettings']["Ports"]["8001/tcp"][0]["HostPort"], "8001"
             )
 
             self.assertEqual(container_info["Config"]["Hostname"], "web1")
@@ -77,9 +81,13 @@ class TestComposeNetsTest1(unittest.TestCase, RunSubprocessMixin):
                 list(container_info["NetworkSettings"]["Networks"].keys())[0], "nets_test1_default"
             )
 
+            self.assertIsNotNone(container_info['NetworkSettings']["Ports"].get("8001/tcp", None))
+            self.assertGreater(len(container_info['NetworkSettings']["Ports"]["8001/tcp"]), 0)
+            self.assertIsNotNone(
+                container_info['NetworkSettings']["Ports"]["8001/tcp"][0].get("HostPort", None)
+            )
             self.assertEqual(
-                container_info['NetworkSettings']["Ports"],
-                {"8001/tcp": [{"HostIp": "", "HostPort": "8002"}]},
+                container_info['NetworkSettings']["Ports"]["8001/tcp"][0]["HostPort"], "8002"
             )
 
             self.assertEqual(container_info["Config"]["Hostname"], "web2")

--- a/tests/integration/nets_test2/test_podman_compose_nets_test2.py
+++ b/tests/integration/nets_test2/test_podman_compose_nets_test2.py
@@ -59,9 +59,13 @@ class TestComposeNetsTest2(unittest.TestCase, RunSubprocessMixin):
             )
 
             # check if Host port is the same as prodvided by the service port
+            self.assertIsNotNone(container_info['NetworkSettings']["Ports"].get("8001/tcp", None))
+            self.assertGreater(len(container_info['NetworkSettings']["Ports"]["8001/tcp"]), 0)
+            self.assertIsNotNone(
+                container_info['NetworkSettings']["Ports"]["8001/tcp"][0].get("HostPort", None)
+            )
             self.assertEqual(
-                container_info['NetworkSettings']["Ports"],
-                {"8001/tcp": [{"HostIp": "", "HostPort": "8001"}]},
+                container_info['NetworkSettings']["Ports"]["8001/tcp"][0]["HostPort"], "8001"
             )
 
             self.assertEqual(container_info["Config"]["Hostname"], "web1")
@@ -78,9 +82,13 @@ class TestComposeNetsTest2(unittest.TestCase, RunSubprocessMixin):
                 list(container_info["NetworkSettings"]["Networks"].keys())[0], "nets_test2_mystack"
             )
 
+            self.assertIsNotNone(container_info['NetworkSettings']["Ports"].get("8001/tcp", None))
+            self.assertGreater(len(container_info['NetworkSettings']["Ports"]["8001/tcp"]), 0)
+            self.assertIsNotNone(
+                container_info['NetworkSettings']["Ports"]["8001/tcp"][0].get("HostPort", None)
+            )
             self.assertEqual(
-                container_info['NetworkSettings']["Ports"],
-                {"8001/tcp": [{"HostIp": "", "HostPort": "8002"}]},
+                container_info['NetworkSettings']["Ports"]["8001/tcp"][0]["HostPort"], "8002"
             )
 
             self.assertEqual(container_info["Config"]["Hostname"], "web2")

--- a/tests/integration/test_utils.py
+++ b/tests/integration/test_utils.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0
 
 import os
+import re
 import subprocess
 import time
 from pathlib import Path
@@ -19,6 +20,14 @@ def test_path():
 def podman_compose_path():
     """Returns the path to the podman compose script"""
     return os.path.join(base_path(), "podman_compose.py")
+
+
+def is_systemd_available():
+    try:
+        with open("/proc/1/comm", "r", encoding="utf-8") as fh:
+            return fh.read().strip() == "systemd"
+    except FileNotFoundError:
+        return False
 
 
 class RunSubprocessMixin:
@@ -52,3 +61,15 @@ class RunSubprocessMixin:
             f"stdout: {decoded_out}\nstderr: {decoded_err}\n",
         )
         return out, err
+
+
+class PodmanAwareRunSubprocessMixin(RunSubprocessMixin):
+    def retrieve_podman_version(self):
+        out, _ = self.run_subprocess_assert_returncode(["podman", "--version"])
+        matcher = re.match(r"\D*(\d+)\.(\d+)\.(\d+)", out.decode('utf-8'))
+        if matcher:
+            major = int(matcher.group(1))
+            minor = int(matcher.group(2))
+            patch = int(matcher.group(3))
+            return (major, minor, patch)
+        raise RuntimeError("Unable to retrieve podman version")

--- a/tests/integration/ulimit/test_podman_compose_ulimit.py
+++ b/tests/integration/ulimit/test_podman_compose_ulimit.py
@@ -34,12 +34,9 @@ class TestUlimit(unittest.TestCase, RunSubprocessMixin):
                 for el in split_output
                 if not el.startswith(b"soft process") and not el.startswith(b"hard process")
             ]
-            # BUG: figure out why echo is called twice
             self.assertEqual(
                 output_part,
                 [
-                    b"soft nofile limit 1001",
-                    b"hard nofile limit 1001",
                     b"soft nofile limit 1001",
                     b"hard nofile limit 1001",
                 ],
@@ -53,8 +50,7 @@ class TestUlimit(unittest.TestCase, RunSubprocessMixin):
             self.assertEqual(
                 out,
                 b"soft process limit 1002\nhard process limit 2002\nsoft nofile limit 1002\n"
-                b"hard nofile limit 1002\nsoft process limit 1002\nhard process limit 2002\n"
-                b"soft nofile limit 1002\nhard nofile limit 1002\n",
+                b"hard nofile limit 1002\n",
             )
 
             out, _ = self.run_subprocess_assert_returncode([
@@ -65,8 +61,7 @@ class TestUlimit(unittest.TestCase, RunSubprocessMixin):
             self.assertEqual(
                 out,
                 b"soft process limit 1003\nhard process limit 2003\nsoft nofile limit 1003\n"
-                b"hard nofile limit 1003\nsoft process limit 1003\nhard process limit 2003\n"
-                b"soft nofile limit 1003\nhard nofile limit 1003\n",
+                b"hard nofile limit 1003\n",
             )
         finally:
             self.run_subprocess_assert_returncode([


### PR DESCRIPTION
This PR fixes #1176, #1178, and #1183 by employing a create-and-start approach, where the containers are created in the
first pass, then they are started using the `run_container()` method to make sure the dependencies'
conditions are checked. The second improvement is to add a version check to skip "podman wait
--condition=healthy" in the `check_dep_conditions()` function to prevent podman-compose hang. BTW,
this PR also fixes a minor problem that podman-compose attempts to stop and remove the containers
defined in the compose file when the `--force-recreate` option is specified when there are no
running containers at all.

Specific changes are as follows:
- Change compose-up to create then start container to enforce dependency condition check
- Skip running compose-down when there are no active containers
- Skip dependency health check to avoid compose-up hang for podman prior to 4.6.0, which doesn't support --condition healthy
- Add relevant integration test case and run the healthy state validation only when systemd is available
- Improve robustness for network, ulimit, extends etctest cases
- Relax pylint rules for test code, disable duplicate code check

4.6.0 seems to be the first version to support --condition=healthy, as discovered by this script:

~~~~bash
#!/bin/bash

# find supported wait conditions since v4.3.1 which is podman version used in
# github actions of podman-compose project
for ver in $(git tag -l | sed -e '/-rc[0-9]\+$/d' -e '/^v[0-3]/d' -e '/^v4.[0-2]/d' -e '/v4.3.0/d'); do
  echo $ver
  git show $ver:cmd/podman/common/completion.go | grep -A 3 "func AutocompleteWaitCondition"
done
~~~~

Finally, there are a few integration test cases mentioning this bug: 
- https://github.com/containers/podman-compose/blob/342a39dcfe6944932561bf12150deeb687fb6c52/tests/integration/env-file-tests/test_podman_compose_env_file.py#L129
- https://github.com/containers/podman-compose/blob/342a39dcfe6944932561bf12150deeb687fb6c52/tests/integration/ulimit/test_podman_compose_ulimit.py#L37