### PR TITLE
Implement 'image' volume type for services

### DIFF
--- a/newsfragments/mount-image-as-volume.feature
+++ b/newsfragments/mount-image-as-volume.feature
@@ -1,0 +1,1 @@
+Support volume.type=image in services, for mounting files from container images.


### PR DESCRIPTION
This adds support for volume.type=image in services, as specified in [Compose spec](https://github.com/compose-spec/compose-spec/blob/76d4a3d08f9d4eb251092746394a64327031a6c6/05-services.md#long-syntax-5).

Fixes https://github.com/containers/podman-compose/issues/1202
