### PR TITLE
Properly surface error code from `pull` command

### DIFF
--- a/newsfragments/pull-return-non-zero-code.bugfix
+++ b/newsfragments/pull-return-non-zero-code.bugfix
@@ -1,0 +1,1 @@
+Implement returning error code from `pull` command.

--- a/tests/integration/commands_fail_exit_code/docker-compose.yml
+++ b/tests/integration/commands_fail_exit_code/docker-compose.yml
@@ -6,3 +6,7 @@ services:
   good:
     build:
       context: good
+  test_pull_good:
+    image: nopush/podman-compose-test
+  test_pull_bad:
+    image: localhost/does-not-exist

--- a/tests/integration/commands_fail_exit_code/test_podman_compose_commands_fail_exit_code.py
+++ b/tests/integration/commands_fail_exit_code/test_podman_compose_commands_fail_exit_code.py
@@ -52,6 +52,30 @@ class TestComposeCommandsFailExitCodes(unittest.TestCase, RunSubprocessMixin):
                 "down",
             ])
 
+    def test_pull_command_fail(self) -> None:
+        # test that pull command is able to return other than "0" return code
+        # "pull" command fails due to missing images or networking errors
+        # failure in pulling any one of the images ends up in error code for "pull" command
+        try:
+            output, error = self.run_subprocess_assert_returncode(
+                [
+                    podman_compose_path(),
+                    "-f",
+                    compose_yaml_path(),
+                    "pull",
+                    "test_pull_bad",
+                    "test_pull_good",
+                ],
+                expected_returncode=125,
+            )
+        finally:
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path(),
+                "down",
+            ])
+
     def test_run_command_fail(self) -> None:
         # test that run command is able to return other than "0" return code
         try:


### PR DESCRIPTION
This PR implements returning error codes for podman-compose `pull` command.

Fixes https://github.com/containers/podman-compose/issues/1305.
