### PR TITLE
Honor `target` option for mount-type external secrets

### DIFF
--- a/newsfragments/secret-target-mount.bugfix
+++ b/newsfragments/secret-target-mount.bugfix
@@ -1,0 +1,1 @@
+Honor the `target` suboption on mount-type external secrets. Previously the target was silently ignored with a warning; it is now forwarded to podman, aligning with docker-compose behavior.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -891,28 +891,13 @@ def get_secret_args(
         secret_opts += f",gid={secret_gid}" if secret_gid else ""
         secret_opts += f",mode={secret_mode}" if secret_mode else ""
         secret_opts += f",type={secret_type}" if secret_type else ""
-        secret_opts += f",target={secret_target}" if secret_target and secret_type == "env" else ""
-        # The target option is only valid for type=env,
-        # which in an ideal world would work
-        # for type=mount as well.
-        # having a custom name for the external secret
-        # has the same problem as well
+        secret_opts += f",target={secret_target}" if secret_target else ""
+        # having a custom name for the external secret is not supported
         ext_name = declared_secret.get("name")
-        err_str = (
-            'ERROR: Custom name/target reference "{}" '
-            'for mounted external secret "{}" is not supported'
-        )
         if ext_name and ext_name != secret_name:
-            raise ValueError(err_str.format(secret_name, ext_name))
-        if secret_target and secret_target != secret_name and secret_type != 'env':
-            raise ValueError(err_str.format(secret_target, secret_name))
-        if secret_target and secret_type != 'env':
-            log.warning(
-                'WARNING: Service "%s" uses target: "%s" for secret: "%s".'
-                + " That is un-supported and a no-op and is ignored.",
-                cnt["_service"],
-                secret_target,
-                secret_name,
+            raise ValueError(
+                f'ERROR: Custom name/target reference "{secret_name}" '
+                f'for mounted external secret "{ext_name}" is not supported'
             )
         return ["--secret", f"{secret_name}{secret_opts}"]
 

--- a/tests/integration/secrets/test_podman_compose_secrets.py
+++ b/tests/integration/secrets/test_podman_compose_secrets.py
@@ -49,10 +49,8 @@ class TestComposeNoSecrets(unittest.TestCase, RunSubprocessMixin):
                 ],
             )
 
-            self.assertIn(
-                b'WARNING: Service "test" uses target: "podman_compose_test_secret_3" '
-                + b'for secret: "podman_compose_test_secret_3". That is un-supported and '
-                + b'a no-op and is ignored.',
+            self.assertNotIn(
+                b'That is un-supported and a no-op and is ignored.',
                 error,
             )
             self.assertIn(

--- a/tests/unit/test_container_to_args_secrets.py
+++ b/tests/unit/test_container_to_args_secrets.py
@@ -179,12 +179,7 @@ class TestContainerToArgsSecrets(unittest.IsolatedAsyncioTestCase):
             }
         ]
 
-        with self.assertLogs() as cm:
-            args = await container_to_args(c, cnt)
-        self.assertEqual(len(cm.output), 1)
-        self.assertIn('That is un-supported and a no-op and is ignored.', cm.output[0])
-        self.assertIn('my_secret_name', cm.output[0])
-
+        args = await container_to_args(c, cnt)
         self.assertEqual(
             args,
             [
@@ -192,7 +187,7 @@ class TestContainerToArgsSecrets(unittest.IsolatedAsyncioTestCase):
                 "-d",
                 "--network=bridge:alias=service_name",
                 "--secret",
-                "my_secret_name,uid=103,gid=103,mode=400",
+                "my_secret_name,uid=103,gid=103,mode=400,target=my_secret_name",
                 "busybox",
             ],
         )
@@ -217,7 +212,7 @@ class TestContainerToArgsSecrets(unittest.IsolatedAsyncioTestCase):
             await container_to_args(c, cnt)
         self.assertIn('ERROR: Custom name/target reference ', str(context.exception))
 
