### PR TITLE
Show logs for each container independently

### DIFF
--- a/newsfragments/fix-compose-logs.bugfix
+++ b/newsfragments/fix-compose-logs.bugfix
@@ -1,0 +1,1 @@
+Fixes the issue with compose logs for multiple targets when any container is missing

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -3553,9 +3553,10 @@ async def compose_logs(compose: PodmanCompose, args: argparse.Namespace) -> None
         podman_args.append("-t")
     if args.until:
         podman_args.extend(["--until", args.until])
+    # podman logs supports multiple targets,
+    # but will fail completely if any container is missing
     for target in targets:
-        podman_args.append(target)
-    await compose.podman.run([], "logs", podman_args)
+        await compose.podman.run([], "logs", [*podman_args, target])
 
 
 @cmd_run(podman_compose, "config", "displays the compose file")


### PR DESCRIPTION
Currently `podman compose logs cnt1 cnt2 cnt3` as well as `podman logs` fails with "no such container" if any container is missing.


Tests will be later.