### PR TITLE
Hide stack trace shown on YAML parse error by default

### DIFF
--- a/newsfragments/hide-stack-trace-yaml-parse-error.change
+++ b/newsfragments/hide-stack-trace-yaml-parse-error.change
@@ -1,0 +1,1 @@
+Hide the stack trace on a YAML parse error.

--- a/tests/integration/parse-error/docker-compose-error.yml
+++ b/tests/integration/parse-error/docker-compose-error.yml
@@ -1,0 +1,4 @@
+version: "3"
+services:foo
+    web1:
+      image: busybox

--- a/tests/integration/parse-error/docker-compose.yml
+++ b/tests/integration/parse-error/docker-compose.yml
@@ -1,0 +1,4 @@
+version: "3"
+services:
+    web1:
+      image: busybox

--- a/tests/integration/parse-error/test_podman_compose_parse_error.py
+++ b/tests/integration/parse-error/test_podman_compose_parse_error.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: GPL-2.0
+
+import os
+import unittest
+
+from tests.integration.test_utils import RunSubprocessMixin
+from tests.integration.test_utils import podman_compose_path
+from tests.integration.test_utils import test_path
+
+
+def bad_compose_yaml_path() -> str:
+    base_path = os.path.join(test_path(), "parse-error")
+    return os.path.join(base_path, "docker-compose-error.yml")
+
+
+def good_compose_yaml_path() -> str:
+    base_path = os.path.join(test_path(), "parse-error")
+    return os.path.join(base_path, "docker-compose.yml")
+
+
+class TestComposeBuildParseError(unittest.TestCase, RunSubprocessMixin):
+    def test_no_error(self) -> None:
+        try:
+            _, err = self.run_subprocess_assert_returncode(
+                [podman_compose_path(), "-f", good_compose_yaml_path(), "config"], 0
+            )
+            self.assertEqual(b"", err)
+
+        finally:
+            self.run_subprocess([
+                podman_compose_path(),
+                "-f",
+                bad_compose_yaml_path(),
+                "down",
+            ])
+
+    def test_simple_parse_error(self) -> None:
+        try:
+            _, err = self.run_subprocess_assert_returncode(
+                [podman_compose_path(), "-f", bad_compose_yaml_path(), "config"], 1
+            )
+            self.assertIn(b"could not find expected ':'", err)
+            self.assertNotIn(b"\nTraceback (most recent call last):\n", err)
+
+        finally:
+            self.run_subprocess([
+                podman_compose_path(),
+                "-f",
+                bad_compose_yaml_path(),
+                "down",
+            ])
+
+    def test_verbose_parse_error_contains_stack_trace(self) -> None:
+        try:
+            _, err = self.run_subprocess_assert_returncode(
+                [podman_compose_path(), "--verbose", "-f", bad_compose_yaml_path(), "config"], 1
+            )
+            self.assertIn(b"\nTraceback (most recent call last):\n", err)
+
+        finally:
+            self.run_subprocess([
+                podman_compose_path(),
+                "-f",
+                bad_compose_yaml_path(),
+                "down",
+            ])


### PR DESCRIPTION
A YAML parse error is not caused by the podman-compose code, and the stack trace will not be helpful
in a typical use case. Adding --verbose will still show it, for those who need it.

Fixes https://github.com/containers/podman-compose/issues/1139

Some questions I have:
- I chose log.fatal() for the parse error message that is always shown. Is it a good choice? Some parts of the code use it, others use sys.stderr.write(), for things like this.
- I don't know if we should let it die in resolve_extends() or try to catch error and return {} in that case. I left the behavior unchanged for now.

EDIT: wrong issue number