### PR TITLE
fix: 'asyncio.iscoroutinefunction' is deprecated in python 3.15

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -15,6 +15,7 @@ import codecs
 import getpass
 import glob
 import hashlib
+import inspect
 import json
 import logging
 import os
@@ -2852,7 +2853,7 @@ class cmd_run:  # pylint: disable=invalid-name,too-few-public-methods
         def wrapped(*args: Any, **kw: Any) -> Any:
             return func(*args, **kw)
 
-        if not asyncio.iscoroutinefunction(func):
+        if not inspect.iscoroutinefunction(func):
             raise PodmanComposeError("Command must be async")
         wrapped._compose = self.compose  # type: ignore[attr-defined]
         # Trim extra indentation at start of multiline docstrings.


### PR DESCRIPTION
Fix following deprecation warning:

```
podman-compose:2704: DeprecationWarning: 'asyncio.iscoroutinefunction' is deprecated and slated for removal in Python 3.16; use inspect.iscoroutinefunction() instead
```

The [inspect.iscoroutinefunction](https://docs.python.org/3/library/inspect.html#inspect.iscoroutinefunction) was added in python 3.5.  Python 3.9 or above are supported.