### PR TITLE
logs: Implement colorful service names for `logs` command

### DIFF
--- a/newsfragments/add_logs_colors.bugfix
+++ b/newsfragments/add_logs_colors.bugfix
@@ -1,0 +1,1 @@
+Implement colored, service-name-only default for `logs` command.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -3923,6 +3923,8 @@ async def compose_logs(compose: PodmanCompose, args: argparse.Namespace) -> None
         podman_args.append("-l")
     if args.names:
         podman_args.append("-n")
+    if not args.no_color:
+        podman_args.append("--color")
     if args.since:
         podman_args.extend(["--since", args.since])
     # the default value is to print all logs which is in podman = 0 and not

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -3908,14 +3908,14 @@ async def compose_restart(compose: PodmanCompose, args: argparse.Namespace) -> N
 
 
 @cmd_run(podman_compose, "logs", "show logs from services")
-async def compose_logs(compose: PodmanCompose, args: argparse.Namespace) -> None:
+async def compose_logs(
+    compose: PodmanCompose, args: argparse.Namespace, log_formatter: str | None = None
+) -> None:
     container_names_by_service = compose.container_names_by_service
     if not args.services and not args.latest:
         args.services = container_names_by_service.keys()
     compose.assert_services(args.services)
-    targets = []
-    for service in args.services:
-        targets.extend(container_names_by_service[service])
+
     podman_args = []
     if args.follow:
         podman_args.append("-f")
@@ -3935,9 +3935,30 @@ async def compose_logs(compose: PodmanCompose, args: argparse.Namespace) -> None
         podman_args.append("-t")
     if args.until:
         podman_args.extend(["--until", args.until])
-    for target in targets:
-        podman_args.append(target)
-    await compose.podman.run([], "logs", podman_args)
+
+    max_service_length = 0
+    tasks = []
+    max_service_length = max(len(service) for service in args.services)
+    for i, service in enumerate(args.services):
+        # Add colored service prefix to output by piping output through sed
+        if args.no_log_prefix:
+            log_formatter = None
+        else:
+            color_idx = i % len(compose.console_colors)
+            if args.no_color:  # monochrome output
+                color = '\x1b[0m'
+            else:
+                color = compose.console_colors[color_idx]
+            space_suffix = " " * (max_service_length - len(service) + 1)
+            log_formatter = f"{color}[{service}]{space_suffix}|\x1b[0m"
+
+        podman_args_with_target = podman_args + container_names_by_service[service]
+        tasks.append(
+            asyncio.create_task(
+                compose.podman.run([], "logs", podman_args_with_target, log_formatter=log_formatter)
+            )
+        )
+    await asyncio.gather(*tasks)
 
 
 @cmd_run(podman_compose, "config", "displays the compose file")
@@ -4386,6 +4407,11 @@ def compose_logs_parse(parser: argparse.ArgumentParser) -> None:
         help="Output the container name in the log",
     )
     parser.add_argument("--no-color", action="store_true", help="Produce monochrome output")
+    parser.add_argument(
+        "--no-log-prefix",
+        action="store_true",
+        help="Don't print prefix with container identifier in logs",
+    )
     parser.add_argument("--since", help="Show logs since TIMESTAMP", type=str, default=None)
     parser.add_argument("-t", "--timestamps", action="store_true", help="Show timestamps.")
     parser.add_argument(

--- a/tests/integration/env_file_tests/test_podman_compose_env_file.py
+++ b/tests/integration/env_file_tests/test_podman_compose_env_file.py
@@ -31,6 +31,8 @@ class TestComposeEnvFile(unittest.TestCase, RunSubprocessMixin):
                 "-f",
                 path_compose_file,
                 "logs",
+                "--no-log-prefix",
+                "--no-color",
             ])
             # takes only value ZZVAR1 as container-compose.yaml file requires
             self.assertEqual(output, b"ZZVAR1=podman-rocks-123\n")
@@ -59,6 +61,8 @@ class TestComposeEnvFile(unittest.TestCase, RunSubprocessMixin):
                 "-f",
                 path_compose_file,
                 "logs",
