### PR TITLE
Fix reset tag attribute to also reset `depends_on` parameter

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1713,6 +1713,8 @@ def normalize_service(service, sub_dir=""):
     if "depends_on" in service:
         # deps should become a dictionary of dependencies
         deps = service["depends_on"]
+        if isinstance(deps, ResetTag):
+            return service
         if isinstance(deps, str):
             deps = {deps: {}}
         elif is_list(deps):

--- a/tests/integration/merge/reset_and_override_tags/reset_tag_attribute/docker-compose.reset_attribute.yaml
+++ b/tests/integration/merge/reset_and_override_tags/reset_tag_attribute/docker-compose.reset_attribute.yaml
@@ -3,3 +3,4 @@ services:
     app:
         image: busybox
         command: !reset {}
+        depends_on: !reset null

--- a/tests/integration/merge/reset_and_override_tags/reset_tag_attribute/docker-compose.yaml
+++ b/tests/integration/merge/reset_and_override_tags/reset_tag_attribute/docker-compose.yaml
@@ -3,3 +3,5 @@ services:
     app:
         image: busybox
         command: ["/bin/busybox", "echo", "Zero"]
+        depends_on:
+            - db

--- a/tests/integration/merge/reset_and_override_tags/reset_tag_attribute/test_podman_compose_reset_tag_attribute.py
+++ b/tests/integration/merge/reset_and_override_tags/reset_tag_attribute/test_podman_compose_reset_tag_attribute.py
@@ -53,6 +53,8 @@ class TestComposeResetTagAttribute(unittest.TestCase, RunSubprocessMixin):
                 "logs",
             ])
             self.assertEqual(output, b"")
+            # depends_on: !reset null testing: if this test works, depends_on is correctly reset.
+            # Otherwise the test would break, since "db" dependency service is not provided
         finally:
             self.run_subprocess_assert_returncode([
                 podman_compose_path(),


### PR DESCRIPTION
Fixes https://github.com/containers/podman-compose/issues/1198.
This PR only fixes this specific issue. Better approach is needed as other specific attributes of services now do not handle being reset or overridden. Override of `depends_on` also is not implemented.

