### PR TITLE
Improve error message for missing variables in `${VAR?err}` syntax

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -305,7 +305,7 @@ def rec_subs(value: dict | str | Iterable, subs_dict: dict[str, Any]) -> dict | 
             if value is not None:
                 return str(value)
             if m.group("err") is not None:
-                raise RuntimeError(m.group("err"))
+                raise RuntimeError(f"Variable '{name}' missing: {m.group('err')}")
             return m.group("default") or ""
 
         value = var_re.sub(convert, value)


### PR DESCRIPTION
When using Bash-style variable substitution with error enforcement (e.g., `${MY_VAR?Variable not set}`), `podman-compose` raises a `RuntimeError` if the variable is missing.

Currently, this error only contains the custom error text provided in the string (e.g., `"Variable not set"`). It does not indicate **which** variable triggered the error. In large `docker-compose.yml` files with many required variables, this makes debugging impossible without modifying the source code.

This PR updates the `RuntimeError` to prepend the variable name to the error message.

*   **Before:** `RuntimeError: Variable not set`
*   **After:** `RuntimeError: Variable 'OPENSEARCH_ADMIN_PASSWORD': Variable not set`