### PR TITLE
Fix formatting of description and help of `systemd` command

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2467,7 +2467,7 @@ class PodmanCompose:
         parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
         self._init_global_parser(parser)
         subparsers = parser.add_subparsers(title="command", dest="command")
-        subparser = subparsers.add_parser("help", help="show help")
+        _ = subparsers.add_parser("help", help="show help")
         for cmd_name, cmd in self.commands.items():
             subparser = subparsers.add_parser(cmd_name, help=cmd.desc)  # pylint: disable=protected-access
             for cmd_parser in cmd._parse_args:  # pylint: disable=protected-access

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2469,7 +2469,7 @@ class PodmanCompose:
         subparsers = parser.add_subparsers(title="command", dest="command")
         _ = subparsers.add_parser("help", help="show help")
         for cmd_name, cmd in self.commands.items():
-            subparser = subparsers.add_parser(cmd_name, help=cmd.desc)  # pylint: disable=protected-access
+            subparser = subparsers.add_parser(cmd_name, help=cmd.help, description=cmd.desc)  # pylint: disable=protected-access
             for cmd_parser in cmd._parse_args:  # pylint: disable=protected-access
                 cmd_parser(subparser)
         self.global_args = parser.parse_args(argv)
@@ -2604,7 +2604,12 @@ class cmd_run:  # pylint: disable=invalid-name,too-few-public-methods
             raise PodmanComposeError("Command must be async")
         wrapped._compose = self.compose  # type: ignore[attr-defined]
         # Trim extra indentation at start of multiline docstrings.
-        wrapped.desc = self.cmd_desc or re.sub(r"^\s+", "", func.__doc__ or "")  # type: ignore[attr-defined]
+        help_desc = self.cmd_desc or re.sub(r"^\s+", "", func.__doc__ or "")  # type: ignore[attr-defined]
+        if "\n" in help_desc:
+            wrapped.help, wrapped.desc = help_desc.split("\n", 1)  # type: ignore[attr-defined]
+        else:
+            wrapped.help = help_desc  # type: ignore[attr-defined]
+            wrapped.desc = None  # type: ignore[attr-defined]
         wrapped._parse_args = []  # type: ignore[attr-defined]
         self.compose.commands[self.cmd_name] = wrapped
         return wrapped


### PR DESCRIPTION
This PR completes unfinished https://github.com/containers/podman-compose/pull/643 by re-basing it on the latest `main` and reformatting.