+                "--no-log-prefix",
+                "--no-color",
             ])
             # takes all values with a substring ZZ as container-compose.env-file-flat.yaml
             # file requires
@@ -91,6 +95,8 @@ class TestComposeEnvFile(unittest.TestCase, RunSubprocessMixin):
                 "-f",
                 path_compose_file,
                 "logs",
+                "--no-log-prefix",
+                "--no-color",
             ])
             # takes all values with a substring ZZ as container-compose.env-file-obj.yaml
             # file requires
@@ -125,6 +131,8 @@ class TestComposeEnvFile(unittest.TestCase, RunSubprocessMixin):
                 "-f",
                 path_compose_file,
                 "logs",
+                "--no-log-prefix",
+                "--no-color",
             ])
             # FIXME: gives a weird output, needs to be double checked
             self.assertEqual(
@@ -158,6 +166,8 @@ class TestComposeEnvFile(unittest.TestCase, RunSubprocessMixin):
                 "-f",
                 path_compose_file,
                 "logs",
+                "--no-log-prefix",
+                "--no-color",
             ])
             # takes all values with a substring ZZ as container-compose.env-file-obj-optional.yaml
             # file requires
@@ -193,6 +203,8 @@ class TestComposeEnvFile(unittest.TestCase, RunSubprocessMixin):
                 "-f",
                 path_compose_file,
                 "logs",
+                "--no-log-prefix",
+                "--no-color",
             ])
             # takes only value ZZVAR1 as container-compose.yaml file requires
             self.assertEqual(output, b"ZZVAR1=podman-rocks-321\n")
@@ -267,6 +279,8 @@ class TestComposeEnvFile(unittest.TestCase, RunSubprocessMixin):
                 "-f",
                 compose_file_path,
                 "logs",
+                "--no-log-prefix",
+                "--no-color",
             ])
             # ZZVAR3 was set in .env file
             self.assertEqual(output, b"ZZVAR3=TEST\n")

--- a/tests/integration/extends/test_podman_compose_extends.py
+++ b/tests/integration/extends/test_podman_compose_extends.py
@@ -27,6 +27,8 @@ class TestComposeExteds(unittest.TestCase, RunSubprocessMixin):
                 "-f",
                 compose_yaml_path(),
                 "logs",
+                "--no-log-prefix",
+                "--no-color",
                 "echo",
             ])
             self.assertEqual(output, b"Zero\n")
@@ -52,6 +54,8 @@ class TestComposeExteds(unittest.TestCase, RunSubprocessMixin):
                 "-f",
                 compose_yaml_path(),
                 "logs",
+                "--no-log-prefix",
+                "--no-color",
                 "echo1",
             ])
             self.assertEqual(output, b"One\n")
@@ -77,6 +81,8 @@ class TestComposeExteds(unittest.TestCase, RunSubprocessMixin):
                 "-f",
                 compose_yaml_path(),
                 "logs",
+                "--no-log-prefix",
+                "--no-color",
                 "env1",
             ])
             lines = output.decode('utf-8').split('\n')

--- a/tests/integration/filesystem/test_podman_compose_filesystem.py
+++ b/tests/integration/filesystem/test_podman_compose_filesystem.py
@@ -32,6 +32,8 @@ class TestFilesystem(unittest.TestCase, RunSubprocessMixin):
                 "-f",
                 compose_path,
                 "logs",
+                "--no-log-prefix",
+                "--no-color",
                 "container1",
             ])
 

--- a/tests/integration/lifetime/test_lifetime.py
+++ b/tests/integration/lifetime/test_lifetime.py
@@ -42,6 +42,8 @@ class TestLifetime(unittest.TestCase, RunSubprocessMixin):
                 "-f",
                 compose_path,
                 "logs",
+                "--no-log-prefix",
+                "--no-color",
                 "container1",
             ])
 
@@ -52,6 +54,8 @@ class TestLifetime(unittest.TestCase, RunSubprocessMixin):
                 "-f",
                 compose_path,
                 "logs",
