### PR TITLE
Implement short syntax for env variables in compose.yml "environment:"

### DIFF
--- a/newsfragments/fix-short-syntax-env-variables.bugfix
+++ b/newsfragments/fix-short-syntax-env-variables.bugfix
@@ -1,0 +1,1 @@
+Implemented short syntax for environment variables set in `.env` for compose.yml "environment:" section.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1159,7 +1159,14 @@ async def container_to_args(
             podman_args.extend(["-e", e])
     env = norm_as_list(cnt.get("environment", {}))
     for e in env:
-        podman_args.extend(["-e", e])
+        # new environment variable is set
+        if "=" in e:
+            podman_args.extend(["-e", e])
+        else:
+            # environment variable already exists in environment so pass its value
+            if e in compose.environ.keys():
+                podman_args.extend(["-e", f"{e}={compose.environ[e]}"])
+
     tmpfs_ls = cnt.get("tmpfs", [])
     if isinstance(tmpfs_ls, str):
         tmpfs_ls = [tmpfs_ls]

--- a/tests/integration/env_file_tests/project/.env
+++ b/tests/integration/env_file_tests/project/.env
@@ -1,2 +1,3 @@
 ZZVAR1='This value is loaded but should be overwritten'
 ZZVAR2='This value is loaded from .env in project/ directory'
+ZZVAR3=TEST

--- a/tests/integration/env_file_tests/project/container-compose.short_syntax.yaml
+++ b/tests/integration/env_file_tests/project/container-compose.short_syntax.yaml
@@ -1,0 +1,10 @@
+services:
+  app:
+    image: nopush/podman-compose-test
+    command: ["/bin/busybox", "sh", "-c", "env | grep ZZVAR3"]
+    # 'env_file:' section is not used, so .env file is searched in the same directory as compose.yml
+    # file
+    environment:
+        # this is short syntax: podman-compose takes only this variable value from '.env' file and
+        # sends it to container environment
+        - ZZVAR3


### PR DESCRIPTION
This commit allows compose file to directly use environment variable values in `environment:` section when variables were set in `.env` file. This functionality was missing, as `docker-compose` supports both: short and variable interpolation syntax forms, in `compose.yml` file:
```
environment:
    - FOO
```
and
```
environment:
    - FOO=${FOO} 
```
Relevant `docker-compose` documentation:
https://docs.docker.com/compose/how-tos/environment-variables/set-environment-variables/ 
`podman-compose` is more compatible with `docker-compose` after this change.

This pull request solves issues: #491, #1011, #1160.

