### PR TITLE
fix: handle non-UTF8 data in container output streams gracefully

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1644,10 +1644,10 @@ class Podman:
             for i, part in enumerate(parts):
                 # Iff part is last and non-empty, we leave an ongoing line to be completed later
                 if i < len(parts) - 1:
-                    _formatted_print_with_nl(part.decode())
+                    _formatted_print_with_nl(part.decode(errors='ignore'))
                     line_ongoing = False
                 elif len(part) > 0:
-                    _formatted_print_without_nl(part.decode())
+                    _formatted_print_without_nl(part.decode(errors='ignore'))
                     line_ongoing = True
         if line_ongoing:
             # Make sure the last line ends with EOL


### PR DESCRIPTION
## Summary
Prevents `UnicodeDecodeError` when containers output binary or invalid UTF-8 data to stdout/stderr, which was causing podman-compose to hang and fail.

## Problem
When containers write binary data or non-UTF8 sequences to their output streams (e.g., logging errors from remote hardware that include binary data), podman-compose crashes with:
```python
UnicodeDecodeError: 'utf-8' codec can't decode bytes in position 73726-73727: unexpected end of data
  File "/usr/lib/python3.9/site-packages/podman_compose.py", line 1608, in _format_stream
    _formatted_print_without_nl(part.decode())
```

This error causes the container to hang in a write syscall because the pipe buffer fills up when podman-compose stops reading.

## Solution
Added `errors='ignore'` parameter to both `decode()` calls (lines 1647 and 1650), which safely discards invalid UTF-8 sequences instead of raising an exception. This matches the behavior of podman-compose 1.0.6 where this issue did not occur.

## Testing
The issue reporter provided a complete reproduction case and confirmed the fix resolves the problem. The fix has been tested with containers that deliberately output binary data.

Fixes #1374