+                "--no-log-prefix",
+                "--no-color",
                 "container2",
             ])
 
@@ -100,6 +104,8 @@ class TestLifetime(unittest.TestCase, RunSubprocessMixin):
                 "-f",
                 compose_path,
                 "logs",
+                "--no-log-prefix",
+                "--no-color",
                 "container1",
             ])
 
@@ -111,6 +117,8 @@ class TestLifetime(unittest.TestCase, RunSubprocessMixin):
                 "-f",
                 compose_path,
                 "logs",
+                "--no-log-prefix",
+                "--no-color",
                 "container2",
             ])
 
@@ -121,6 +129,8 @@ class TestLifetime(unittest.TestCase, RunSubprocessMixin):
                     "-f",
                     compose_path,
                     "logs",
+                    "--no-log-prefix",
+                    "--no-color",
                     "container2",
                 ])
             self.assertTrue(out.startswith(b"test2\ntest2"))

--- a/tests/integration/logs/docker-compose.yml
+++ b/tests/integration/logs/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3"
+services:
+  test1:
+    image: busybox
+    command: ["echo", "test1"]
+  test2:
+    image: busybox
+    command: ["echo", "test2"]
+  test3:
+    image: busybox
+    command: ["echo", "test3"]

--- a/tests/integration/logs/test_podman_compose_logs.py
+++ b/tests/integration/logs/test_podman_compose_logs.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: GPL-2.0
+
+
+import os
+import unittest
+
+from parameterized import parameterized
+
+from tests.integration.test_utils import RunSubprocessMixin
+from tests.integration.test_utils import podman_compose_path
+from tests.integration.test_utils import test_path
+
+
+class TestLogs(unittest.TestCase, RunSubprocessMixin):
+    @parameterized.expand([
+        (
+            "all_services_no_flag",
+            [],
+            [
+                b'',
+                b'\x1b[1;32m[test1] |\x1b[0m \x1b[37mtest1\x1b[0m',
+                b'\x1b[1;33m[test2] |\x1b[0m \x1b[37mtest2\x1b[0m',
+                b'\x1b[1;34m[test3] |\x1b[0m \x1b[37mtest3\x1b[0m',
+            ],
+        ),
+        (
+            "all_services_flag_no_color",
+            ["--no-color"],
+            [
+                b'',
+                b'\x1b[0m[test1] |\x1b[0m test1',
+                b'\x1b[0m[test2] |\x1b[0m test2',
+                b'\x1b[0m[test3] |\x1b[0m test3',
+            ],
+        ),
+        (
+            "all_services_flag_no_log_prefix",
+            ["--no-log-prefix"],
+            [b'', b'\x1b[37mtest1\x1b[0m', b'\x1b[37mtest2\x1b[0m', b'\x1b[37mtest3\x1b[0m'],
+        ),
+        (
+            "all_services_flag_no_color_no_log_prefix",
+            ["--no-color", "--no-log-prefix"],
+            [b'', b'test1', b'test2', b'test3'],
+        ),
+        (
+            "one_service_no_flag",
+            ["test1"],
+            [b'', b'\x1b[1;32m[test1] |\x1b[0m \x1b[37mtest1\x1b[0m'],
+        ),
+        (
+            "one_service_flag_no_color",
+            ["test1", "--no-color"],
+            [b'', b'\x1b[0m[test1] |\x1b[0m test1'],
+        ),
+        (
+            "one_service_flag_no_log_prefix",
+            ["test1", "--no-log-prefix"],
+            [b'', b'\x1b[37mtest1\x1b[0m'],
+        ),
+        (
+            "one_service_flag_no_color_no_log_prefix",
+            ["test1", "--no-color", "--no-log-prefix"],
+            [b'', b'test1'],
+        ),
+        (
+            "two_services_no_flag",
+            ["test2", "test3"],
+            [
+                b'',
+                b'\x1b[1;32m[test2] |\x1b[0m \x1b[37mtest2\x1b[0m',
+                b'\x1b[1;33m[test3] |\x1b[0m \x1b[37mtest3\x1b[0m',
+            ],
+        ),
+        (
+            "two_services_flag_no_color",
+            ["test2", "test3", "--no-color"],
+            [b'', b'\x1b[0m[test2] |\x1b[0m test2', b'\x1b[0m[test3] |\x1b[0m test3'],
+        ),
+        (
+            "two_services_flag_no_log_prefix",
+            ["test2", "test3", "--no-log-prefix"],
+            [b'', b'\x1b[37mtest2\x1b[0m', b'\x1b[37mtest3\x1b[0m'],
+        ),
+        (
+            "two_services_flag_no_color_no_log_prefix",
+            ["test2", "test3", "--no-color", "--no-log-prefix"],
+            [b'', b'test2', b'test3'],
+        ),
+    ])
+    def test_logs(
+        self, test_name: str, additional_args: list[str], expected_log: list[bytes]
+    ) -> None:
+        compose_path = os.path.join(test_path(), "logs/docker-compose.yml")
+
+        try:
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_path,
+                "up",
+                "-d",
+            ])
+            command_args = [
+                podman_compose_path(),
+                "-f",
+                compose_path,
+                "logs",
+            ]
+            command_args.extend(additional_args)
+            out, _ = self.run_subprocess_assert_returncode(command_args)
+            lines = out.split(b'\n')
+            lines.sort()
+            self.assertEqual(lines, expected_log)
+        finally:
+            out, _ = self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_path,
+                "down",
+            ])

