### PR TITLE
fix: allow users to specify file after build, up, down... subcommand

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -4487,6 +4487,14 @@ def compose_build_up_parse(parser: argparse.ArgumentParser) -> None:
 @cmd_parse(podman_compose, ["build", "up", "down", "start", "stop", "restart"])
 def compose_build_parse(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
+        "-f",
+        "--file",
+        help="Specify an compose file (default: docker-compose.yml) or '-' to read from stdin.",
+        metavar="file",
+        action="append",
+        default=[],
+    )
+    parser.add_argument(
         "services",
         metavar="services",
         nargs="*",


### PR DESCRIPTION
Allow users to specify `-f` after sub command for `build, up, down, start, stop, restart`

It could be worth exploring a more expressive CLI framework such as [click](https://click.palletsprojects.com/en/stable/commands-and-groups/). It supports flags cascading down etc.