### PR TITLE
Only pull image before containers teardown if podman version >= 5.6.0

### DIFF
--- a/newsfragments/fix_policy_flag_error.bugfix
+++ b/newsfragments/fix_policy_flag_error.bugfix
@@ -1,0 +1,1 @@
+Fix shell error: `unknown flag: --policy`.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -3639,13 +3639,22 @@ async def pull_images(
 async def prepare_images(
     compose: PodmanCompose, args: argparse.Namespace, excluded: set[str]
 ) -> int | None:
-    log.info("pulling images: ...")
 
-    pull_services = [v for k, v in compose.services.items() if k not in excluded]
-    err = await pull_images(compose.podman, args, pull_services)
-    if err:
-        log.error("Pull image failed")
-        return err
+    # When creating containers, podman create internally invokes podman pull with the default
+    # policy of --pull=missing.
+    # To minimize downtime during container up command, we explicitly run podman pull before
+    # tearing down the old container, ensuring the image is already cached when we subsequently
+    # call podman create.
+    # However, the pull --policy flag was only introduced to podman in version 5.6.0, so we can
+    # only perform this pre-teardown optimization when using podman >= 5.6.0.
+    if compose.podman_version is not None and not strverscmp_lt(compose.podman_version, "5.6.0"):
+        log.info("pulling images: ...")
+
+        pull_services = [v for k, v in compose.services.items() if k not in excluded]
+        err = await pull_images(compose.podman, args, pull_services)
+        if err:
+            log.error("Pull image failed")
+            return err
 
     log.info("building images: ...")
 
@@ -3709,7 +3718,7 @@ async def wait_for_container_running_healthy(
 
 
 @cmd_run(podman_compose, "up", "Create and start the entire stack or some of its services")
-async def compose_up(compose: PodmanCompose, args: argparse.Namespace) -> int | None:
+async def compose_up(compose: PodmanCompose, args: argparse.Namespace) -> int | None:  # pylint: disable=too-many-return-statements
     excluded = get_excluded(compose, args)
 
     exit_code = await prepare_images(compose, args, excluded)

--- a/tests/integration/compose_up_behavior/Dockerfile
+++ b/tests/integration/compose_up_behavior/Dockerfile
@@ -1,0 +1,1 @@
+FROM alpine:latest

--- a/tests/integration/compose_up_behavior/docker-compose_build_localhost_image.yaml
+++ b/tests/integration/compose_up_behavior/docker-compose_build_localhost_image.yaml
@@ -1,0 +1,6 @@
+services:
+  test:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: localhost/not-exists

--- a/tests/integration/compose_up_behavior/docker-compose_default_pull_policy.yaml
+++ b/tests/integration/compose_up_behavior/docker-compose_default_pull_policy.yaml
@@ -1,0 +1,4 @@
+services:
+  test:
+    image: alpine:latest
+    command: ["true"]

--- a/tests/integration/compose_up_behavior/docker-compose_non_existent_localhost_image.yaml
+++ b/tests/integration/compose_up_behavior/docker-compose_non_existent_localhost_image.yaml
@@ -1,0 +1,6 @@
+services:
+  test:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: localhost/test-image:1

--- a/tests/integration/compose_up_behavior/docker-compose_override_missing.yaml
+++ b/tests/integration/compose_up_behavior/docker-compose_override_missing.yaml
@@ -1,0 +1,9 @@
+services:
+  test:
+    image: alpine:latest
+    command: ["true"]
+    # default pull_policy is 'missing'
+  test-override:
+    image: alpine:latest
+    command: ["true"]
+    pull_policy: always

--- a/tests/integration/compose_up_behavior/test_compose_up_behavior.py
+++ b/tests/integration/compose_up_behavior/test_compose_up_behavior.py
@@ -5,9 +5,11 @@ import os
 import unittest
 from typing import Any
 
+from packaging import version
 from parameterized import parameterized
 
 from tests.integration.test_utils import RunSubprocessMixin
+from tests.integration.test_utils import get_podman_version
 from tests.integration.test_utils import podman_compose_path
 from tests.integration.test_utils import test_path
 
@@ -18,7 +20,7 @@ def compose_yaml_path(scenario: str) -> str:
     )
 
 
-class TestComposeDownBehavior(unittest.TestCase, RunSubprocessMixin):
+class TestComposeUpBehavior(unittest.TestCase, RunSubprocessMixin):
     def get_existing_containers(self, scenario: str) -> dict[str, Any]:
         out, _ = self.run_subprocess_assert_returncode(
             [
@@ -133,3 +135,276 @@ class TestComposeDownBehavior(unittest.TestCase, RunSubprocessMixin):
                 "-t",
                 "0",
             ])
+
+    @unittest.skipIf(
+        get_podman_version() < version.parse("5.6.0"),
+        "The image pull policy feature was only added as of Podman 5.6.0.",
+    )
+    def test_pull_only_if_image_missing(self) -> None:
+        """Verify image is pulled because default pull policy is --missing"""
+
+        compose_file = compose_yaml_path("default_pull_policy")
+        image = "docker.io/library/alpine:latest"
+
+        try:
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_file,
+                "up",
+                "-d",
+            ])
+
+            # Remove image while container is still up
+            self.run_subprocess_assert_returncode([
+                "podman",
+                "rmi",
+                "-f",
+                image,
+            ])
+
+            # up container one more time, it sees missing images and pulls them again
+            _, error = self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "--verbose",
+                "-f",
+                compose_file,
+                "up",
+                "-d",
+            ])
+
+            # podman pull command is explicitly run before container teardown and now is
+            # visible in --verbose output. After container teardown, podman create is called
+            # and already has needed images available
+            self.assertIn(b"podman pull --policy missing alpine:latest", error)
+
+            output, _ = self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_file,
+                "ps",
+            ])
+            self.assertIn(b"compose_up_behavior_test_1", output)
+        finally:
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_file,
+                "down",
+                "-t",
+                "0",
+            ])
+            self.run_subprocess_assert_returncode([
+                "podman",
+                "rmi",
+                "-f",
+                image,
+            ])
+
+    @unittest.skipIf(
+        get_podman_version() < version.parse("5.6.0"),
+        "The image pull policy feature was only added as of Podman 5.6.0.",
+    )
+    def test_pull_default_policy_overrides_lower_priority_policy(self) -> None:
+        """Verify pull policy flag with higher priority overrides the default pull
+        policy --missing"""
+
+        compose_file = compose_yaml_path("override_missing")
+        image = "docker.io/library/alpine:latest"
+
+        try:
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_file,
+                "up",
+                "-d",
+            ])
+
+            # Remove image while container is still up
+            self.run_subprocess_assert_returncode([
+                "podman",
+                "rmi",
+                "-f",
+                image,
+            ])
+
+            # up container one more time
+            _, error = self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "--verbose",
+                "-f",
+                compose_file,
+                "up",
+                "-d",
+            ])
+            # default pull-policy is --missing, but it has been overridden by policy of
+            # higher priority --always
+            self.assertIn(b"podman pull --policy always alpine:latest", error)
+        finally:
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_file,
+                "down",
+                "-t",
+                "0",
+            ])
+            self.run_subprocess_assert_returncode([
+                "podman",
+                "rmi",
+                "-f",
+                image,
+            ])
+
+    @unittest.skipIf(
+        get_podman_version() < version.parse("5.6.0"),
+        "The image pull policy feature was only added as of Podman 5.6.0.",
+    )
+    def test_localhost_image_not_pulled(self) -> None:
+        """Verify existing localhost/ images are used locally without pulling"""
+
+        compose_file = compose_yaml_path("non_existent_localhost_image")
+        image = "localhost/test-image:1"
+
+        try:
+            # pre-create image locally by tagging a minimal base image,
+            # this simulates the image already existing locally
+            self.run_subprocess_assert_returncode(["podman", "pull", "alpine:latest"])
+            self.run_subprocess_assert_returncode(["podman", "tag", "alpine:latest", image])
+
+            output, _ = self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_file,
+                "up",
+                "-d",
+            ])
+
+            # Remove image while container is still up
+            self.run_subprocess_assert_returncode([
+                "podman",
+                "rmi",
+                "-f",
+                image,
+            ])
+
+            # since the compose file has both 'build' and 'image', podman-compose
+            # should use the existing image (or rebuild if necessary), but it should
+            # never attempt to pull localhost/ images
+            _, error = self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "--verbose",
+                "-f",
+                compose_file,
+                "up",
+                "-d",
+            ])
+            self.assertNotIn(b"Trying to pull", error)
+
+            # Confirm container is actually started with localhost/ image
+            output, _ = self.run_subprocess_assert_returncode([
+                "podman",
+                "ps",
+                "-a",
+                "--filter",
+                f"ancestor={image}",
+                "--format",
+                "{{.Image}}",
+            ])
+            self.assertIn(b"localhost/test-image:1", output)
+        finally:
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_file,
+                "down",
+            ])
+            self.run_subprocess_assert_returncode([
+                "podman",
+                "rmi",
+                "-f",
+                image,
+            ])
+
+    @unittest.skipIf(
+        get_podman_version() < version.parse("5.6.0"),
+        "The image pull policy feature was only added as of Podman 5.6.0.",
+    )
+    def test_localhost_image_built_if_does_not_exist(self) -> None:
+        """Verify non-existent localhost/ images are built instead of pulling"""
+
+        compose_file = compose_yaml_path("build_localhost_image")
+        image = "localhost/not-exists"
+
+        # check image does not exist
+        self.run_subprocess_assert_returncode(
+            [
+                "podman",
+                "image",
+                "exists",
+                image,
+            ],
+            1,
+        )
+
+        try:
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_file,
+                "up",
+                "-d",
+            ])
+
+            # Remove image while container is still up
+            self.run_subprocess_assert_returncode([
+                "podman",
+                "rmi",
+                "-f",
+                image,
+            ])
+
+            # image was not pulled, it was built
+            output, _ = self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "--verbose",
+                "-f",
+                compose_file,
+                "up",
+                "-d",
+            ])
+            self.assertNotIn(b"Trying to pull", output)
+
+            # After up command, image now exists (was built)
+            output, _ = self.run_subprocess_assert_returncode([
+                "podman",
+                "images",
+                "--filter",
+                f"reference={image}",
+                "--format",
+                "{{.Repository}}:{{.Tag}}",
+            ])
+            self.assertIn(image.encode(), output)
+
+            # Container uses the locally built image
+            output, _ = self.run_subprocess_assert_returncode([
+                "podman",
+                "ps",
+                "-a",
+                "--filter",
+                f"ancestor={image}",
+                "--format",
+                "{{.Image}}",
+            ])
+            self.assertIn(image.encode(), output)
+        finally:
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_file,
+                "down",
+            ])
+            self.run_subprocess_assert_returncode(
+                ["podman", "rmi", "-f", image],
+            )


### PR DESCRIPTION
This PR adds missing integration tests (https://github.com/containers/podman-compose/issues/1426) and fixes the `Error: unknown flag: --policy` errors (https://github.com/containers/podman-compose/issues/1417).

After container teardown, podman `create` internally pulls missing images using the default `--pull=missing` policy.
By explicitly calling podman `pull` before teardown, we reduce container downtime. This requires to pass the `--policy=missing` option to podman `pull` to maintain podman-compose's defaults.
Since this option was introduced in Podman 5.6.0, the optimization is only available from that version onwards.

Integration tests for #1298 (Feat pull images before teardown containers on up command, ef9785a) were missing, so compatibility issues with older Podman versions were not caught.

podman `pull --policy` documentation:
https://docs.podman.io/en/stable/markdown/podman-pull.1.html
    
compose specification for `pull_policy`:
https://github.com/compose-spec/compose-spec/blob/main/05-services.md#pull_policy


