### PR TITLE
Expose io.podman.compose.service label

### DIFF
--- a/newsfragments/io-podman-compose-service-label.feature
+++ b/newsfragments/io-podman-compose-service-label.feature
@@ -1,0 +1,1 @@
+Added `io.podman.compose.service` label to created containers. It contains the same value as com.docker.compose.service.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2315,7 +2315,8 @@ class PodmanCompose:
                 labels.extend(podman_compose_labels)
                 labels.extend([
                     f"com.docker.compose.container-number={num}",
-                    "com.docker.compose.service=" + service_name,
+                    f"io.podman.compose.service={service_name}",
+                    f"com.docker.compose.service={service_name}",
                 ])
                 cnt["labels"] = labels
                 cnt["_service"] = service_name


### PR DESCRIPTION
We had com.docker.compose.service, but not io.podman.compose.service.