### PR TITLE
feature: add list all running containers command

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -62,13 +62,11 @@ def filteri(a: list[str]) -> list[str]:
 
 
 @overload
-def try_int(i: int | str, fallback: int) -> int:
-    ...
+def try_int(i: int | str, fallback: int) -> int: ...
 
 
 @overload
-def try_int(i: int | str, fallback: None) -> int | None:
-    ...
+def try_int(i: int | str, fallback: None) -> int | None: ...
 
 
 def try_int(i: int | str, fallback: int | None = None) -> int | None:
@@ -275,18 +273,15 @@ var_re = re.compile(
 
 
 @overload
-def rec_subs(value: dict, subs_dict: dict[str, Any]) -> dict:
-    ...
+def rec_subs(value: dict, subs_dict: dict[str, Any]) -> dict: ...
 
 
 @overload
-def rec_subs(value: str, subs_dict: dict[str, Any]) -> str:
-    ...
+def rec_subs(value: str, subs_dict: dict[str, Any]) -> str: ...
 
 
 @overload
-def rec_subs(value: Iterable, subs_dict: dict[str, Any]) -> Iterable:
-    ...
+def rec_subs(value: Iterable, subs_dict: dict[str, Any]) -> Iterable: ...
 
 
 def rec_subs(value: dict | str | Iterable, subs_dict: dict[str, Any]) -> dict | str | Iterable:
@@ -2580,11 +2575,7 @@ class PodmanCompose:
         subparsers = parser.add_subparsers(title="command", dest="command")
         _ = subparsers.add_parser("help", help="show help")
         for cmd_name, cmd in self.commands.items():
-            subparser = subparsers.add_parser(
-                cmd_name,
-                help=cmd.help,
-                description=cmd.desc
-            )  # pylint: disable=protected-access
+            subparser = subparsers.add_parser(cmd_name, help=cmd.help, description=cmd.desc)  # pylint: disable=protected-access
             for cmd_parser in cmd._parse_args:  # pylint: disable=protected-access
                 cmd_parser(subparser)
         self.global_args = parser.parse_args(argv)
@@ -2748,6 +2739,7 @@ class cmd_parse:  # pylint: disable=invalid-name,too-few-public-methods
 # actual commands
 ###################
 
+
 @cmd_run(podman_compose, "ls", "List running compose projects")
 async def list_running_projects(compose: PodmanCompose, args: argparse.Namespace) -> None:
     img_containers = [cnt for cnt in compose.containers if "image" in cnt]
@@ -2771,7 +2763,7 @@ async def list_running_projects(compose: PodmanCompose, args: argparse.Namespace
                     {{ .State.Running }}
                     {{ index .Config.Labels "com.docker.compose.project.working_dir" }}
                     {{ index .Config.Labels "com.docker.compose.project.config_files" }}
-                    '''
+                    ''',
                 ],
             )
             output = output.decode().split()
