### PR TITLE
Support service level config hash

### DIFF
--- a/newsfragments/service_level_change_detect.bugfix
+++ b/newsfragments/service_level_change_detect.bugfix
@@ -1,0 +1,1 @@
+Support service level configuration change detection on up command

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2139,12 +2139,17 @@ class PodmanCompose:
             return service["_config_hash"]
 
         # Use a stable representation of the service configuration
-        jsonable_servcie = {
-            k: v for k, v in service.items() if isinstance(k, str) and not k.startswith("_")
-        }
+        jsonable_servcie = self.original_service(service)
         config_str = json.dumps(jsonable_servcie, sort_keys=True)
         service["_config_hash"] = hashlib.sha256(config_str.encode('utf-8')).hexdigest()
         return service["_config_hash"]
+
+    def original_service(self, service: dict[str, Any]) -> dict[str, Any]:
+        """
+        Returns the original service configuration without any overrides or resets.
+        This is used to compare the original service configuration with the current one.
+        """
+        return {k: v for k, v in service.items() if isinstance(k, str) and not k.startswith("_")}
 
     def resolve_pod_name(self) -> str | None:
         # Priorities:

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1769,7 +1769,10 @@ class Podman:
             c.get("Names")[0]: ExistingContainer(
                 name=c.get("Names")[0],
                 id=c.get("Id"),
-                service_name=c.get("Labels", {}).get("io.podman.compose.service", ""),
+                service_name=(
+                    c.get("Labels", {}).get("io.podman.compose.service", "")
+                    or c.get("Labels", {}).get("com.docker.compose.service", "")
+                ),
                 config_hash=c.get("Labels", {}).get("io.podman.compose.config-hash", ""),
                 exited=c.get("Exited", False),
                 state=c.get("State", ""),

--- a/tests/integration/compose_up_behavior/docker-compose_service_change_app.yaml
+++ b/tests/integration/compose_up_behavior/docker-compose_service_change_app.yaml
@@ -1,0 +1,14 @@
+services:
+  app:
+    image: nopush/podman-compose-test
+    command: ["dumb-init", "/bin/busybox", "httpd", "-f", "-p", "8080"]
+    environment:
+      - SERVICE_CHANGE=true
+    depends_on:
+      - db
+  db:
+    image: nopush/podman-compose-test
+    command: ["dumb-init", "/bin/busybox", "httpd", "-f", "-p", "8080"]
+  no_deps:
+    image: nopush/podman-compose-test
+    command: ["dumb-init", "/bin/busybox", "httpd", "-f", "-p", "8080"]

--- a/tests/integration/compose_up_behavior/docker-compose_service_change_base.yaml
+++ b/tests/integration/compose_up_behavior/docker-compose_service_change_base.yaml
@@ -1,0 +1,12 @@
+services:
+  app:
+    image: nopush/podman-compose-test
+    command: ["dumb-init", "/bin/busybox", "httpd", "-f", "-p", "8080"]
+    depends_on:
+      - db
+  db:
+    image: nopush/podman-compose-test
+    command: ["dumb-init", "/bin/busybox", "httpd", "-f", "-p", "8080"]
+  no_deps:
+    image: nopush/podman-compose-test
+    command: ["dumb-init", "/bin/busybox", "httpd", "-f", "-p", "8080"]

--- a/tests/integration/compose_up_behavior/docker-compose_service_change_db.yaml
+++ b/tests/integration/compose_up_behavior/docker-compose_service_change_db.yaml
@@ -1,0 +1,14 @@
+services:
+  app:
+    image: nopush/podman-compose-test
+    command: ["dumb-init", "/bin/busybox", "httpd", "-f", "-p", "8080"]
+    depends_on:
+      - db
+  db:
+    image: nopush/podman-compose-test
+    command: ["dumb-init", "/bin/busybox", "httpd", "-f", "-p", "8080"]
+    environment:
+      - SERVICE_CHANGE=true
+  no_deps:
+    image: nopush/podman-compose-test
+    command: ["dumb-init", "/bin/busybox", "httpd", "-f", "-p", "8080"]

--- a/tests/integration/compose_up_behavior/test_compose_up_behavior.py
+++ b/tests/integration/compose_up_behavior/test_compose_up_behavior.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: GPL-2.0
+
+import json
+import os
+import unittest
+from typing import Any
+
+from parameterized import parameterized
+
+from tests.integration.test_utils import RunSubprocessMixin
+from tests.integration.test_utils import podman_compose_path
+from tests.integration.test_utils import test_path
+
+
+def compose_yaml_path(scenario: str) -> str:
+    return os.path.join(
+        os.path.join(test_path(), "compose_up_behavior"), f"docker-compose_{scenario}.yaml"
+    )
+
+
+class TestComposeDownBehavior(unittest.TestCase, RunSubprocessMixin):
+    def get_existing_containers(self, scenario: str) -> dict[str, Any]:
+        out, _ = self.run_subprocess_assert_returncode(
+            [
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path(scenario),
+                "ps",
+                "--format",
+                'json',
+            ],
+        )
+        containers = json.loads(out)
+        return {
+            c.get("Names")[0]: {
+                "name": c.get("Names")[0],
+                "id": c.get("Id"),
+                "service_name": c.get("Labels", {}).get("io.podman.compose.service", ""),
+                "config_hash": c.get("Labels", {}).get("io.podman.compose.config-hash", ""),
+                "exited": c.get("Exited"),
+            }
+            for c in containers
+        }
+
+    @parameterized.expand([
+        (
+            "service_change_app",
+            "service_change_base",
+            ["up"],
+            {"app"},
+        ),
+        (
+            "service_change_app",
+            "service_change_base",
+            ["up", "app"],
+            {"app"},
+        ),
+        (
+            "service_change_app",
+            "service_change_base",
+            ["up", "db"],
+            set(),
+        ),
+        (
+            "service_change_db",
+            "service_change_base",
+            ["up"],
+            {"db", "app"},
+        ),
+        (
+            "service_change_db",
+            "service_change_base",
+            ["up", "app"],
+            {"db", "app"},
+        ),
+        (
+            "service_change_db",
+            "service_change_base",
+            ["up", "db"],
+            {"db", "app"},
+        ),
+    ])
+    def test_recreate_on_config_changed(
+        self,
+        change_to: str,
+        running_scenario: str,
+        command_args: list[str],
+        expect_recreated_services: set[str],
+    ) -> None:
+        try:
+            self.run_subprocess_assert_returncode(
+                [podman_compose_path(), "-f", compose_yaml_path(running_scenario), "up", "-d"],
+            )
+
+            original_containers = self.get_existing_containers(running_scenario)
+
+            out, err = self.run_subprocess_assert_returncode(
+                [
+                    podman_compose_path(),
+                    "--verbose",
+                    "-f",
+                    compose_yaml_path(change_to),
+                    *command_args,
+                    "-d",
+                ],
+            )
+
+            new_containers = self.get_existing_containers(change_to)
+            recreated_services = {
+                c.get("service_name")
+                for c in original_containers.values()
+                if new_containers.get(c.get("name"), {}).get("id") != c.get("id")
+            }
+
+            self.assertEqual(
+                recreated_services,
+                expect_recreated_services,
+                msg=f"Expected services to be recreated: {expect_recreated_services}, "
+                f"but got: {recreated_services}, containers: "
+                f"[{original_containers}, {new_containers}]",
+            )
+            self.assertTrue(
+                all([c.get("exited") is False for c in new_containers.values()]),
+                msg="Not all containers are running after up command",
+            )
+
+        finally:
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path(change_to),
+                "down",
+                "-t",
+                "0",
+            ])

