### PR TITLE
Fix dockerfile definition if directory name ends with ".git"

### DIFF
--- a/newsfragments/fix-dockerfile-definition-regression.bugfix
+++ b/newsfragments/fix-dockerfile-definition-regression.bugfix
@@ -1,0 +1,1 @@
+Fixed regression of dockerfile definition if working directory name ends with ".git".

--- a/tests/unit/test_container_to_build_args.py
+++ b/tests/unit/test_container_to_build_args.py
@@ -210,16 +210,6 @@ class TestContainerToBuildArgs(unittest.TestCase):
         with self.assertRaises(OSError):
             container_to_build_args(c, cnt, args, lambda path: False)
 
-    def test_context_invalid_git_url_git_is_not_suffix(self):
-        c = create_compose_mock()
-
-        cnt = get_minimal_container()
-        cnt['build']['context'] = "https://github.com/test_repo.git/not_suffix"
-        args = get_minimal_args()
-
-        with self.assertRaises(OSError):
-            container_to_build_args(c, cnt, args, lambda path: False)
-
     def test_build_ssh_absolute_path(self):
         c = create_compose_mock()
 

--- a/tests/unit/test_is_context_git_url.py
+++ b/tests/unit/test_is_context_git_url.py
@@ -7,7 +7,7 @@ from parameterized import parameterized
 from podman_compose import is_context_git_url
 
 
-class TestIsPathGitUrl(unittest.TestCase):
+class TestIsContextGitUrl(unittest.TestCase):
     @parameterized.expand([
         ("with_url_fragment", "http://host.xz/path/to/repo.git#fragment", True),
         ("suffix_and_prefix", "git://host.xz/path/to/repo.git", True),
@@ -74,6 +74,7 @@ class TestIsPathGitUrl(unittest.TestCase):
         ("", "file://~/path/to/repo.git/", True),
         ("", "github.com:containers/podman-compose.git", True),
         ("", "github:containers/podman-compose.git", True),
+        ("", "https://github.com/test_repo.git/git_not_suffix", True),
     ])
     def test_is_path_git_url(self, test_name: str, path: str, result: bool) -> None:
         self.assertEqual(is_context_git_url(path), result)


### PR DESCRIPTION
After changes in 92f0a8583afe9e2f263be4b8dac274b94056e332, the dockerfile parameter is igored if the (local) work directory's name ends in `.git`.
This commit fixes the regression and adds more tests.

PR fixes issue https://github.com/containers/podman-compose/issues/1226.
