### PR TITLE
support nested variable interpolation

### DIFF
--- a/newsfragments/nested-variable-interpolation.feature
+++ b/newsfragments/nested-variable-interpolation.feature
@@ -1,0 +1,1 @@
+Support nested variable interpolation

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -23,6 +23,7 @@ import random
 import re
 import shlex
 import signal
+import string
 import subprocess
 import sys
 import tempfile
@@ -263,22 +264,195 @@ def fix_mount_dict(
 # ${VARIABLE?err} raise error if not set
 # $$ means $
 
-var_re = re.compile(
-    r"""
-    \$(?:
-        (?P<escaped>\$) |
-        (?P<named>[_a-zA-Z][_a-zA-Z0-9]*) |
-        (?:{
-            (?P<braced>[_a-zA-Z][_a-zA-Z0-9]*)
-            (?:(?P<empty>:)?(?:
-                (?:-(?P<default>[^}]*)) |
-                (?:\?(?P<err>[^}]*))
-            ))?
-        })
-    )
-""",
-    re.VERBOSE,
-)
+
+def var_interpolate(value: str, env: dict[str, Any]) -> str:
+    var_name_chars = string.ascii_letters + string.digits + "_"
+    var_name_start_chars = string.ascii_letters + "_"
+
+    class VarInterpolationOperators(Enum):
+        VAR_IF_NONEMPTY = ':-'
+        VAR_IF_SET = '-'
+        REQUIRED_SET = '?'
+        REQUIRED_NONEMPTY = ':?'
+        ALTERNATIVE1 = ':+'
+        ALTERNATIVE2 = '+'
+
+    operators = {op.value for op in VarInterpolationOperators}
+
+    @dataclass
+    class Token:
+        def resolve(self, _: dict[str, str | None]) -> str:
+            raise NotImplementedError()
+
+    @dataclass
+    class LiteralToken(Token):
+        value: str
+
+        def resolve(self, _: dict[str, str | None]) -> str:
+            return self.value
+
+    @dataclass
+    class VarToken(Token):
+        name: str
+        operator: str | None
+        operand: str | None
+
+        def resolve(self, env: dict[str, str | None]) -> str:
+            var_value = env.get(self.name)
+
+            # This is only the case for simple $VAR or ${VAR} without any operator,
+            # in which case we just return the variable value or empty string if not set
+            if self.operator is None or self.operand is None:
+                return var_value if var_value is not None else ''
+
+            if self.operator == VarInterpolationOperators.REQUIRED_NONEMPTY.value:
+                if var_value is None or var_value == '':
+                    interpolated_operand = (
+                        interpolate_str(self.operand, env) if self.operand else ''
+                    )
+                    raise ValueError(
+                        f"required variable {self.name} is missing a value: {interpolated_operand}"
+                    )
+                return var_value
+
+            if self.operator == VarInterpolationOperators.REQUIRED_SET.value:
+                if var_value is None:
+                    interpolated_operand = (
+                        interpolate_str(self.operand, env) if self.operand else ''
+                    )
+                    raise ValueError(
+                        f"required variable {self.name} is missing a value: {interpolated_operand}"
+                    )
+                return var_value
+
+            if self.operator == VarInterpolationOperators.VAR_IF_NONEMPTY.value:
+                condition = var_value is None or var_value == ''
+                alternative = var_value if var_value is not None else ''
+            elif self.operator == VarInterpolationOperators.VAR_IF_SET.value:
+                condition = var_value is None
+                alternative = var_value if var_value is not None else ''
+            elif self.operator == VarInterpolationOperators.ALTERNATIVE1.value:
+                condition = var_value is not None and var_value != ''
+                alternative = ''
+            elif self.operator == VarInterpolationOperators.ALTERNATIVE2.value:
+                condition = var_value is not None
+                alternative = ''
+            else:
+                raise ValueError(f"Unknown operator in variable interpolation: {self.operator}")
+
+            return interpolate_str(self.operand, env) if condition else alternative
+
+    def var_name_lookahead(start: int, chars: list[str]) -> tuple[int, str]:
+        """
+        moves the index to the end of the variable name
+        returns variable name and position after variable name
+        """
+        var_name = ''
+        i = start
+        while i < len(chars) and chars[i] in var_name_chars:
+            var_name += chars[i]
+            i += 1
+        return i, var_name
+
+    def advance_to_closing_brace(start: int, chars: list[str]) -> int:
+        i = start
+        brace_level = 1
+        while i < len(chars):
+            char = chars[i]
+            if char == '}':
+                brace_level -= 1
+                if brace_level == 0:
+                    return i  # position of the closing brace
+            elif char == '{':
+                brace_level += 1
+            i += 1
+        raise ValueError("No closing brace found for variable interpolation")
+
+    def resolve_brace_content(content: str) -> VarToken:
+        operator = None
+        operand = None
+
+        # Check that the brace content starts with a valid variable name character.
+        # Refuse to interpolate otherwise. This is how Docker behaves.
+        if len(content) == 0 or content[0] not in var_name_start_chars:
+            raise ValueError(
+                f"Invalid interpolation format: ${{{content}}}."
+                " You may need to escape any $ with another $"
+            )
+
+        i, name = var_name_lookahead(0, list(content))
+
+        rest = content[i:]
+        if rest:
+            for op in operators:
+                if rest.startswith(op):
+                    operator = op
+                    operand = rest[len(op) :]
+                    break
+
+            if operator is None:
+                raise ValueError(f"Invalid variable interpolation syntax: ${{{content}}}")
+
+        return VarToken(name=name, operator=operator, operand=operand)
+
+    def tokenize(value: str) -> list[Token]:
+        chars = list(value)
+        tokens: list[Token] = []
+        in_brace = False
+
+        def append_text_char(char: str) -> None:
+            if tokens and isinstance(tokens[-1], LiteralToken):
+                tokens[-1].value += char
+            else:
+                tokens.append(LiteralToken(value=char))
+
+        i = 0
+        while i < len(chars):
+            char = chars[i]
+            if not in_brace:
+                if char == '$':
+                    # There is no lookahead, treat $ as literal
+                    if i + 1 >= len(chars):
+                        append_text_char(char)
+                        i += 1
+                        continue
+                    lookahead_char = chars[i + 1]
+                    if lookahead_char == '{':
+                        in_brace = True
+                        i += 2  # skip $ and {
+                        continue
+                    if lookahead_char == '$':
+                        append_text_char('$')
+                        i += 2  # skip both $$
+                        continue
+                    # If the lookahead char is valid for starting a variable name, parse the name.
+                    # Otherwise, treat $ as literal (e.g. in "price is $5", $ should be literal)
+                    if lookahead_char in var_name_start_chars:
+                        i, var_name = var_name_lookahead(i + 1, chars)
+                        tokens.append(VarToken(name=var_name, operator=None, operand=None))
+                        continue  # already advanced i to a char after var name
+
+                # Regular character
+                append_text_char(char)
+                i += 1
+                continue
+
+            # in_brace == True
+            closing_index = advance_to_closing_brace(i, chars)
+            brace_content = ''.join(chars[i:closing_index])
+            tokens.append(resolve_brace_content(brace_content))
+            i = closing_index + 1  # move past the closing brace
+            in_brace = False
+            continue
+
+        return tokens
+
+    def interpolate_str(s: str, env: dict[str, str | None]) -> str:
+        tokens = tokenize(s)
+        resolved_parts = [token.resolve(env) for token in tokens]
+        return ''.join(resolved_parts)
+
+    return interpolate_str(value, env)
 
 
 @overload
@@ -305,21 +479,7 @@ def rec_subs(value: dict | str | Iterable, subs_dict: dict[str, Any]) -> dict | 
 
         value = {rec_subs(k, subs_dict): rec_subs(v, subs_dict) for k, v in value.items()}
     elif isinstance(value, str):
-
-        def convert(m: re.Match) -> str:
-            if m.group("escaped") is not None:
-                return "$"
-            name = m.group("named") or m.group("braced")
-            value = subs_dict.get(name)
-            if value == "" and m.group("empty"):
-                value = None
-            if value is not None:
-                return str(value)
-            if m.group("err") is not None:
-                raise RuntimeError(m.group("err"))
-            return m.group("default") or ""
-
-        value = var_re.sub(convert, value)
+        value = var_interpolate(value, subs_dict)
     elif hasattr(value, "__iter__"):
         value = [rec_subs(i, subs_dict) for i in value]
     return value

--- a/tests/unit/test_var_interpolate.py
+++ b/tests/unit/test_var_interpolate.py
@@ -1,0 +1,213 @@
+# SPDX-License-Identifier: GPL-2.0
+
+import subprocess
+import unittest
+from typing import Union
+
+from parameterized import parameterized
+
+from podman_compose import var_interpolate
+
+
+class TestVarInterpolate(unittest.TestCase):
+    test_cases = [
+        # 0. Substitution without braces
+        ("Hello $NAME!", {"NAME": "Alice"}, "Hello Alice!", True),
+        # 1. Substitution with braces
+        ("Hello ${NAME}", {"NAME": "Alice"}, "Hello Alice", True),
+        # 2. Unset variable (empty substitution)
+        ("Hello ${NAME}", {}, "Hello ", True),
+        # 3. Default if unset (:-)
+        ("User: ${USER:-guest}", {}, "User: guest", True),
+        # 4. Default if unset or empty (:-)
+        ("User: ${USER:-guest}", {"USER": ""}, "User: guest", True),
+        # 5. Default if unset (-)
+        ("User: ${USER-guest}", {}, "User: guest", True),
+        # 6. Default if unset but not if empty (-)
+        ("User: ${USER-guest}", {"USER": ""}, "User: ", True),
+        # 7. Required variable (error if unset or empty)
+        ("Path: ${TEST_PATH:?TEST_PATH required}", {"TEST_PATH": "/bin"}, "Path: /bin", True),
+        # 8. Required variable fails when missing
+        (
+            "Path: ${TEST_PATH:?TEST_PATH required}",
+            {},
+            ValueError("required variable TEST_PATH is missing a value: TEST_PATH required"),
+            True,
+        ),
+        # 9. Required variable fails when empty (since :?)
+        (
+            "Path: ${TEST_PATH:?TEST_PATH required}",
+            {"TEST_PATH": ""},
+            ValueError("required variable TEST_PATH is missing a value: TEST_PATH required"),
+            True,
+        ),
+        # 10. Required variable (no colon, fails only if unset)
+        ("Config: ${CFG?missing}", {"CFG": "cfg.yaml"}, "Config: cfg.yaml", True),
+        # 11. Required variable fails when unset
+        (
+            "Config: ${CFG?missing}",
+            {},
+            ValueError("required variable CFG is missing a value: missing"),
+            True,
+        ),
+        # 12. Required variable passes even if empty (no colon)
+        ("Config: ${CFG?missing}", {"CFG": ""}, "Config: ", True),
+        # 13. Alternative if set (:+)
+        ("Alt: ${MODE:+active}", {"MODE": "1"}, "Alt: active", True),
+        # 14. Alternative if set, variable empty (still uses alt)
+        ("Alt: ${MODE+active}", {"MODE": ""}, "Alt: active", True),
+        # 15. Alternative if not set (+)
+        ("Alt: ${MODE+active}", {}, "Alt: ", True),
+        # 16. Combination of multiple vars
+        ("${GREETING:-Hi}, ${NAME:-stranger}!", {}, "Hi, stranger!", True),
+        # 17. Mix of required and default
+        ("${ENV:?Missing ENV} - ${SERVICE:-api}", {"ENV": "prod"}, "prod - api", True),
+        # 18. Default values with spaces
+        ("${USER:-default user}", {}, "default user", True),
+        # 19. Escaped dollar sign
+        (
+            "Price: $$${AMOUNT}",
+            {"AMOUNT": "100"},
+            "Price: $100",
+            False,  # In POSIX shells, $$ becomes PID, so skip shell test
+        ),
+        # 20. Empty variable substitution
+        ("Value: ${VAR}", {"VAR": ""}, "Value: ", True),
+        # 21. Nested default (inner default resolves)
+        ("${OUTER:-${INNER:-default}}", {}, "default", True),
+        # 22. Nested default (inner variable exists)
+        ("${OUTER:-${INNER:-default}}", {"INNER": "inner_value"}, "inner_value", True),
+        # 23. Nested default (outer variable exists)
+        (
+            "${OUTER:-${INNER:-default}}",
+            {"OUTER": "outer_value", "INNER": "inner_value"},
+            "outer_value",
+            True,
+        ),
+        # 24. Nested fallback chain
+        ("${A:-${B:-${C:-final}}}", {}, "final", True),
+        # 25. Nested fallback uses middle value
+        ("${A:-${B:-${C:-final}}}", {"B": "mid"}, "mid", True),
+        # 26. Nested fallback uses top value
+        ("${A:-${B:-${C:-final}}}", {"A": "top"}, "top", True),
+        # 27. Nested required variable message
+        ("${MAIN:-${BACKUP:?Missing BACKUP}}", {"BACKUP": "backup_value"}, "backup_value", True),
+        # 28. Nested required variable fails (inner missing)
+        (
+            "${MAIN:-${BACKUP:?Missing BACKUP}}",
+            {},
+            ValueError("required variable BACKUP is missing a value: Missing BACKUP"),
+            True,
+        ),
+        # 29. Nested default with error in inner fallback
+        ("${X:-${Y:?Y required}}", {"Y": "ok"}, "ok", True),
+        # 30. Nested default that triggers inner error
+        (
+            "${X:-${Y:?Y required}}",
+            {},
+            ValueError("required variable Y is missing a value: Y required"),
+            True,
+        ),
+        # 31. Inner nested default that is never triggered because outer value is used
+        ("${X:-${Y:?Y required}}", {"X": "ok"}, "ok", True),
+        # 32. Nested alternative expansion
+        (
+            "${VAR:+${ALT:-default_alt}}",
+            {"VAR": "something", "ALT": "alt_value"},
+            "alt_value",
+            True,
+        ),
+        # 33. Nested alternative fallback
+        ("${VAR:+${ALT:-default_alt}}", {"VAR": "something"}, "default_alt", True),
+        # 34. Nested with unset outer, inner provides default
+        ("${OUTER:-prefix_${INNER:-none}}", {}, "prefix_none", True),
+        # 35. Nested with inner variable set
+        ("${OUTER:-prefix_${INNER:-none}}", {"INNER": "abc"}, "prefix_abc", True),
+        # 36. Outer required, inner fallback
+        ("${REQ:?Missing ${ALT:-something}}", {"REQ": "value"}, "value", True),
+        # 37. Outer required triggers nested message
+        (
+            "${REQ:?Missing ${ALT:-something}}",
+            {},
+            ValueError("required variable REQ is missing a value: Missing something"),
+            True,
+        ),
+        # 38. Nested alternative chain
+        ("${A:+${B:+${C:-end}}}", {"A": "1", "B": "1", "C": "final"}, "final", True),
+        # 39. Nested alternative where middle missing
+        ("${A:+${B:+${C:-end}}}", {"A": "1"}, "", True),
+        # 40. Triple nested default with middle empty
+        ("${A:-${B:-${C:-${D:-default}}}}", {"B": ""}, "default", True),
+        # 41. Mixed chain: required + default + alternative
+        ("${ENV:-${FALLBACK:+${ALT:-alt_value}}}", {"FALLBACK": "1"}, "alt_value", True),
+        # 42. Invalid variable name in braces (starts with digit)
+        (
+            "${1INVALID}",
+            {},
+            ValueError(
+                "Invalid interpolation format: ${1INVALID}."
+                " You may need to escape any $ with another $"
+            ),
+            True,
+        ),
+        # 43. Invalid variable name in braces (starts with non-alphanumeric)
+        (
+            "${-INVALID}",
+            {},
+            ValueError(
+                "Invalid interpolation format: ${-INVALID}."
+                " You may need to escape any $ with another $"
+            ),
+            True,
+        ),
+        # 44. Invalid variable name in braces (empty)
+        (
+            "${}",
+            {},
+            ValueError(
+                "Invalid interpolation format: ${}. You may need to escape any $ with another $"
+            ),
+            False,
+        ),
+        # 45. Dollar sign not followed by valid variable name (should be treated as literal)
+        # Disable shell comparison since POSIX shells would treat $5 as fifth argument
+        ("Price is $5", {}, "Price is $5", False),
+    ]
+
+    @parameterized.expand(test_cases)
+    def test_var_interpolate(
+        self,
+        to_interpolate: str,
+        var_values: dict[str, str],
+        expected: Union[str, ValueError],
+        compare_shell_evaluation: bool,
+    ) -> None:
+        try:
+            result = var_interpolate(to_interpolate, var_values)
+            self.assertEqual(result, expected)
+        except ValueError as e:
+            self.assertTrue(
+                isinstance(expected, ValueError),
+                msg=f"Expected ValueError for input: {to_interpolate}",
+            )
+            self.assertEqual(str(e), str(expected))
+
+        if not compare_shell_evaluation:
+            return
+
+        # Ensure that the behavior matches the behavior of POSIX shells
+        process = subprocess.Popen(
+            f'echo "{to_interpolate}"',
+            env=var_values,
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        stdout, _ = process.communicate()
+        shell_result = stdout.rstrip(b'\n').decode()
+        exit_code = process.returncode
+        if isinstance(expected, ValueError):
+            error_msg = f"Expected non-zero return code success for input: {to_interpolate}"
+            self.assertNotEqual(exit_code, 0, msg=error_msg)
+        else:
+            self.assertEqual(shell_result, expected)


### PR DESCRIPTION
This commit adds support for nested variable interpolation. Instead of relying on regular expressions with which adhering to the Compose spec will be impossible, lookaheads for matching closing brackets are performed. In addition, support for alternative values (:+ and + operators) is added and the full interpolation feature set described at https://github.com/docker/docs/blob/050f15d67d5956e8a48f8b92c9449c21bc3207cb/content/reference/compose-file/interpolation.md is implemented.