### PR TITLE
Better error message when podman probe fails

### DIFF
--- a/newsfragments/podman_probe_better_error.change
+++ b/newsfragments/podman_probe_better_error.change
@@ -1,0 +1,1 @@
+Better error message when probing for podman fails.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2181,10 +2181,17 @@ class PodmanCompose:
                     "utf-8"
                 ).strip() or ""
                 self.podman_version = (self.podman_version.split() or [""])[-1]
-            except (subprocess.CalledProcessError, FileNotFoundError):
+            except (subprocess.CalledProcessError, FileNotFoundError) as e:
+                msg = str(e)
+                if isinstance(e, subprocess.CalledProcessError) and e.output:
+                    msg += f": {e.output.decode('utf-8')}"
+                log.error("failed to check if podman is installed: %s", msg)
                 self.podman_version = None
             if not self.podman_version:
-                log.fatal("it seems that you do not have `podman` installed")
+                log.fatal(
+                    "It seems that you either do not have `podman` installed "
+                    "or the `podman version` command failed."
+                )
                 sys.exit(1)
             log.info("using podman version: %s", self.podman_version)
         cmd_name = args.command


### PR DESCRIPTION
This error message left me scratching my head for a while. My intention with this contribution is to help others not who ran into this, figure out the issue quicker.

In my exact situation, I had wrong permissions on the folder in my CWD, and attempted to execute `podman compose pull`. The console output was just this:

```
$ podman compose pull

CRITICAL:podman_compose:it seems that you do not have `podman` installed
Error: executing /usr/bin/podman-compose pull: exit status 1
```

Which is clearly wrong, as this command was invoked by podman itself.

Looking at the code, I realized that the issue is that any error during running `podman version` results in this error message. Even if `podman version` itself returns an error (which it does).

With this PR the error message becomes this, which is a little more helpful:

```
$ podman compose --version

ERROR:podman_compose:failed to check if podman is installed: Command 'podman --version ' returned non-zero exit status 1.: cannot chdir to /tmp/tmp.5R1DFMq5vG/asdasdasd: Permission denied

CRITICAL:podman_compose:It seems that you either do not have `podman` installed or the `podman version` command failed.
Error: executing /usr/bin/podman-compose --version: exit status 1
```

I don't think this change is something that can be unit-tested well, but if you disagree let me know!

It also seems like someone else ran into this issue as well: https://github.com/containers/podman/issues/28004

Fixes: https://github.com/containers/podman-compose/issues/220 (kindof)