### PR TITLE
 fix failed recognition of custom containerfile due to Windows paths (e.g `C:\some\path`) being misinterpreted as git urls

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2834,7 +2834,9 @@ def is_context_git_url(path: str) -> bool:
         return True
     # URL contains a ":" character, a hint of a valid URL
     if r.scheme != "" and r.netloc == "" and r.path != "":
-        return True
+        # On Windows, this could be a drive letter, so we need to check the scheme
+        if not (os.name == "nt" and len(r.scheme) == 1):
+            return True
     if r.scheme == "":  # tweak path URL to get username from url parser
         r = urllib.parse.urlparse("ssh://" + path)
         if r.username is not None and r.username != "":


### PR DESCRIPTION
[Link to docker-compose spec.](https://docs.docker.com/reference/compose-file/build/#dockerfile)

See [minimal example](https://github.com/metroite/podman-compose-dockerfile-bug-example) (works with docker compose, not with podman).

This error occurs when trying to run any podman-compose.yml with a build `context:` and `dockerfile:` directive:
```
Error: no Containerfile or Dockerfile specified or found in context directory, C:/path/to/service/context/hello: The system cannot find the file specified.
Error: executing podman-compose build hello: exit status 125
```

There is a line in `is_context_git_url()` which checks for a `:` in the context path. As Windows uses `:` to seperate drives, this results in a bad assertion of every Windows path as a git context.