--- a/tests/unit/test_can_merge_build.py
+++ b/tests/unit/test_can_merge_build.py
@@ -92,8 +92,9 @@ class TestCanMergeBuild(unittest.TestCase):
 
         actual_compose = {}
         if podman_compose.services:
-            podman_compose.services["test-service"].pop("_deps")
-            actual_compose = podman_compose.services["test-service"]
+            actual_compose = podman_compose.original_service(
+                podman_compose.services["test-service"]
+            )
         self.assertEqual(actual_compose, expected)
 
     # $$$ is a placeholder for either command or entrypoint
@@ -138,8 +139,7 @@ class TestCanMergeBuild(unittest.TestCase):
 
             actual = {}
             if podman_compose.services:
-                podman_compose.services["test-service"].pop("_deps")
-                actual = podman_compose.services["test-service"]
+                actual = podman_compose.original_service(podman_compose.services["test-service"])
             self.assertEqual(actual, expected)
 
 

--- a/tests/unit/test_normalize_final_build.py
+++ b/tests/unit/test_normalize_final_build.py
@@ -123,8 +123,9 @@ class TestNormalizeFinalBuild(unittest.TestCase):
 
         actual_compose = {}
         if podman_compose.services:
-            podman_compose.services["test-service"].pop("_deps")
-            actual_compose = podman_compose.services["test-service"]
+            actual_compose = podman_compose.original_service(
+                podman_compose.services["test-service"]
+            )
         self.assertEqual(actual_compose, expected)
 
     @parameterized.expand([
@@ -238,8 +239,9 @@ class TestNormalizeFinalBuild(unittest.TestCase):
 
         actual_compose = {}
         if podman_compose.services:
-            podman_compose.services["test-service"].pop("_deps")
-            actual_compose = podman_compose.services["test-service"]
+            actual_compose = podman_compose.original_service(
+                podman_compose.services["test-service"]
+            )
         self.assertEqual(actual_compose, expected)
 
 


### PR DESCRIPTION
Currently, podman-compose does not support service level configuration changes.
This means that any configuration changes will lead to a full recreation of services.

By setting `service_level_change_detect: true` under global `x-podman` key, podman-compose
will calculate a hash of the service level configuration and will only recreate
that service if the hash has changed.