### PR TITLE
Fix orphan removal: use getattr

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -3667,7 +3667,7 @@ async def compose_down(compose: PodmanCompose, args: argparse.Namespace) -> None
         await compose.podman.run([], "rm", [cnt["name"]])
 
     orphaned_images = set()
-    if args.remove_orphans:
+    if getattr(args, 'remove_orphans', False):
         orphaned_containers = (
             (
                 await compose.podman.output(


### PR DESCRIPTION
When exiting podman compose by repeating ctrl+C rapidly, its state may get corrupt and no longer have the remove_orphans attribute. This broke podman compose for me.


## Contributor Checklist:

If this PR adds a new feature that improves compatibility with docker-compose, please add a link
to the exact part of compose spec that the PR touches.

For any user-visible change please add a release note to newsfragments directory, e.g.
newsfragments/my_feature.feature. See newsfragments/README.md for more details.

All changes require additional unit tests.
