### PR TITLE
Fix override tag to work with `depends_on` parameter

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2059,10 +2059,12 @@ def normalize_service(service: dict[str, Any], sub_dir: str = "") -> dict[str, A
             deps = {deps: {}}
         elif is_list(deps):
             deps = {x: {} for x in deps}
+        elif isinstance(deps, OverrideTag):
+            deps.value = {x: {} for x in deps.value}
 
         # the dependency service_started is set by default
         # unless requested otherwise.
-        for k, v in deps.items():
+        for k, v in deps.items() if not isinstance(deps, OverrideTag) else deps.value.items():  # type: ignore[union-attr]
             v.setdefault('condition', 'service_started')
         service["depends_on"] = deps
     if "volumes" in service and sub_dir:

--- a/tests/integration/merge/reset_and_override_tags/override_tag_attribute/docker-compose.override_attribute.yaml
+++ b/tests/integration/merge/reset_and_override_tags/override_tag_attribute/docker-compose.override_attribute.yaml
@@ -5,3 +5,8 @@ services:
         command: ["/bin/busybox", "echo", "One"]
         ports: !override
             - "8111:81"
+        depends_on: !override
+            - other_db
+    other_db:
+        image: busybox
+        command: ["/bin/busybox", "sleep", "10"]

--- a/tests/integration/merge/reset_and_override_tags/override_tag_attribute/docker-compose.yaml
+++ b/tests/integration/merge/reset_and_override_tags/override_tag_attribute/docker-compose.yaml
@@ -5,3 +5,5 @@ services:
         command: ["/bin/busybox", "echo", "Zero"]
         ports:
             - "8080:80"
+        depends_on:
+          - db

--- a/tests/integration/merge/reset_and_override_tags/override_tag_attribute/test_podman_compose_override_tag_attribute.py
+++ b/tests/integration/merge/reset_and_override_tags/override_tag_attribute/test_podman_compose_override_tag_attribute.py
@@ -60,6 +60,8 @@ class TestComposeOverrideTagAttribute(unittest.TestCase, RunSubprocessMixin):
                 container_info['NetworkSettings']["Ports"],
                 {"81/tcp": [{"HostIp": "", "HostPort": "8111"}]},
             )
+            # depends_on: !override testing: if this test works, depends_on is correctly overridden.
+            # Otherwise, the test would break, since "db" dependency service is not provided
         finally:
             self.run_subprocess_assert_returncode([
                 podman_compose_path(),


### PR DESCRIPTION
This pr fixes a bug where `!override` doesn't work with `depends_on` in the service configuration. Currently the following example does work in docker-compose, but throws an error with podman-compose:

compose.yml:
```yaml
services:
  app:
    image: busybox
    command: ["/bin/busybox", "echo", "Hello"]
    depends_on:
      - db
```

compose.override.yml:
```yaml
services:
  app:
    depends_on: !override
      - other_db
  other_db:
    image: busybox
    command: ["/bin/busybox", "sleep", "10"]
```
Here is the corresponding Docker-Documentation: https://docs.docker.com/reference/compose-file/merge/#replace-value

This issue is also referenced in #1208 