-    async def test_secret_target_does_not_match_secret_name_secret_type_not_env(self) -> None:
+    async def test_secret_target_does_not_match_secret_name_secret_type_mount(self) -> None:
         c = create_compose_mock()
         c.declared_secrets = {
             "my_secret_name": {
@@ -229,14 +224,23 @@ class TestContainerToArgsSecrets(unittest.IsolatedAsyncioTestCase):
         cnt["secrets"] = [
             {
                 "source": "my_secret_name",
-                "target": "does_not_equal_secret_name",
-                "type": "does_not_equal_env",
+                "target": "/tmp/custom_path",
+                "type": "mount",
             }
         ]
 
-        with self.assertRaises(ValueError) as context:
-            await container_to_args(c, cnt)
-        self.assertIn('ERROR: Custom name/target reference ', str(context.exception))
+        args = await container_to_args(c, cnt)
+        self.assertEqual(
+            args,
+            [
+                "--name=project_name_service_name1",
+                "-d",
+                "--network=bridge:alias=service_name",
+                "--secret",
+                "my_secret_name,type=mount,target=/tmp/custom_path",
+                "busybox",
+            ],
+        )
 
     async def test_secret_target_does_not_match_secret_name_secret_type_env(self) -> None:
         c = create_compose_mock()
@@ -273,16 +277,9 @@ class TestContainerToArgsSecrets(unittest.IsolatedAsyncioTestCase):
         }
         cnt = get_minimal_container()
         cnt["_service"] = "test-service"
-        cnt["secrets"] = [
-            {"source": "my_secret_name", "target": "my_secret_name", "type": "does_not_equal_env"}
-        ]
+        cnt["secrets"] = [{"source": "my_secret_name", "target": "my_secret_name", "type": "mount"}]
 
-        with self.assertLogs() as cm:
-            args = await container_to_args(c, cnt)
-        self.assertEqual(len(cm.output), 1)
-        self.assertIn('That is un-supported and a no-op and is ignored.', cm.output[0])
-        self.assertIn('my_secret_name', cm.output[0])
-
+        args = await container_to_args(c, cnt)
         self.assertEqual(
             args,
             [
@@ -290,7 +287,7 @@ class TestContainerToArgsSecrets(unittest.IsolatedAsyncioTestCase):
                 "-d",
                 "--network=bridge:alias=service_name",
                 "--secret",
-                "my_secret_name,type=does_not_equal_env",
+                "my_secret_name,type=mount,target=my_secret_name",
                 "busybox",
             ],
         )
@@ -428,3 +425,104 @@ class TestContainerToArgsSecrets(unittest.IsolatedAsyncioTestCase):
         with self.assertRaises(ValueError) as context:
             await container_to_args(c, cnt)
         self.assertIn('not supported for runtime secrets', str(context.exception))
+
+    async def test_external_secret_with_target_path_uid_gid_mode(self) -> None:
+        """Reproduce the reported bug: external secret with custom target path, uid, gid, mode."""
+        c = create_compose_mock()
+        c.declared_secrets = {"ssh-private-key": {"external": True}}
+        cnt = get_minimal_container()
+        cnt["_service"] = "alpine_secret"
+        cnt["secrets"] = [
+            {
+                "source": "ssh-private-key",
+                "target": "/tmp/private_key",
+                "mode": "700",
+                "uid": "600",
+                "gid": "600",
+            }
+        ]
+
+        args = await container_to_args(c, cnt)
+        self.assertEqual(
+            args,
+            [
+                "--name=project_name_service_name1",
+                "-d",
+                "--network=bridge:alias=service_name",
+                "--secret",
+                "ssh-private-key,uid=600,gid=600,mode=700,target=/tmp/private_key",
+                "busybox",
+            ],
+        )
+
+    async def test_external_secret_with_mount_type_and_target(self) -> None:
+        """External secret with explicit type=mount and a target path."""
+        c = create_compose_mock()
+        c.declared_secrets = {"my_secret": {"external": True}}
+        cnt = get_minimal_container()
+        cnt["_service"] = "test-service"
+        cnt["secrets"] = [
+            {
+                "source": "my_secret",
+                "target": "/etc/secrets/my_secret",
+                "type": "mount",
+                "uid": "1000",
+                "gid": "1000",
+                "mode": "400",
+            }
+        ]
+
+        args = await container_to_args(c, cnt)
+        self.assertEqual(
+            args,
+            [
+                "--name=project_name_service_name1",
+                "-d",
+                "--network=bridge:alias=service_name",
+                "--secret",
+                "my_secret,uid=1000,gid=1000,mode=400,type=mount,target=/etc/secrets/my_secret",
+                "busybox",
+            ],
+        )
+
+    async def test_external_secret_no_target(self) -> None:
+        """External secret without target should not include target in args."""
+        c = create_compose_mock()
+        c.declared_secrets = {"my_secret": {"external": True}}
+        cnt = get_minimal_container()
+        cnt["_service"] = "test-service"
+        cnt["secrets"] = [
+            {
+                "source": "my_secret",
+            }
+        ]
+
+        args = await container_to_args(c, cnt)
+        self.assertEqual(
+            args,
+            [
+                "--name=project_name_service_name1",
+                "-d",
+                "--network=bridge:alias=service_name",
+                "--secret",
+                "my_secret",
+                "busybox",
+            ],
+        )
+
+    async def test_external_secret_custom_name_mismatch_still_raises(self) -> None:
+        """External secret with mismatched 'name' should still raise ValueError."""
+        c = create_compose_mock()
+        c.declared_secrets = {
+            "my_secret": {
+                "external": True,
+                "name": "different_name",
+            }
+        }
+        cnt = get_minimal_container()
+        cnt["_service"] = "test-service"
+        cnt["secrets"] = ["my_secret"]
+
+        with self.assertRaises(ValueError) as context:
+            await container_to_args(c, cnt)
+        self.assertIn('ERROR: Custom name/target reference ', str(context.exception))


### PR DESCRIPTION
Aligns behavior with docker-compose, which always honors `target`.

Previously, `target` on an external secret was only forwarded to `podman run --secret` when `type=env`. For `type=mount` (the default), the target was silently dropped and a warning was emitted, even though podman (>= 4.0) supports `--secret name,type=mount,target=/path`.

Changes:
- Always append `target=X` to the `--secret` options when set, not only for env-type secrets.
- Drop the "un-supported and a no-op and is ignored" warning.
- Drop the ValueError raised when `target != secret_name` and `type != env` — this was rejecting configurations that podman now accepts natively.

The check for a mismatched `name:` on the declared secret is kept: external secrets with a custom name still raise ValueError, as podman cannot rename external secrets at mount time.
