### PR TITLE
Fix typos and other mistakes in `podman-compose`

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,5 +1,5 @@
 [MESSAGES CONTROL]
-# C0111 missing-docstring: missing-class-docstring, missing-function-docstring, missing-method-docstring, missing-module-docstrin
+# C0111 missing-docstring: missing-class-docstring, missing-function-docstring, missing-method-docstring, missing-module-docstring
 # consider-using-with: we need it for color formatter pipe
 disable=too-many-lines,too-many-branches,too-many-locals,too-many-statements,too-many-arguments,too-many-instance-attributes,fixme,multiple-statements,missing-docstring,line-too-long,consider-using-f-string,consider-using-with,unnecessary-lambda-assignment,broad-exception-caught
 # allow _ for ignored variables

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ Note: Some steps are OPTIONAL but all are RECOMMENDED.
 To add a command, you need to add a function that is decorated with `@cmd_run`.
 
 The decorated function must be declared `async` and should accept two arguments: The compose
-instance and the command-specific arguments (resulted from the Python's `argparse` package).
+instance and the command-specific arguments (resulting from Python's `argparse` package).
 
 In this function, you can run Podman (e.g. `await compose.podman.run(['inspect', 'something'])`),
 access `compose.pods`, `compose.containers` etc.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Install the latest stable version from PyPI:
 pip3 install podman-compose
 ```
 
-pass `--user` to install inside regular user home without being root.
+pass `--user` to install inside a regular user's home without being root.
 
 Or latest development version from GitHub:
 

--- a/docs/Changelog-1.1.0.md
+++ b/docs/Changelog-1.1.0.md
@@ -8,7 +8,7 @@ Bug fixes
 - Fixed duplicate arguments being emitted in `stop` and `restart` commands.
 - Removed extraneous debug output. `--verbose` flag has been added to preserve verbose output.
 - Links aliases are now added to service aliases.
-- Fixed image build process to use defined environmental variables.
+- Fixed image build process to use defined environment variables.
 - Empty list is now allowed to be `COMMAND` and `ENTRYPOINT`.
 - Environment files are now resolved relative to current working directory.
 - Exit code of container build is now preserved as return code of `build` command.

--- a/docs/Changelog-1.2.0.md
+++ b/docs/Changelog-1.2.0.md
@@ -31,7 +31,7 @@ New features
 - Added support for multi-line environment files.
 - Added support for passing contents of `podman-compose.yml` via stdin.
 - Added support for specifying the value for `--in-pod` setting in `podman-compose.yml` file.
-- Added support for environmental secrets.
+- Added support for environment secrets.
 
 Documentation
 -------------

--- a/docs/Changelog-1.3.0.md
+++ b/docs/Changelog-1.3.0.md
@@ -30,7 +30,7 @@ Features
 - Added support for removing networks in `podman-compose down`.
 - Added support for network scoped service aliases.
 - Added support for network level `mac_address` attribute.
-- Added ability to substitute variables with the environment of the service.
+- Added the ability to substitute variables with the environment of the service.
 
 Misc
 ----

--- a/docs/Changelog-1.4.0.md
+++ b/docs/Changelog-1.4.0.md
@@ -30,7 +30,7 @@ Features
 - Added `--rmi` argument to `down` command for image removal
 - Added support for `x-podman.disable-dns` to disable DNS plugin on defined networks
 - Added support for `x-podman.dns` to set DNS nameservers for defined networks
-- Improved file descriptor handling - no longer closes externally created descriptors.
+- Improved file descriptor handling by no longer closing externally created descriptors.
   This allows descriptors created e.g. via systemd socket activation to be passed to
   containers.
 - Added support for `cpuset` configuration

--- a/docs/Changelog-1.5.0.md
+++ b/docs/Changelog-1.5.0.md
@@ -23,7 +23,7 @@ Features
 - Added support for environment variable interpolation for YAML keys.
 - Added `io.podman.compose.service` label to created containers. It contains the same value as
   `com.docker.compose.service`.
-- Added relabel option to secret to make possible to read the secret file by the contained process.
+- Added relabel option to secret to make possible to read the secret file by the container process.
 - Added support for setting x-podman values using PODMAN_COMPOSE_* environment variables.
 - Added support to set `--route` option to `podman network create` via
   `x-podman.routes` key on network configuration.

--- a/docs/Extensions.md
+++ b/docs/Extensions.md
@@ -1,6 +1,6 @@
 # Podman specific extensions to the docker-compose format
 
-Podman-compose supports the following extension to the docker-compose format. These extensions
+Podman-compose supports the following extensions to the docker-compose format. These extensions
 are generally specified under fields with "x-podman" prefix in the compose file.
 
 ## Container management
@@ -48,7 +48,7 @@ For explanations of these extensions, please refer to the [podman-run --volume d
 The following extension keys are available under network configuration:
 
 * `x-podman.disable_dns` - Disable the DNS plugin for the network when set to 'true'.
-* `x-podman.dns` - Specifies a list of nameservers for the network This cannot be used with x-podman.disable_dns`.
+* `x-podman.dns` - Specifies a list of nameservers for the network. This cannot be used with x-podman.disable_dns`.
 
 For example, the following docker-compose.yml allows all containers on the same network to use the
 specified nameservers:
@@ -129,7 +129,7 @@ services:
 
 ## Per-network interface name
 
-Using `x-podman.interface_name` within a containers network config you can specify the interface name inside the container.
+Using `x-podman.interface_name` within a container's network config you can specify the interface name inside the container.
 
 ## Podman-specific network modes
 
@@ -159,7 +159,7 @@ Generic docker-compose supports the following values for mount `type`:
 - `bind`
 - `tmpfs`
 
-In addition, podman-compose supports the following podman-pecific values for mount `type`:
+In addition, podman-compose supports the following podman-specific values for mount `type`:
 
 - `glob`
 
@@ -185,7 +185,7 @@ This setting can also be changed by setting the `PODMAN_COMPOSE_DOCKER_COMPOSE_C
 
 Currently, podman-compose is using underscores (`_` character) as a separator in names of
 containers, images, etc., while docker-compose has switched to hyphens (`-` character). This setting
-allows to switch podman-compose to use hyphens as well.
+allows you to switch podman-compose to use hyphens as well.
 
 To enable compatibility between docker-compose and podman-compose, specify
 `name_separator_compat: true` under global `x-podman` key:
@@ -224,7 +224,7 @@ variable.
 ## Compatibility of default network behavior between docker-compose and podman-compose
 
 When there is no network defined (neither network-mode nor networks) in service,
-The behavior of default network in docker-compose and podman-compose are different.
+The behavior of default network in docker-compose and podman-compose is different.
 
 | Top-level networks             | podman-compose             | docker-compose |
 | ------------------------------ | -------------------------- | -------------- |
@@ -246,8 +246,8 @@ variable.
 
 ## Custom pods management
 
-Podman-compose can have containers in pods. This can be controlled by extension key x-podman in_pod.
-It allows providing custom value for --in-pod and is especially relevant when --userns has to be set.
+Podman-compose can have containers in pods. This can be controlled by the extension key x-podman in_pod.
+It allows providing a custom value for --in-pod and is especially relevant when --userns has to be set.
 
 For example, the following docker-compose.yml allows using userns_mode by overriding the default
 value of --in-pod (unless it was specifically provided by "--in-pod=True" in command line interface).

--- a/examples/awx17/README.md
+++ b/examples/awx17/README.md
@@ -1,6 +1,6 @@
 # AWX Compose
 
-the directory roles is taken from [here](https://github.com/ansible/awx/tree/17.1.0/installer/roles/local_docker)
+The directory roles is taken from [here](https://github.com/ansible/awx/tree/17.1.0/installer/roles/local_docker)
 
 also look at https://github.com/ansible/awx/tree/17.1.0/tools/docker-compose
 

--- a/examples/awx17/roles/local_docker/tasks/set_image.yml
+++ b/examples/awx17/roles/local_docker/tasks/set_image.yml
@@ -1,7 +1,7 @@
 ---
 - name: Manage AWX Container Images
   block:
-    - name: Export Docker awx image if it isn't local and there isn't a registry defined
+    - name: Export Docker AWX image if it isn't local and there isn't a registry defined
       docker_image:
         name: "{{ awx_image }}"
         tag: "{{ awx_version }}"

--- a/examples/azure-vote/README.md
+++ b/examples/azure-vote/README.md
@@ -1,6 +1,6 @@
 # Azure Vote Example
 
-This example have two containers:
+This example has two containers:
 
 * backend: `redis` used as storage
 * frontend: having supervisord, nginx, uwsgi/python
@@ -11,7 +11,7 @@ echo "HOST_PORT=8080" > .env
 podman-compose up
 ```
 
-after typing the commands above open your browser on the host port you picked above like
+After typing the commands above, open your browser on the host port you picked above, like
 [http://localhost:8080/](http://localhost:8080/)
 
 

--- a/examples/echo/README.md
+++ b/examples/echo/README.md
@@ -4,7 +4,7 @@
 podman-compose up
 ```
 
-Test the service with `curl like this`
+Test the service with curl like this:
 
 ```
 $ curl -X POST -d "foobar" http://localhost:8080/; echo

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -145,7 +145,7 @@ def parse_short_mount(mount_str: str, basedir: str) -> dict[str, Any]:
     mount_opt_dict: dict[str, Any] = {}
     mount_opt = None
     if len(mount_a) == 1:
-        # Anonymous: Just specify a path and let the engine creates the volume
+        # Anonymous: Just specify a path and let the engine create the volume
         # - /var/lib/mysql
         mount_src, mount_dst = None, mount_str
     elif len(mount_a) == 2:
@@ -211,7 +211,7 @@ def fix_mount_dict(
     - if name is missing it would be source prefixed with project
     - if no source it would be generated
     """
-    # if already applied nothing todo
+    # if already applied nothing to do
     assert compose.project_name is not None
 
     if "_vol" in mount_dict:
@@ -288,7 +288,7 @@ def rec_subs(value: dict | str | Iterable, subs_dict: dict[str, Any]) -> dict | 
             subs_dict = subs_dict.copy()
             svc_envs = {k: v for k, v in value['environment'].items() if k not in subs_dict}
             # we need to add `svc_envs` to the `subs_dict` so that it can evaluate the
-            # service environment that reference to another service environment.
+            # service environment that references another service environment.
             svc_envs = rec_subs(svc_envs, subs_dict)
             subs_dict.update(svc_envs)
 
@@ -431,7 +431,7 @@ async def assert_volume(compose: PodmanCompose, mount_dict: dict[str, Any]) -> N
         _ = (await compose.podman.output([], "volume", ["inspect", vol_name])).decode("utf-8")
     except subprocess.CalledProcessError as e:
         if is_ext:
-            raise RuntimeError(f"External volume [{vol_name}] does not exists") from e
+            raise RuntimeError(f"External volume [{vol_name}] does not exist") from e
         labels = vol.get("labels", [])
         args = [
             "create",
@@ -673,7 +673,7 @@ def get_secret_args(
                 mount_options += selinux_relabel_to_mount_option_map[x_podman_relabel]
             except KeyError as exc:
                 raise ValueError(
-                    f'ERROR: Run secret "{secret_name} has invalid "relabel" option related '
+                    f'ERROR: Run secret "{secret_name}" has invalid "relabel" option related '
                     + f' to SELinux "{x_podman_relabel}". Expected "z" "Z" or nothing.'
                 ) from exc
             volume_ref = ["--volume", f"{source_file}:{dest_file}:{mount_options}"]
@@ -962,7 +962,7 @@ async def assert_cnt_nets(compose: PodmanCompose, cnt: dict[str, Any]) -> None:
             await compose.podman.output([], "network", ["exists", net_name])
         except subprocess.CalledProcessError as e:
             if is_ext:
-                raise RuntimeError(f"External network [{net_name}] does not exists") from e
+                raise RuntimeError(f"External network [{net_name}] does not exist") from e
             args = get_network_create_args(net_desc, compose.project_name, net_name)
             await compose.podman.output([], "network", args)
             await compose.podman.output([], "network", ["exists", net_name])
@@ -1311,7 +1311,7 @@ async def container_to_args(
                 podman_args.extend(["--healthcheck-command", json.dumps(healthcheck_test)])
             elif healthcheck_type == "CMD-SHELL":
                 if len(healthcheck_test) != 1:
-                    raise ValueError("'CMD_SHELL' takes a single string after it")
+                    raise ValueError("'CMD-SHELL' takes a single string after it")
                 podman_args.extend(["--healthcheck-command", json.dumps(healthcheck_test)])
             else:
                 raise ValueError(
@@ -1384,7 +1384,7 @@ class ServiceDependencyCondition(Enum):
             if member.value == value:
                 return member
 
-        # Check if this is a value coming from  reference
+        # Check if this is a value coming from a reference
         docker_to_podman_cond = {
             "service_healthy": ServiceDependencyCondition.HEALTHY,
             "service_started": ServiceDependencyCondition.RUNNING,
@@ -1431,7 +1431,7 @@ def rec_deps(
         start_point = service_name
     deps = services[service_name]["_deps"]
     for dep_name in deps.copy():
-        # avoid A depens on A
+        # avoid A depends on A
         if dep_name.name == service_name:
             continue
         dep_srv = services.get(dep_name.name)
@@ -3040,7 +3040,7 @@ def container_to_build_args(
             cleanup_callbacks.append(cleanup_temp_dockfile)
 
     build_args = []
-    # if givent context was not recognized as git url, try joining paths to get a file locally
+    # if given context was not recognized as git url, try joining paths to get a file locally
     if not is_context_git_url(ctx):
         custom_dockerfile_given = False
         if dockerfile:
@@ -3228,7 +3228,7 @@ def get_excluded(
     if args.services:
         excluded = set(compose.services)
         for service in args.services:
-            # we need 'getattr' as compose_down_parse dose not configure 'no_deps'
+            # we need 'getattr' as compose_down_parse does not configure 'no_deps'
             if service in compose.services and not getattr(args, "no_deps", False):
                 excluded -= set(x.name for x in compose.services[service].get(dep_field, set()))
             excluded.discard(service)
@@ -3363,16 +3363,16 @@ async def pull_images(
     services: list[dict[str, Any]],
 ) -> int | None:
     pull_tasks = []
-    settingettings: dict[str, PullImageSettings] = {}
+    settings: dict[str, PullImageSettings] = {}
     for pull_service in services:
         if not is_local(pull_service):
             image = str(pull_service.get("image", ""))
             policy = getattr(args, "pull", None) or pull_service.get("pull_policy", "missing")
 
-            if image in settingettings:
-                settingettings[image].update_policy(policy)
+            if image in settings:
+                settings[image].update_policy(policy)
             else:
-                settingettings[image] = PullImageSettings(
+                settings[image] = PullImageSettings(
                     image, policy, getattr(args, "quiet_pull", False)
                 )
 
@@ -3382,9 +3382,9 @@ async def pull_images(
                 # we should try to pull the image first,
                 # and then build it if it does not exist.
                 # we should not stop here if pull fails.
-                settingettings[image].ignore_pull_error = True
+                settings[image].ignore_pull_error = True
 
-    for s in settingettings.values():
+    for s in settings.values():
         pull_tasks.append(pull_image(podman, s))
 
     if pull_tasks:

--- a/tests/integration/additional_contexts/README.md
+++ b/tests/integration/additional_contexts/README.md
@@ -6,7 +6,7 @@ podman-compose up
 podman-compose down
 ```
 
-expected output would be
+The expected output is
 
 ```
 [dict] | Data for dict

--- a/tests/integration/build_fail/test_podman_compose_build_fail.py
+++ b/tests/integration/build_fail/test_podman_compose_build_fail.py
@@ -9,7 +9,7 @@ from tests.integration.test_utils import test_path
 
 
 def compose_yaml_path():
-    """ "Returns the path to the compose file used for this test module"""
+    """Returns the path to the compose file used for this test module"""
     base_path = os.path.join(test_path(), "build_fail")
     return os.path.join(base_path, "docker-compose.yml")
 

--- a/tests/integration/commands_fail_exit_code/good/Dockerfile
+++ b/tests/integration/commands_fail_exit_code/good/Dockerfile
@@ -1,3 +1,3 @@
 FROM busybox
-#ensure that this build finishes second so that it has a chance to overwrite the return code
+# ensure that this build finishes second so that it has a chance to overwrite the return code
 RUN sleep 0.5

--- a/tests/integration/extends_w_file_subdir/test_podman_compose_extends_w_file_subdir.py
+++ b/tests/integration/extends_w_file_subdir/test_podman_compose_extends_w_file_subdir.py
@@ -99,6 +99,6 @@ class TestComposeExtendsWithFileSubdir(unittest.TestCase, RunSubprocessMixin):
             "localhost/subdir_test:me",
         ])
 
-        # check container did not exists anymore
+        # check container did not exist anymore
         out, _ = self.run_subprocess_assert_returncode(command_check_container)
         self.assertEqual(out, b'')

--- a/tests/integration/in_pod/test_podman_compose_in_pod.py
+++ b/tests/integration/in_pod/test_podman_compose_in_pod.py
@@ -249,7 +249,7 @@ class TestPodmanComposeInPod(unittest.TestCase, RunSubprocessMixin):
     def test_x_podman_in_pod_true_command_line_in_pod_true(self) -> None:
         """
         Test that podman-compose does not allow pod creating when --userns and --pod are set
-        together even when x-podman in_pod=true and and command line in_pod=True: throws an error
+        together even when x-podman in_pod=true and command line in_pod=True: throws an error
         """
         # FIXME: creates a pod anyway, although it should not
         # Container is not created, so command 'down' is not needed

--- a/tests/integration/include/test_podman_compose_include.py
+++ b/tests/integration/include/test_podman_compose_include.py
@@ -63,6 +63,6 @@ class TestPodmanComposeInclude(unittest.TestCase, RunSubprocessMixin):
         out, _ = self.run_subprocess_assert_returncode(command_down)
         # cleanup test image(tags)
         self.assertNotEqual(out, b"")
-        # check container did not exists anymore
+        # check container did not exist anymore
         out, _ = self.run_subprocess_assert_returncode(command_check_container)
         self.assertEqual(out, b"")

--- a/tests/integration/multicompose/test_podman_compose_multicompose.py
+++ b/tests/integration/multicompose/test_podman_compose_multicompose.py
@@ -50,7 +50,7 @@ class TestComposeMulticompose(unittest.TestCase, RunSubprocessMixin):
                 "-c",
                 "set",
             ])
-            # checks if `enf_file` was appended, not replaced
+            # checks if `env_file` was appended, not replaced
             # (which means that we normalize to array before merge)
             self.assertIn(b"var12='d1/12.env'", output)
 

--- a/tests/integration/nets_test3/test_podman_compose_nets_test3.py
+++ b/tests/integration/nets_test3/test_podman_compose_nets_test3.py
@@ -33,7 +33,7 @@ class TestComposeNetsTest3(unittest.TestCase, RunSubprocessMixin):
     def test_nets_test3(
         self,
         container_name: str,
-        nework_alias_name: str,
+        network_alias_name: str,
         expected_text: bytes,
         expected_returncode: int,
     ) -> None:
@@ -59,7 +59,7 @@ class TestComposeNetsTest3(unittest.TestCase, RunSubprocessMixin):
                 "-",
                 "-o",
                 "/dev/null",
-                f"http://{nework_alias_name}:8001/index.txt",
+                f"http://{network_alias_name}:8001/index.txt",
             ]
             out, _, returncode = self.run_subprocess(cmd)
             self.assertEqual(expected_returncode, returncode)

--- a/tests/integration/secrets/docker-compose.yaml
+++ b/tests/integration/secrets/docker-compose.yaml
@@ -14,7 +14,7 @@ services:
         # Custom name reference for mounted external secret is not supported
         #- podman_compose_test_secret_2
         - source: podman_compose_test_secret_3
-          # warning about un-supported "target" field
+          # warning about unsupported "target" field
           target: podman_compose_test_secret_3
           uid: '103'
           gid: '103'
@@ -25,7 +25,7 @@ services:
         - source: file_secret
           target: /etc/custom_location
         - source: file_secret
-          # warning about un-supported "uid", "gid", "mode" fields
+          # warning about unsupported "uid", "gid", "mode" fields
           target: unused_params_warning
           uid: '103'
           gid: '103'

--- a/tests/integration/service_scale/test_podman_compose_scale.py
+++ b/tests/integration/service_scale/test_podman_compose_scale.py
@@ -17,7 +17,7 @@ def compose_yaml_path(test_ref_folder: str) -> str:
 
 @unittest.skipIf(get_podman_version() >= version.parse("5.0.0"), "Breaks as of podman-5.4.2.")
 class TestComposeScale(unittest.TestCase, RunSubprocessMixin):
-    # scale-up using `scale` prarmeter in docker-compose.yml
+    # scale-up using `scale` parameter in docker-compose.yml
     def test_scaleup_scale_parameter(self) -> None:
         try:
             output, _, return_code = self.run_subprocess([
@@ -55,7 +55,7 @@ class TestComposeScale(unittest.TestCase, RunSubprocessMixin):
                 "0",
             ])
 
-    # scale-up using `deploy => replicas` prarmeter in docker-compose.yml
+    # scale-up using `deploy => replicas` parameter in docker-compose.yml
     def test_scaleup_deploy_replicas_parameter(self) -> None:
         try:
             output, _, return_code = self.run_subprocess([

--- a/tests/integration/up_down/test_podman_compose_up_down.py
+++ b/tests/integration/up_down/test_podman_compose_up_down.py
@@ -28,7 +28,7 @@ class TestPodmanCompose(unittest.TestCase, RunSubprocessMixin):
 
     def setUp(self) -> None:
         """
-        Retag the debian image before each test to no mess with the other integration tests when
+        Retag the debian image before each test to not mess with the other integration tests when
         testing the `--rmi` argument
         """
         tag_cmd = [

--- a/tests/integration/vol/README.md
+++ b/tests/integration/vol/README.md
@@ -1,8 +1,8 @@
-# to test create the two external volumes
+# To test, create the two external volumes
 
 ```
 podman volume create my-app-data
 podman volume create actual-name-of-volume
-podman-compose up 
+podman-compose up
 ```
 

--- a/tests/integration/vol/test_podman_compose_vol.py
+++ b/tests/integration/vol/test_podman_compose_vol.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: GPL-2.0
 
 """
-test_podman_compose_up_down.py
+test_podman_compose_vol.py
 
-Tests the podman compose up and down commands used to create and remove services.
+Tests the podman compose up and down commands used to create and remove services with volumes.
 """
 
 # pylint: disable=redefined-outer-name


### PR DESCRIPTION
This PR fixes typos and other mistakes in `podman-compose` project files.
