### PR TITLE
Fix merging of dicts into empty tags

### DIFF
--- a/newsfragments/map-merge.bugfix
+++ b/newsfragments/map-merge.bugfix
@@ -1,0 +1,1 @@
+Fix crash on merging named volumes with driver options into the uncustomized named volumes

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1941,6 +1941,14 @@ def rec_merge_one(target: dict[str, Any], source: dict[str, Any]) -> dict[str, A
             target[key] = clone(value2)
             continue
 
+        # We can merge dicts into an empty tag. E.g.:
+        # vol_1:
+        # and
+        # vol_1:
+        #   driver: "abcdef"
+        if value is None and isinstance(value2, dict):
+            target[key] = value = {}
+
         if not isinstance(value2, type(value)):
             value_type = type(value)
             value2_type = type(value2)

--- a/tests/unit/test_can_merge_build.py
+++ b/tests/unit/test_can_merge_build.py
@@ -97,6 +97,27 @@ class TestCanMergeBuild(unittest.TestCase):
             )
         self.assertEqual(actual_compose, expected)
 
+    def test_parse_with_map_merge_into_none(self):
+        compose_test_1 = {"volumes": {"vol_a": None}}
+        compose_test_2 = {
+            "volumes": {
+                "vol_a": {
+                    "driver_opts": {"type": "none", "device": "/dev/some", "o": "bind"},
+                }
+            }
+        }
+        expected = {"driver_opts": {"device": "/dev/some", "o": "bind", "type": "none"}}
+        dump_yaml(compose_test_1, "test-compose-1.yaml")
+        dump_yaml(compose_test_2, "test-compose-2.yaml")
+
+        podman_compose = PodmanCompose()
+        set_args(podman_compose, ["test-compose-1.yaml", "test-compose-2.yaml"])
+
+        podman_compose._parse_compose_file()  # pylint: disable=protected-access
+
+        actual_compose = podman_compose.vols["vol_a"]
+        self.assertEqual(actual_compose, expected)
+
     # $$$ is a placeholder for either command or entrypoint
     @parameterized.expand([
         ({}, {"$$$": []}, {"$$$": []}),


### PR DESCRIPTION
Docker Compose specification doesn't describe the behavior of merging into the empty tags. This can happen if the source YAML file has named volumes without any customizations:

```
volumes:
  vol_a:
  vol_b:
```

and the override file adds customizations for these volumes:

```
volumes:
  vol_a:
    driver: "something"
    opts: "anything"
```

Docker-Compose handles this properly, podman-compose crashes with an exception.
