### PR TITLE
feat: Add support for COMPOSE_PROFILES environment variable

### DIFF
--- a/newsfragments/compose_profiles_env.feature
+++ b/newsfragments/compose_profiles_env.feature
@@ -1,0 +1,1 @@
+Support COMPOSE_PROFILES environment variable to enable profiles.


### PR DESCRIPTION
This change implements support for the  environment variable, allowing users to specify active Compose profiles through their environment. [#1083](https://github.com/containers/podman-compose/issues/1083), [comment](https://github.com/containers/podman-compose/pull/592#issuecomment-1906227314)