### PR TITLE
Add `--no-color` flag for `podman-compose logs` command

### DIFF
--- a/newsfragments/add_logs_no_color_flag.bugfix
+++ b/newsfragments/add_logs_no_color_flag.bugfix
@@ -1,0 +1,1 @@
+Add `--no-color` flag for `podman-compose logs` command.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -4166,6 +4166,7 @@ def compose_logs_parse(parser: argparse.ArgumentParser) -> None:
         action="store_true",
         help="Output the container name in the log",
     )
+    parser.add_argument("--no-color", action="store_true", help="Produce monochrome output")
     parser.add_argument("--since", help="Show logs since TIMESTAMP", type=str, default=None)
     parser.add_argument("-t", "--timestamps", action="store_true", help="Show timestamps.")
     parser.add_argument(


### PR DESCRIPTION
This PR adds `--no-color` flag to the `podman-compose logs` command.

Relevant `docker-compose` reference:
https://docs.docker.com/reference/cli/docker/compose/logs

Fixes https://github.com/containers/podman-compose/issues/492

According to the documentation, logs should be colored by default and the `--no-color` flag is intended to force monochrome output, but this behavior is not yet implemented.





