### PR TITLE
fix symlink volumes for remote container

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -576,7 +576,7 @@ async def assert_volume(compose: PodmanCompose, mount_dict: dict[str, Any]) -> N
     if mount_dict["type"] == "bind":
         basedir = os.path.realpath(compose.dirname)
         mount_src = mount_dict["source"]
-        mount_src = os.path.realpath(os.path.join(basedir, os.path.expanduser(mount_src)))
+        mount_src = os.path.abspath(os.path.join(basedir, os.path.expanduser(mount_src)))
         if not os.path.exists(mount_src):
             bind_opts = mount_dict.get("bind", {})
             if "create_host_path" in bind_opts and not bind_opts["create_host_path"]:


### PR DESCRIPTION
For now, if volume source is a symlink, it's dereferenced, resulting to a change of the volume source path. 
If remote container host doesn't have the same path as the local symlink target, such volume can't mount and breaks the compose.

This scenario is commonly used in flatpaks, where $XDG_RUNTIME_DIR is full of flatpaks-specific symlinks:
```console
$ find $XDG_RUNTIME_DIR/ -type l -ls
      797      0 lrwxrwxrwx   1 bam      bam            17 апр  8 01:27 /run/user/1001/bus -> ../../flatpak/bus
      796      0 lrwxrwxrwx   1 bam      bam            19 апр  8 01:27 /run/user/1001/pulse -> ../../flatpak/pulse
      795      0 lrwxrwxrwx   1 bam      bam            23 апр  8 01:27 /run/user/1001/wayland-0 -> ../../flatpak/wayland-0
      794      0 lrwxrwxrwx   1 bam      bam            17 апр  8 01:27 /run/user/1001/app -> ../../flatpak/app
      793      0 lrwxrwxrwx   1 bam      bam            17 апр  8 01:27 /run/user/1001/doc -> ../../flatpak/doc
      792      0 lrwxrwxrwx   1 bam      bam            22 апр  8 01:27 /run/user/1001/.flatpak -> ../../flatpak/.flatpak
      791      0 lrwxrwxrwx   1 bam      bam            21 апр  8 01:27 /run/user/1001/p11-kit -> ../../flatpak/p11-kit
      790      0 lrwxrwxrwx   1 bam      bam            22 апр  8 01:27 /run/user/1001/flatpak-info -> ../../../.flatpak-info
```
Consider following typical volume declaration for Wayland socket pass-through:
```yaml
    volumes:
      - $XDG_RUNTIME_DIR/$WAYLAND_DISPLAY:$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY:ro
```
If compose happens in flatpak, and `podman` is in the remote mode (`podman-compose --podman-path podman-remote` option or `remote = true` in [`containers.conf`](https://github.com/containers/container-libs/blob/main/common/docs/containers.conf.5.md)), this breaks `podman create` call as the remote system doesn't have local `/run/flatpak/wayland-0` path, without any feasible workarounds:
```console
$ podman-compose --verbose up
...
podman create ... -v /run/flatpak/wayland-0:/run/user/1001/wayland-0:ro ...
Error: statfs /run/flatpak/wayland-0: no such file or directory
```
This is fixed by avoiding the symlinks dereference in the volume source paths.