### PR TITLE
wait for deps in compose_run

### DIFF
--- a/newsfragments/fix-compose-run-dependency-condition-check.bugfix
+++ b/newsfragments/fix-compose-run-dependency-condition-check.bugfix
@@ -1,0 +1,1 @@
+Fixes compose run by waiting until the conditions are satisfied

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -3388,6 +3388,7 @@ async def compose_run(compose: PodmanCompose, args: argparse.Namespace) -> None:
             )
         )
         await compose.commands["up"](compose, up_args)
+        await check_dep_conditions(compose, deps_from_container(up_args, cnt))
 
     build_args = argparse.Namespace(
         services=[args.service], if_not_exists=(not args.build), build_arg=[], **args.__dict__


### PR DESCRIPTION
Hello.
This PR may be treated as an extra fix for #78
Currently podman compose run starts dependencies but doesn't check for condition requirements.

Could you suggest what test are needed?