### PR TITLE
Fix relative host path resolution for volume bind mount source

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -421,6 +421,7 @@ async def assert_volume(compose: PodmanCompose, mount_dict: dict[str, Any]) -> N
                 os.makedirs(mount_src, exist_ok=True)
             except OSError:
                 pass
+        mount_dict["source"] = mount_src
         return
     if mount_dict["type"] != "volume" or not vol or not vol.get("name"):
         return

--- a/tests/integration/selinux/test_podman_compose_selinux.py
+++ b/tests/integration/selinux/test_podman_compose_selinux.py
@@ -36,8 +36,9 @@ class TestPodmanCompose(unittest.TestCase, RunSubprocessMixin):
                 "selinux_container1_1",
             ])
             inspect_out = json.loads(out)
-            create_command_list = inspect_out[0].get("Config", []).get("CreateCommand", {})
-            self.assertIn('./host_test_text.txt:/test_text.txt:z', create_command_list)
+            create_command_list = inspect_out[0].get("Config", []).get("CreateCommand", [])
+            host_path = os.path.join(test_path(), "selinux", "host_test_text.txt")
+            self.assertIn(f'{host_path}:/test_text.txt:z', create_command_list)
 
             out, _ = self.run_subprocess_assert_returncode([
                 "podman",
@@ -45,8 +46,9 @@ class TestPodmanCompose(unittest.TestCase, RunSubprocessMixin):
                 "selinux_container2_1",
             ])
             inspect_out = json.loads(out)
-            create_command_list = inspect_out[0].get("Config", []).get("CreateCommand", {})
-            self.assertIn('./host_test_text.txt:/test_text.txt', create_command_list)
+            create_command_list = inspect_out[0].get("Config", []).get("CreateCommand", [])
+            host_path = os.path.join(test_path(), "selinux", "host_test_text.txt")
+            self.assertIn(f'{host_path}:/test_text.txt', create_command_list)
         finally:
             out, _ = self.run_subprocess_assert_returncode([
                 podman_compose_path(),


### PR DESCRIPTION
e03d675b9bcd92864fd1aedc23d92f72e410a54d broke relative host path resolution by deleting `os.chdir()`. After this commit current working directory is not relevant anymore.

Fixes https://github.com/containers/podman-compose/issues/1221.

