### PR TITLE
feat: allow multiple `--env-file` flags

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2302,7 +2302,7 @@ class PodmanCompose:
 
         # env-file is relative to the CWD
         dotenv_dict = {}
-        if len(args.env_file) == 0:
+        if args.env_file is None or len(args.env_file) == 0:
             # Load .env from the Compose file's directory to preserve
             # behavior prior to 1.1.0 and to match with Docker Compose (v2).
             project_dotenv_file = os.path.realpath(os.path.join(dirname, ".env"))

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2302,15 +2302,16 @@ class PodmanCompose:
 
         # env-file is relative to the CWD
         dotenv_dict = {}
-        if args.env_file:
+        if len(args.env_file) == 0:
             # Load .env from the Compose file's directory to preserve
             # behavior prior to 1.1.0 and to match with Docker Compose (v2).
-            if ".env" == args.env_file:
-                project_dotenv_file = os.path.realpath(os.path.join(dirname, ".env"))
-                if os.path.exists(project_dotenv_file):
-                    dotenv_dict.update(dotenv_to_dict(project_dotenv_file))
-            dotenv_path = os.path.realpath(args.env_file)
-            dotenv_dict.update(dotenv_to_dict(dotenv_path))
+            project_dotenv_file = os.path.realpath(os.path.join(dirname, ".env"))
+            if os.path.exists(project_dotenv_file):
+                dotenv_dict.update(dotenv_to_dict(project_dotenv_file))
+        else:
+            for env_file in args.env_file:
+                dotenv_path = os.path.realpath(env_file)
+                dotenv_dict.update(dotenv_to_dict(dotenv_path))
 
         os.environ.update({
             key: value  # type: ignore[misc]
@@ -2689,8 +2690,8 @@ class PodmanCompose:
             "--env-file",
             help="Specify an alternate environment file",
             metavar="env_file",
-            type=str,
-            default=".env",
+            action="append",
+            default=[],
         )
         parser.add_argument(
             "-f",

--- a/tests/integration/env_file_tests/env-files/project-2.env
+++ b/tests/integration/env_file_tests/env-files/project-2.env
@@ -1,3 +1,2 @@
 ZZVAR1=podman-rocks-223
 ZZVAR2=podman-rocks-224
-ZZVAR4=podman-rocks-225

--- a/tests/integration/env_file_tests/env-files/project-2.env
+++ b/tests/integration/env_file_tests/env-files/project-2.env
@@ -1,2 +1,3 @@
 ZZVAR1=podman-rocks-223
 ZZVAR2=podman-rocks-224
+ZZVAR4=podman-rocks-225

--- a/tests/integration/env_file_tests/project/container-compose.yaml
+++ b/tests/integration/env_file_tests/project/container-compose.yaml
@@ -7,3 +7,4 @@ services:
       - /tmp
     environment:
       ZZVAR1: $ZZVAR1
+      ZZVAR4: $ZZVAR4

--- a/tests/integration/env_file_tests/project/container-compose.yaml
+++ b/tests/integration/env_file_tests/project/container-compose.yaml
@@ -7,4 +7,4 @@ services:
       - /tmp
     environment:
       ZZVAR1: $ZZVAR1
-      ZZVAR4: $ZZVAR4
+      ZZVAR3: $ZZVAR3

--- a/tests/integration/env_file_tests/test_podman_compose_env_file.py
+++ b/tests/integration/env_file_tests/test_podman_compose_env_file.py
@@ -35,7 +35,7 @@ class TestComposeEnvFile(unittest.TestCase, RunSubprocessMixin):
                 "--no-color",
             ])
             # takes only value ZZVAR1 as container-compose.yaml file requires
