### PR TITLE
Add Debian-trixie release for testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,11 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
+        image-suffix: ['bookworm', 'trixie']
 
     runs-on: ubuntu-latest
     container:
-      image: "docker.io/library/python:${{ matrix.python-version }}-bookworm"
+      image: "docker.io/library/python:${{ matrix.python-version }}-${{ matrix.image-suffix }}"
       # cgroupns needed to address the following error:
       # write /sys/fs/cgroup/cgroup.subtree_control: operation not supported
       options: --privileged --cgroupns=host


### PR DESCRIPTION
`podman-compose` has been tested exclusively with the Debian-bookworm release, which supports Podman version 4.3.1. However, newer versions of Podman have since been released, and the Debian-trixie release updates to these newer versions accordingly.

This commit enhances `podman-compose` testing by extending the tests to run on Debian-trixie with the latest versions of Podman.
