### PR TITLE
Adds the correct behavior for the dockerfile attribute when using git context.

### DIFF
--- a/newsfragments/honor_dockerfile_attribute_with_git_context.bugfix
+++ b/newsfragments/honor_dockerfile_attribute_with_git_context.bugfix
@@ -1,0 +1,1 @@
+Honor the `dockerfile` attribute when using a git remote context.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -3488,6 +3488,9 @@ def container_to_build_args(
                 raise OSError(f"Dockerfile not found in {dockerfile}")
             raise OSError(f"Dockerfile not found in {ctx}")
 
+    if is_context_git_url(ctx) and dockerfile:
+        build_args.extend(["-f", dockerfile])
+
     build_args.extend(["-t", cnt["image"]])
 
     if "platform" in cnt:

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -3488,7 +3488,7 @@ def container_to_build_args(
                 raise OSError(f"Dockerfile not found in {dockerfile}")
             raise OSError(f"Dockerfile not found in {ctx}")
 
-    if is_context_git_url(ctx) and dockerfile:
+    elif dockerfile:
         build_args.extend(["-f", dockerfile])
 
     build_args.extend(["-t", cnt["image"]])

--- a/tests/unit/test_container_to_build_args.py
+++ b/tests/unit/test_container_to_build_args.py
@@ -195,6 +195,27 @@ class TestContainerToBuildArgs(unittest.TestCase):
             ],
         )
 
+    def test_context_git_url_with_dockerfile(self):
+        c = create_compose_mock()
+
+        cnt = get_minimal_container()
+        cnt['build']['context'] = "https://github.com/test_repo.git"
+        cnt['build']['dockerfile'] = "Dockerfile.custom"
+        args = get_minimal_args()
+
+        args = container_to_build_args(c, cnt, args, lambda path: False)
+        self.assertEqual(
+            args,
+            [
+                '-f',
+                'Dockerfile.custom',
+                '-t',
+                'new-image',
+                '--no-cache',
+                'https://github.com/test_repo.git',
+            ],
+        )
+
     def test_context_invalid_git_url_git_is_not_prefix(self):
         c = create_compose_mock()
 


### PR DESCRIPTION
The current implementation of Git remote contexts fails to respect/honor the Dockerfile attribute in the compose file. This fix results in "Dockerfile" being used if the attribute is unset and the value of the dockerfile attribute otherwise. This brings it in-line with docker compose and the intended compose-spec behavior.