@@ -2785,11 +2777,7 @@ async def list_running_projects(compose: PodmanCompose, args: argparse.Namespace
 
             elif _format == "json":
                 # Replicate how docker compose returns the list
-                json_obj = {
-                    "Name": name,
-                    "Status": status,
-                    "ConfigFiles": path
-                }
+                json_obj = {"Name": name, "Status": status, "ConfigFiles": path}
                 data.append(json_obj)
         except Exception:
             break

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2745,7 +2745,7 @@ async def list_running_projects(compose: PodmanCompose, args: argparse.Namespace
     img_containers = [cnt for cnt in compose.containers if "image" in cnt]
     parsed_args = vars(args)
     _format = parsed_args.get("format", "table")
-    data = []
+    data: list[Any] = []
     if _format == "table":
         data.append(["NAME", "STATUS", "CONFIG_FILES"])
 
@@ -2766,13 +2766,13 @@ async def list_running_projects(compose: PodmanCompose, args: argparse.Namespace
                     ''',
                 ],
             )
-            output = output.decode().split()
-            running = bool(json.loads(output[1]))
-            status = "{}({})".format(output[0], 1 if running else 0)
-            path = "{}/{}".format(output[2], output[3])
+            command_output = output.decode().split()
+            running = bool(json.loads(command_output[1]))
+            status = "{}({})".format(command_output[0], 1 if running else 0)
+            path = "{}/{}".format(command_output[2], command_output[3])
 
             if _format == "table":
-                if isinstance(output, list):
+                if isinstance(command_output, list):
                     data.append([name, status, path])
 
             elif _format == "json":

--- a/tests/integration/list/docker-compose.yml
+++ b/tests/integration/list/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3.6'
+
+services:
+  service_1:
+    image: nopush/podman-compose-test
+    command: ["dumb-init", "/bin/busybox", "httpd", "-f", "-h", ".", "-p", "8003"]
+  service_2:
+    image: nopush/podman-compose-test
+    command: ["dumb-init", "/bin/busybox", "httpd", "-f", "-h", ".", "-p", "8003"]
+  service_3:
+    image: nopush/podman-compose-test
+    command: ["dumb-init", "/bin/busybox", "httpd", "-f", "-h", ".", "-p", "8003"]
+

--- a/tests/integration/list/test_podman_compose_list.py
+++ b/tests/integration/list/test_podman_compose_list.py
@@ -1,0 +1,99 @@
+import ast
+import os
+import unittest
+
+from tests.integration.test_utils import RunSubprocessMixin
+from tests.integration.test_utils import podman_compose_path
+from tests.integration.test_utils import test_path
+
+
+class TestPodmanComposeInclude(unittest.TestCase, RunSubprocessMixin):
+    def test_podman_compose_list(self) -> None:
+        """
+        Test podman compose list (ls) command
+        """
+        command_up = [
+            "coverage",
+            "run",
+            podman_compose_path(),
+            "-f",
+            os.path.join(test_path(), "list", "docker-compose.yml"),
+            "up",
+            "-d",
+        ]
+
+        command_list = [
+            "coverage",
+            "run",
+            podman_compose_path(),
+            "-f",
+            os.path.join(test_path(), "list", "docker-compose.yml"),
+            "ls",
+        ]
+
+        command_check_container = [
+            "podman",
+            "ps",
+            "-a",
+            "--filter",
+            "label=io.podman.compose.project=list",
+            "--format",
+            '"{{.Image}}"',
+        ]
+
+        command_container_id = [
+            "podman",
+            "ps",
+            "-a",
+            "--filter",
+            "label=io.podman.compose.project=list",
+            "--format",
+            '"{{.ID}}"',
+        ]
+
+        command_down = ["podman", "rm", "--force"]
+
+        running_containers = []
+        self.run_subprocess_assert_returncode(command_up)
+        out, _ = self.run_subprocess_assert_returncode(command_list)
+        out = out.decode()
+
+        # Test for table view
+        services = out.strip().split("\n")
+        headers = [h.strip() for h in services[0].split("\t")]
+
+        for service in services[1:]:
+            values = [val.strip() for val in service.split("\t")]
+            zipped = dict(zip(headers, values))
+            self.assertNotEqual(zipped.get("NAME"), None)
+            self.assertNotEqual(zipped.get("STATUS"), None)
+            self.assertNotEqual(zipped.get("CONFIG_FILES"), None)
+            running_containers.append(zipped)
+        self.assertEqual(len(running_containers), 3)
+
+        # Test for json view
+        command_list.extend(["--format", "json"])
+        out, _ = self.run_subprocess_assert_returncode(command_list)
+        out = out.decode()
+        services = ast.literal_eval(out)
+
+        for service in services:
+            self.assertIsInstance(service, dict)
+            self.assertNotEqual(service.get("Name"), None)
+            self.assertNotEqual(service.get("Status"), None)
+            self.assertNotEqual(service.get("ConfigFiles"), None)
+
+        self.assertEqual(len(services), 3)
+
+        # Get container ID to remove it
+        out, _ = self.run_subprocess_assert_returncode(command_container_id)
+        self.assertNotEqual(out, b"")
+        container_ids = out.decode().strip().split("\n")
+        container_ids = [container_id.replace('"', "") for container_id in container_ids]
+        command_down.extend(container_ids)
+        out, _ = self.run_subprocess_assert_returncode(command_down)
+        # cleanup test image(tags)
+        self.assertNotEqual(out, b"")
+        # check container did not exists anymore
+        out, _ = self.run_subprocess_assert_returncode(command_check_container)
+        self.assertEqual(out, b"")


### PR DESCRIPTION
sample usage and results

```
podman-compose ls

# table format - default
NAME            STATUS          CONFIG_FILES
test_redis      running(1)      /podman-compose/compose.yaml

# --format json or -f json
[{'Name': 'test_redis', 'Status': 'running(1)', 'ConfigFiles': '/podman-compose/compose.yaml'}]
```

Related request - https://github.com/containers/podman-compose/issues/1307
Signed-off-by: Anton Petrov