### PR TITLE
Fix CMD healthchecks running with `/bin/sh`

### DIFF
--- a/newsfragments/fix-cmd-healtchecks.bugfix
+++ b/newsfragments/fix-cmd-healtchecks.bugfix
@@ -1,0 +1,1 @@
+Fixed support for CMD healthchecks to run using the given command directly and not using `/bin/sh -c`.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -29,14 +29,8 @@ import urllib.parse
 from asyncio import Task
 from enum import Enum
 
-try:
-    from shlex import quote as cmd_quote
-except ImportError:
-    from pipes import quote as cmd_quote  # pylint: disable=deprecated-module
-
 # import fnmatch
 # fnmatch.fnmatchcase(env, "*_HOST")
-
 import yaml
 from dotenv import dotenv_values
 
@@ -1228,7 +1222,7 @@ async def container_to_args(compose, cnt, detached=True, no_deps=False):
             # podman does not add shell to handle command with whitespace
             podman_args.extend([
                 "--healthcheck-command",
-                "/bin/sh -c " + cmd_quote(healthcheck_test),
+                json.dumps(["CMD-SHELL", healthcheck_test]),
             ])
         elif is_list(healthcheck_test):
             healthcheck_test = healthcheck_test.copy()
@@ -1237,13 +1231,11 @@ async def container_to_args(compose, cnt, detached=True, no_deps=False):
             if healthcheck_type == "NONE":
                 podman_args.append("--no-healthcheck")
             elif healthcheck_type == "CMD":
-                cmd_q = "' '".join([cmd_quote(i) for i in healthcheck_test])
-                podman_args.extend(["--healthcheck-command", "/bin/sh -c " + cmd_q])
+                podman_args.extend(["--healthcheck-command", json.dumps(healthcheck_test)])
             elif healthcheck_type == "CMD-SHELL":
                 if len(healthcheck_test) != 1:
                     raise ValueError("'CMD_SHELL' takes a single string after it")
-                cmd_q = cmd_quote(healthcheck_test[0])
-                podman_args.extend(["--healthcheck-command", "/bin/sh -c " + cmd_q])
+                podman_args.extend(["--healthcheck-command", json.dumps(healthcheck_test)])
             else:
                 raise ValueError(
                     f"unknown healthcheck test type [{healthcheck_type}],\

--- a/tests/unit/test_container_to_args.py
+++ b/tests/unit/test_container_to_args.py
@@ -694,3 +694,73 @@ class TestContainerToArgs(unittest.IsolatedAsyncioTestCase):
 
         with self.assertRaises(ValueError):
             await container_to_args(c, cnt)
+
+    async def test_heathcheck_string(self):
+        c = create_compose_mock()
+        cnt = get_minimal_container()
+        cnt["healthcheck"] = {
+            "test": "cmd arg1 arg2",
+        }
+
+        args = await container_to_args(c, cnt)
+        self.assertEqual(
+            args,
+            [
+                "--name=project_name_service_name1",
+                "-d",
+                "--network=bridge:alias=service_name",
+                "--healthcheck-command",
+                '["CMD-SHELL", "cmd arg1 arg2"]',
+                "busybox",
+            ],
+        )
+
+    async def test_heathcheck_cmd_args(self):
+        c = create_compose_mock()
+        cnt = get_minimal_container()
+        cnt["healthcheck"] = {
+            "test": ["CMD", "cmd", "arg1", "arg2"],
+        }
+
+        args = await container_to_args(c, cnt)
+        self.assertEqual(
+            args,
+            [
+                "--name=project_name_service_name1",
+                "-d",
+                "--network=bridge:alias=service_name",
+                "--healthcheck-command",
+                '["cmd", "arg1", "arg2"]',
+                "busybox",
+            ],
+        )
+
+    async def test_heathcheck_cmd_shell(self):
+        c = create_compose_mock()
+        cnt = get_minimal_container()
+        cnt["healthcheck"] = {
+            "test": ["CMD-SHELL", "cmd arg1 arg2"],
+        }
+
+        args = await container_to_args(c, cnt)
+        self.assertEqual(
+            args,
+            [
+                "--name=project_name_service_name1",
+                "-d",
+                "--network=bridge:alias=service_name",
+                "--healthcheck-command",
+                '["cmd arg1 arg2"]',
+                "busybox",
+            ],
+        )
+
+    async def test_heathcheck_cmd_shell_error(self):
+        c = create_compose_mock()
+        cnt = get_minimal_container()
+        cnt["healthcheck"] = {
+            "test": ["CMD-SHELL", "cmd arg1", "arg2"],
+        }
+
+        with self.assertRaises(ValueError):
+            await container_to_args(c, cnt)


### PR DESCRIPTION
This PR builds on PR https://github.com/containers/podman-compose/pull/1106 and completes it with units tests and newsfragment.
Thanks to @ben-krieger  for the solution.
Fixes https://github.com/containers/podman-compose/issues/23.
