### PR TITLE
Move `config` command integration test to a dedicated file

### DIFF
--- a/tests/integration/command_config/test_podman_compose_config_command.py
+++ b/tests/integration/command_config/test_podman_compose_config_command.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: GPL-2.0
+
+import os
+import unittest
+
+from tests.integration.test_utils import RunSubprocessMixin
+from tests.integration.test_utils import podman_compose_path
+from tests.integration.test_utils import test_path
+
+
+def compose_yaml_path() -> str:
+    """ "Returns the path to the compose file used for this test module"""
+    base_path = os.path.join(test_path(), "commands_fail_exit_code")
+    return os.path.join(base_path, "docker-compose.yml")
+
+
+class TestConfigCommand(unittest.TestCase, RunSubprocessMixin):
+    def test_config_quiet(self) -> None:
+        """
+        Tests podman-compose config command with the --quiet flag.
+        """
+        config_cmd = [
+            "coverage",
+            "run",
+            podman_compose_path(),
+            "-f",
+            compose_yaml_path(),
+            "config",
+            "--quiet",
+        ]
+
+        out, _ = self.run_subprocess_assert_returncode(config_cmd)
+        self.assertEqual(out.decode("utf-8"), "")

--- a/tests/integration/profile/test_podman_compose_config.py
+++ b/tests/integration/profile/test_podman_compose_config.py
@@ -80,20 +80,3 @@ class TestComposeConfig(unittest.TestCase, RunSubprocessMixin):
             actual_services[service] = service in actual_output
 
         self.assertEqual(expected_services, actual_services)
-
-    def test_config_quiet(self) -> None:
-        """
-        Tests podman-compose config command with the --quiet flag.
-        """
-        config_cmd = [
-            "coverage",
-            "run",
-            podman_compose_path(),
-            "-f",
-            profile_compose_file(),
-            "config",
-            "--quiet",
-        ]
-
-        out, _ = self.run_subprocess_assert_returncode(config_cmd)
-        self.assertEqual(out.decode("utf-8"), "")


### PR DESCRIPTION
`podman-compose config` command lacked a dedicated integration-test file.
