### PR TITLE
Add `--abort-on-container-failure` option

### DIFF
--- a/newsfragments/abort-on-container-failure.feature
+++ b/newsfragments/abort-on-container-failure.feature
@@ -1,0 +1,1 @@
+- Added --abort-on-container-failure option, to match docker-compose

--- a/tests/integration/abort/docker-compose-fail-first.yaml
+++ b/tests/integration/abort/docker-compose-fail-first.yaml
@@ -1,0 +1,11 @@
+version: "3"
+services:
+    sh1:
+      image: nopush/podman-compose-test
+      command: ["dumb-init", "/bin/busybox", "sh", "-c", "sleep 1; exit 1"]
+    sh2:
+      image: nopush/podman-compose-test
+      command: ["dumb-init", "/bin/busybox", "sh", "-c", "sleep 2; exit 0"]
+    sh3:
+      image: nopush/podman-compose-test
+      command: ["dumb-init", "/bin/busybox", "sh", "-c", "sleep 3; exit 0"]

--- a/tests/integration/abort/docker-compose-fail-none.yaml
+++ b/tests/integration/abort/docker-compose-fail-none.yaml
@@ -1,0 +1,11 @@
+version: "3"
+services:
+    sh1:
+      image: nopush/podman-compose-test
+      command: ["dumb-init", "/bin/busybox", "sh", "-c", "sleep 1; exit 0"]
+    sh2:
+      image: nopush/podman-compose-test
+      command: ["dumb-init", "/bin/busybox", "sh", "-c", "sleep 2; exit 0"]
+    sh3:
+      image: nopush/podman-compose-test
+      command: ["dumb-init", "/bin/busybox", "sh", "-c", "sleep 3; exit 0"]

--- a/tests/integration/abort/docker-compose-fail-second.yaml
+++ b/tests/integration/abort/docker-compose-fail-second.yaml
@@ -1,0 +1,11 @@
+version: "3"
+services:
+    sh1:
+      image: nopush/podman-compose-test
+      command: ["dumb-init", "/bin/busybox", "sh", "-c", "sleep 1; exit 0"]
+    sh2:
+      image: nopush/podman-compose-test
+      command: ["dumb-init", "/bin/busybox", "sh", "-c", "sleep 2; exit 1"]
+    sh3:
+      image: nopush/podman-compose-test
+      command: ["dumb-init", "/bin/busybox", "sh", "-c", "sleep 3; exit 0"]

--- a/tests/integration/abort/docker-compose-fail-simultaneous.yaml
+++ b/tests/integration/abort/docker-compose-fail-simultaneous.yaml
@@ -1,0 +1,11 @@
+version: "3"
+services:
+    sh1:
+      image: nopush/podman-compose-test
+      command: ["dumb-init", "/bin/busybox", "sh", "-c", "sleep 1; exit 1"]
+    sh2:
+      image: nopush/podman-compose-test
+      command: ["dumb-init", "/bin/busybox", "sh", "-c", "sleep 1; exit 0"]
+    sh3:
+      image: nopush/podman-compose-test
+      command: ["dumb-init", "/bin/busybox", "sh", "-c", "sleep 2; exit 0"]

--- a/tests/integration/abort/test_podman_compose_abort.py
+++ b/tests/integration/abort/test_podman_compose_abort.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: GPL-2.0
+
+import os
+import unittest
+
+from parameterized import parameterized
+
+from tests.integration.test_utils import RunSubprocessMixin
+from tests.integration.test_utils import podman_compose_path
+from tests.integration.test_utils import test_path
+
+
+def compose_yaml_path(failure_order):
+    return os.path.join(test_path(), "abort", f"docker-compose-fail-{failure_order}.yaml")
+
+
+class TestComposeAbort(unittest.TestCase, RunSubprocessMixin):
+    @parameterized.expand([
+        ("exit", "first", 0),
+        ("failure", "first", 1),
+        ("exit", "second", 0),
+        ("failure", "second", 1),
+        ("exit", "simultaneous", 0),
+        ("failure", "simultaneous", 1),
+        ("exit", "none", 0),
+        ("failure", "none", 0),
+    ])
+    def test_abort(self, abort_type, failure_order, expected_exit_code):
+        try:
+            self.run_subprocess_assert_returncode(
+                [
+                    podman_compose_path(),
+                    "-f",
+                    compose_yaml_path(failure_order),
+                    "up",
+                    f"--abort-on-container-{abort_type}",
+                ],
+                expected_exit_code,
+            )
+        finally:
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path(failure_order),
+                "down",
+            ])


### PR DESCRIPTION
Fixes #1164, with behaviour matching https://github.com/docker/compose/pull/11680 (see discussion in https://github.com/docker/compose/issues/10225)