### PR TITLE
Add subpath support to volumes  with type volume in `--mount` 

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -428,7 +428,8 @@ async def assert_volume(compose: PodmanCompose, mount_dict: dict[str, Any]) -> N
     # podman volume list --format '{{.Name}}\t{{.MountPoint}}' \
     #     -f 'label=io.podman.compose.project=HERE'
     try:
-        _ = (await compose.podman.output([], "volume", ["inspect", vol_name])).decode("utf-8")
+        await compose.podman.output([], "volume", ["inspect", vol_name])
+
     except subprocess.CalledProcessError as e:
         if is_ext:
             raise RuntimeError(f"External volume [{vol_name}] does not exist") from e
@@ -450,7 +451,7 @@ async def assert_volume(compose: PodmanCompose, mount_dict: dict[str, Any]) -> N
             args.extend(["--opt", f"{opt}={value}"])
         args.append(vol_name)
         await compose.podman.output([], "volume", args)
-        _ = (await compose.podman.output([], "volume", ["inspect", vol_name])).decode("utf-8")
+        await compose.podman.output([], "volume", ["inspect", vol_name])
 
 
 def mount_desc_to_mount_args(mount_desc: dict[str, Any]) -> str:


### PR DESCRIPTION
To allow subpath mount as describes in [Compose Specs](https://github.com/compose-spec/compose-spec/blob/main/05-services.md), in complement of #1336

Fixes #1188

Compose entries exemple:
```yaml
    - type: volume 
      source: webservices
      target: /srv/www/vhosts/server1
      read_only: true
      volume: 
         subpath: server1
    - type: volume 
      source: webservices
      target: /srv/www/vhosts/server2
      read_only: true
      volume:
          subpath: server2
    - type: volume
      source: webservices
      target: /srv/www/vhosts/server2/uploads
      read_only: false
      volume: 
          subpath: server2/uploads
```

Runs podman with options

    --mount type=volume,source=webservices,target=/srv/www/vhosts/server1,ro
    --mount type=volume,source=webservices,target=/srv/www/vhosts/server2,ro,subpath=server2
    --mount type=volume,source=webservices,target=/srv/www/vhosts/server2/uploads,subpath=server2/uploads


## Contributor Checklist:

If this PR adds a new feature that improves compatibility with docker-compose, please add a link
to the exact part of compose spec that the PR touches.

For any user-visible change please add a release note to newsfragments directory, e.g.
newsfragments/my_feature.feature. See newsfragments/README.md for more details.

All changes require additional unit tests.