-            self.assertEqual(output, b"ZZVAR1=podman-rocks-123\n")
+            self.assertEqual(output, b"ZZVAR1=podman-rocks-123\nZZVAR3=podman-rocks-125\n")
         finally:
             self.run_subprocess_assert_returncode([
                 podman_compose_path(),
@@ -66,7 +66,7 @@ class TestComposeEnvFile(unittest.TestCase, RunSubprocessMixin):
                 "logs",
             ])
             # takes only value ZZVAR1 as container-compose.yaml file requires
-            self.assertEqual(output, b"ZZVAR1=podman-rocks-223\nZZVAR4=podman-rocks-225\n")
+            self.assertEqual(output, b"ZZVAR1=podman-rocks-223\nZZVAR3=podman-rocks-125\n")
         finally:
             self.run_subprocess_assert_returncode([
                 podman_compose_path(),
@@ -238,7 +238,7 @@ class TestComposeEnvFile(unittest.TestCase, RunSubprocessMixin):
                 "--no-color",
             ])
             # takes only value ZZVAR1 as container-compose.yaml file requires
-            self.assertEqual(output, b"ZZVAR1=podman-rocks-321\n")
+            self.assertEqual(output, b"ZZVAR1=podman-rocks-321\nZZVAR3=podman-rocks-125\n")
         finally:
             self.run_subprocess_assert_returncode([
                 podman_compose_path(),

--- a/tests/integration/env_file_tests/test_podman_compose_env_file.py
+++ b/tests/integration/env_file_tests/test_podman_compose_env_file.py
@@ -44,6 +44,37 @@ class TestComposeEnvFile(unittest.TestCase, RunSubprocessMixin):
                 "down",
             ])
 
+    def test_path_env_file_inline_many(self) -> None:
+        # Test taking env variable value directly from env-file when its path is inline path
+        base_path = compose_base_path()
+        path_compose_file = os.path.join(base_path, "project/container-compose.yaml")
+        try:
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                path_compose_file,
+                "--env-file",
+                os.path.join(base_path, "env-files/project-1.env"),
+                "--env-file",
+                os.path.join(base_path, "env-files/project-2.env"),
+                "up",
+            ])
+            output, _ = self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                path_compose_file,
+                "logs",
+            ])
+            # takes only value ZZVAR1 as container-compose.yaml file requires
+            self.assertEqual(output, b"ZZVAR1=podman-rocks-123\nZZVAR4=podman-rocks-225\n")
+        finally:
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                path_compose_file,
+                "down",
+            ])
+
     def test_path_env_file_flat_in_compose_file(self) -> None:
         # Test taking env variable value from env-file/project-1.env which was declared in
         # compose file's env_file

--- a/tests/integration/env_file_tests/test_podman_compose_env_file.py
+++ b/tests/integration/env_file_tests/test_podman_compose_env_file.py
@@ -64,6 +64,8 @@ class TestComposeEnvFile(unittest.TestCase, RunSubprocessMixin):
                 "-f",
                 path_compose_file,
                 "logs",
+                "--no-log-prefix",
+                "--no-color",
             ])
             # takes only value ZZVAR1 as container-compose.yaml file requires
             self.assertEqual(output, b"ZZVAR1=podman-rocks-223\nZZVAR3=podman-rocks-125\n")

--- a/tests/integration/env_file_tests/test_podman_compose_env_file.py
+++ b/tests/integration/env_file_tests/test_podman_compose_env_file.py
@@ -66,7 +66,7 @@ class TestComposeEnvFile(unittest.TestCase, RunSubprocessMixin):
                 "logs",
             ])
             # takes only value ZZVAR1 as container-compose.yaml file requires
-            self.assertEqual(output, b"ZZVAR1=podman-rocks-123\nZZVAR4=podman-rocks-225\n")
+            self.assertEqual(output, b"ZZVAR1=podman-rocks-223\nZZVAR4=podman-rocks-225\n")
         finally:
             self.run_subprocess_assert_returncode([
                 podman_compose_path(),


### PR DESCRIPTION
Allow multiple `--env-file` flags as docker compose do. Merge each file, the later taking precedence. 