--- a/tests/integration/merge/reset_and_override_tags/override_tag_attribute/test_podman_compose_override_tag_attribute.py
+++ b/tests/integration/merge/reset_and_override_tags/override_tag_attribute/test_podman_compose_override_tag_attribute.py
@@ -40,6 +40,8 @@ class TestComposeOverrideTagAttribute(unittest.TestCase, RunSubprocessMixin):
                 "-f",
                 override_file,
                 "logs",
+                "--no-log-prefix",
+                "--no-color",
             ])
             self.assertEqual(output, b"One\n")
 

--- a/tests/integration/merge/reset_and_override_tags/override_tag_service/test_podman_compose_override_tag_service.py
+++ b/tests/integration/merge/reset_and_override_tags/override_tag_service/test_podman_compose_override_tag_service.py
@@ -42,6 +42,8 @@ class TestComposeOverrideTagService(unittest.TestCase, RunSubprocessMixin):
                 "-f",
                 override_file,
                 "logs",
+                "--no-log-prefix",
+                "--no-color",
             ])
             self.assertEqual(output, b"One\n")
 

--- a/tests/integration/merge/reset_and_override_tags/reset_tag_service/test_podman_compose_reset_tag_service.py
+++ b/tests/integration/merge/reset_and_override_tags/reset_tag_service/test_podman_compose_reset_tag_service.py
@@ -51,6 +51,8 @@ class TestComposeResetTagService(unittest.TestCase, RunSubprocessMixin):
                 "-f",
                 reset_file,
                 "logs",
+                "--no-log-prefix",
+                "--no-color",
             ])
             self.assertEqual(output, b"One\n")
         finally:

--- a/tests/integration/testlogs/docker-compose.yml
+++ b/tests/integration/testlogs/docker-compose.yml
@@ -1,9 +1,0 @@
-version: "3"
-services:
-    loop1:
-      image: busybox
-      command: ["/bin/sh", "-c", "for i in `seq 1 10000`; do echo \"loop1: $$i\"; sleep 1; done"]
-    loop2:
-      image: busybox
-      command: ["/bin/sh", "-c", "for i in `seq 1 10000`; do echo \"loop2: $$i\"; sleep 3; done"]
-


### PR DESCRIPTION
The `logs` command now displays short service names in color by default (the project-name prefix has been removed). An option has been added to either render service names in monochrome or omit them entirely. 

This update improves compatibility of the `logs` command with `docker-compose`. For relevant documentation, see:  https://docs.docker.com/reference/cli/docker/compose/logs/

Fixes: https://github.com/containers/podman-compose/issues/1355, https://github.com/containers/podman-compose/issues/111.