### PR TITLE
fix: dependson servicecompletedsuccessfully isnt always followed

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -3311,6 +3311,33 @@ def get_excluded(
     return excluded
 
 
+async def _wait_containers_started(compose: PodmanCompose, containers: list) -> None:
+    """Poll until all containers have left the 'created' state.
+
+    For service_completed_successfully (--condition=stopped), podman wait may return
+    immediately if the container hasn't transitioned out of "created" state yet —
+    i.e. podman start was called but the container hasn't actually begun running.
+    We poll until all dependency containers have left the "created" state before
+    invoking podman wait, eliminating the race condition.
+    See: https://github.com/containers/podman-compose/issues/1330
+    """
+    while True:
+        try:
+            statuses_raw = await compose.podman.output(
+                [], "inspect", ["--format={{.State.Status}}"] + containers
+            )
+            statuses = statuses_raw.decode().split()
+            if all(s != "created" for s in statuses if s):
+                break
+        except subprocess.CalledProcessError:
+            pass
+        log.debug(
+            "Waiting for dependency containers to leave 'created' state: %s",
+            ', '.join(containers),
+        )
+        await asyncio.sleep(0.05)
+
+
 async def check_dep_conditions(compose: PodmanCompose, deps: set) -> None:
     """Enforce that all specified conditions in deps are met"""
     if not deps:
@@ -3338,28 +3365,8 @@ async def check_dep_conditions(compose: PodmanCompose, deps: set) -> None:
                 deps_cd.extend(compose.container_names_by_service[d.name])
 
         if deps_cd:
-            # For service_completed_successfully (--condition=stopped), podman wait may return
-            # immediately if the container hasn't transitioned out of "created" state yet ΓÇö
-            # i.e. podman start was called but the container hasn't actually begun running.
-            # We poll until all dependency containers have left the "created" state before
-            # invoking podman wait, eliminating the race condition.
-            # See: https://github.com/containers/podman-compose/issues/1330
             if condition == ServiceDependencyCondition.STOPPED:
-                while True:
-                    try:
-                        statuses_raw = await compose.podman.output(
-                            [], "inspect", ["--format={{.State.Status}}"] + deps_cd
-                        )
-                        statuses = statuses_raw.decode().split()
-                        if all(s != "created" for s in statuses if s):
-                            break
-                    except subprocess.CalledProcessError:
-                        pass
-                    log.debug(
-                        "Waiting for dependency containers to leave 'created' state: %s",
-                        ', '.join(deps_cd),
-                    )
-                    await asyncio.sleep(0.05)
+                await _wait_containers_started(compose, deps_cd)
 
             # podman wait will return always with a rc -1.
             while True:

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -3338,6 +3338,29 @@ async def check_dep_conditions(compose: PodmanCompose, deps: set) -> None:
                 deps_cd.extend(compose.container_names_by_service[d.name])
 
         if deps_cd:
+            # For service_completed_successfully (--condition=stopped), podman wait may return
+            # immediately if the container hasn't transitioned out of "created" state yet ΓÇö
+            # i.e. podman start was called but the container hasn't actually begun running.
+            # We poll until all dependency containers have left the "created" state before
+            # invoking podman wait, eliminating the race condition.
+            # See: https://github.com/containers/podman-compose/issues/1330
+            if condition == ServiceDependencyCondition.STOPPED:
+                while True:
+                    try:
+                        statuses_raw = await compose.podman.output(
+                            [], "inspect", ["--format={{.State.Status}}"] + deps_cd
+                        )
+                        statuses = statuses_raw.decode().split()
+                        if all(s != "created" for s in statuses if s):
+                            break
+                    except subprocess.CalledProcessError:
+                        pass
+                    log.debug(
+                        "Waiting for dependency containers to leave 'created' state: %s",
+                        ', '.join(deps_cd),
+                    )
+                    await asyncio.sleep(0.05)
+
             # podman wait will return always with a rc -1.
             while True:
                 try:


### PR DESCRIPTION
## Summary

Closes #1330

## Problem

**Describe the bug**
The `depends_on:` attribute with value "service_completed_successfully" isn't always honored, and containers may start out of their desired order.
**To Reproduce**

## Changes

This PR addresses the issue by:
- Identifying the root cause in the relevant code path
- Applying a targeted fix with minimal scope

## Testing

- [x] Code compiles without errors
- [x] Changes are scoped to the affected code paths only
- [x] Reviewed for regressions and side effects

## Checklist

- [x] I have read and followed the contribution guidelines
- [x] My changes do not introduce new warnings or errors
- [x] I have commented my code where necessary
