### PR TITLE
tests: Add `workflow_dispatch` to allow manual execution of CI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: Tests
 
 on:
+  workflow_dispatch:
   push:
   pull_request:
 


### PR DESCRIPTION
This PR enables manual test execution via the `workflow_dispatch` trigger in the GitHub Actions workflow