### PR TITLE
feat: Add pod_network setting for pod network inheritance

### DIFF
--- a/newsfragments/pod_network_inheritance.feature
+++ b/newsfragments/pod_network_inheritance.feature
@@ -1,0 +1,1 @@
+Add x-podman.pod_network setting to enable pod network inheritance for external/macvlan networks.

--- a/tests/unit/test_container_to_args.py
+++ b/tests/unit/test_container_to_args.py
@@ -23,6 +23,8 @@ def create_compose_mock(project_name: str = "test_project_name") -> PodmanCompos
     compose.x_podman = {}
     compose.join_name_parts = mock.Mock(side_effect=lambda *args: '_'.join(args))
     compose.format_name = mock.Mock(side_effect=lambda *args: '_'.join([project_name, *args]))
+    # Default behavior: don't inherit network from pod (backwards compatible)
+    compose.should_inherit_net_from_pod = mock.Mock(return_value=False)
 
     async def podman_output(*args: Any, **kwargs: Any) -> None:
         pass


### PR DESCRIPTION
When using pods with external networks (such as macvlan for routable IPs), containers need to inherit the pod's network namespace rather than having their own network configuration. Previously, podman-compose always added --network=<project>_default to container commands, which overrode podman's automatic network namespace inheritance from the pod.

This change adds a new x-podman.pod_network setting that:
1. Specifies the network to attach to the pod during creation
2. Skips adding --network to container commands when containers should inherit from the pod

The feature enables use cases like:
- Macvlan networks where the pod has a routable LAN IP
- External networks managed outside of compose
- Containers that need to share localhost within the pod

Usage in docker-compose.yml:
```yaml
x-podman:
  pod_network: my_external_network
  pod_args: "--infra=true --share=ipc,net"

services:
  myservice:
    image: myimage
    # No 'networks' or 'network_mode' - inherits from pod
```

The container will only inherit from pod when:
- pod_network is configured
- Container is assigned to a pod
- Container has no explicit network_mode or networks configuration
