### PR TITLE
[ADD] Support tls verify flag for compose

### DIFF
--- a/docs/Extensions.md
+++ b/docs/Extensions.md
@@ -282,3 +282,21 @@ to `["--infra=false", "--share="]`.
 
 This setting can also be changed by setting `PODMAN_COMPOSE_POD_ARGS` environment
 variable.
+
+## TLS verification for registry operations
+
+By default, podman-compose requires TLS verification when contacting a registry
+for `pull`, `push`, and `build` operations. Use the `--tls-verify` flag to
+override this:
+
+```
+podman-compose --tls-verify=false up
+```
+
+Valid values are `true` (default) and `false`. Setting it to `false` passes
+`--tls-verify=false` to every `podman pull`, `podman push`, and `podman build`
+invocation, which is useful when using self-signed certificates or registries
+behind a corporate VPN.
+
+Refer to the [podman-pull documentation](https://docs.podman.io/en/latest/markdown/podman-pull.1.html)
+for details on TLS verification in Podman.

--- a/newsfragments/tls_verify_registry.feature
+++ b/newsfragments/tls_verify_registry.feature
@@ -1,0 +1,1 @@
+Add global --tls-verify flag to disable TLS verification for registry operations (pull, push, build).

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2112,6 +2112,12 @@ class PodmanCompose:
         cmd_args = self.global_args.__dict__.get(f"podman_{cmd_norm}_args", [])
         for args in cmd_args:
             xargs.extend(shlex.split(args))
+        if getattr(self.global_args, "tls_verify", "true") == "false" and cmd in (
+            "pull",
+            "push",
+            "build",
+        ):
+            xargs.append("--tls-verify=false")
         return xargs
 
     async def run(self, argv: list[str] | None = None) -> None:
@@ -2735,6 +2741,17 @@ class PodmanCompose:
                 action="append",
                 default=[],
             )
+        parser.add_argument(
+            "--tls-verify",
+            help=(
+                "tls verification for registry commands (pull/push/build):\n"
+                "  'true'  - verify TLS (default)\n"
+                "  'false' - skip verification (e.g. self-signed registries)"
+            ),
+            metavar="tls_verify",
+            choices=("true", "false"),
+            default="true",
+        )
         parser.add_argument(
             "--no-ansi",
             help="Do not print ANSI control characters",

--- a/tests/unit/test_get_podman_args_tls_verify.py
+++ b/tests/unit/test_get_podman_args_tls_verify.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: GPL-2.0
+
+import argparse
+import unittest
+
+from parameterized import parameterized
+
+from podman_compose import PodmanCompose
+
+
+def compose_with_tls_verify(tls_verify: str) -> PodmanCompose:
+    compose = PodmanCompose()
+    compose.global_args = argparse.Namespace(
+        podman_args=[],
+        tls_verify=tls_verify,
+        podman_pull_args=[],
+        podman_push_args=[],
+        podman_build_args=[],
+        podman_run_args=[],
+        podman_inspect_args=[],
+        podman_start_args=[],
+        podman_stop_args=[],
+        podman_rm_args=[],
+        podman_volume_args=[],
+    )
+    return compose
+
+
+class TestGetPodmanArgsTlsVerify(unittest.TestCase):
+    @parameterized.expand([
+        ("pull",),
+        ("push",),
+        ("build",),
+    ])
+    def test_tls_verify_true_registry_commands_no_tls_flag(self, cmd: str) -> None:
+        compose = compose_with_tls_verify("true")
+        xargs = compose.get_podman_args(cmd)
+        self.assertNotIn("--tls-verify=false", xargs)
+
+    @parameterized.expand([
+        ("pull",),
+        ("push",),
+        ("build",),
+    ])
+    def test_tls_verify_false_registry_commands_injects_flag(self, cmd: str) -> None:
+        compose = compose_with_tls_verify("false")
+        xargs = compose.get_podman_args(cmd)
+        self.assertIn("--tls-verify=false", xargs)
+        self.assertEqual(len([a for a in xargs if a.startswith("--tls-verify")]), 1)
+
+    @parameterized.expand([
+        ("run",),
+        ("start",),
+        ("stop",),
+        ("rm",),
+        ("inspect",),
+        ("volume",),
+    ])
+    def test_tls_verify_false_non_registry_commands_no_tls_flag(self, cmd: str) -> None:
+        compose = compose_with_tls_verify("false")
+        xargs = compose.get_podman_args(cmd)
+        self.assertNotIn("--tls-verify=false", xargs)
+
+    def test_tls_verify_false_with_podman_pull_args(self) -> None:
+        compose = compose_with_tls_verify("false")
+        compose.global_args.podman_pull_args = ["--quiet"]
+        xargs = compose.get_podman_args("pull")
+        self.assertIn("--tls-verify=false", xargs)
+        self.assertIn("--quiet", xargs)


### PR DESCRIPTION
## Summary

Added support for disabling TLS verification when podman-compose runs `podman pull`, `podman push`, and `podman build`. This allows use behind VPNs or with self-signed/invalid registry certificates where podman would otherwise fail with x509 TLS errors.

## Motivation

- **Problem:** Under VPNs or with self-signed registry certs, `podman pull` (and push/build that contact registries) can fail with x509 certificate verification errors.
- **Podman** already supports `--tls-verify=false` for `podman pull`, `podman push`, and `podman login`, but podman-compose did not expose this when invoking these commands internally.
- **Workaround today:** Users can pass `--podman-pull-args "--tls-verify=false"` (and similarly for push/build), but that is hard to discover and easy to forget for commands like `up` that trigger pulls. This change provides a single, explicit option.

## Changes

- **CLI:** New global flag `--tls-verify` with values `true` or `false` (default `true`). When set to `false`, podman-compose passes `--tls-verify=false` to all registry-related podman subcommands.
- **Injection:** In `get_podman_args(cmd)`, when `--tls-verify=false` is in effect and `cmd` is `pull`, `push`, or `build`, the returned arguments include `--tls-verify=false`. This automatically covers:
  - **pull:** `podman-compose pull` and the pull phase in `podman-compose up`
  - **push:** `podman-compose push`
  - **build:** `podman-compose build` and the build phase in `up` (e.g. when using `--pull=always`)
- **Tests:** New unit tests in `tests/unit/test_get_podman_args_tls_verify.py` for `get_podman_args()` with `tls_verify` true/false and for registry vs non-registry commands.
- **Backward compatibility:** Default remains TLS verification **on**. Behavior is unchanged when the new flag is not used.
