### PR TITLE
Show friendly missing external network/volume errors and quote create hints

### DIFF
--- a/newsfragments/beautify-missing-external-network.bugfix
+++ b/newsfragments/beautify-missing-external-network.bugfix
@@ -1,0 +1,1 @@
+Show a clean one-line error (without Python traceback) when an external network or volume is missing, including a suggested `podman network create` / `podman volume create` command.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -603,7 +603,10 @@ async def assert_volume(compose: PodmanCompose, mount_dict: dict[str, Any]) -> N
 
     except subprocess.CalledProcessError as e:
         if is_ext:
-            raise RuntimeError(f"External volume [{vol_name}] does not exist") from e
+            raise PodmanComposeError(
+                f"External volume [{vol_name}] does not exist. "
+                f"Create it first with: podman volume create '{vol_name}'"
+            ) from e
         labels = vol.get("labels", [])
         args = [
             "create",
@@ -1154,7 +1157,10 @@ async def assert_cnt_nets(compose: PodmanCompose, cnt: dict[str, Any]) -> None:
             await compose.podman.output([], "network", ["exists", net_name])
         except subprocess.CalledProcessError as e:
             if is_ext:
-                raise RuntimeError(f"External network [{net_name}] does not exist") from e
+                raise PodmanComposeError(
+                    f"External network [{net_name}] does not exist. "
+                    f"Create it first with: podman network create '{net_name}'"
+                ) from e
             args = get_network_create_args(net_desc, compose.project_name, net_name)
             await compose.podman.output([], "network", args)
             await compose.podman.output([], "network", ["exists", net_name])
@@ -4953,7 +4959,11 @@ async def async_main() -> None:
 
 
 def main() -> None:
-    asyncio.run(async_main())
+    try:
+        asyncio.run(async_main())
+    except PodmanComposeError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_container_to_args.py
+++ b/tests/unit/test_container_to_args.py
@@ -2,6 +2,7 @@
 
 import os
 import shutil
+import subprocess
 import unittest
 from typing import Any
 from unittest import mock
@@ -9,6 +10,7 @@ from unittest import mock
 from parameterized import parameterized
 
 from podman_compose import PodmanCompose
+from podman_compose import PodmanComposeError
 from podman_compose import container_to_args
 
 
@@ -45,6 +47,29 @@ def get_test_file_path(rel_path: str) -> str:
 
 
 class TestContainerToArgs(unittest.IsolatedAsyncioTestCase):
+    async def test_external_network_missing_raises_user_friendly_error(self) -> None:
+        c = create_compose_mock()
+        c.default_net = "external_net"
+        c.networks = {
+            "external_net": {
+                "external": True,
+                "name": "missing-external-network",
+            }
+        }
+
+        async def podman_output(*args: Any, **kwargs: Any) -> None:
+            if args[2] == ["exists", "missing-external-network"]:
+                raise subprocess.CalledProcessError(1, "podman network exists")
+
+        setattr(c.podman, "output", mock.Mock(side_effect=podman_output))
+        cnt = get_minimal_container()
+
+        with self.assertRaisesRegex(
+            PodmanComposeError,
+            r"External network \[missing-external-network\] does not exist\.",
+        ):
+            await container_to_args(c, cnt)
+
     async def test_minimal(self) -> None:
         c = create_compose_mock()
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: GPL-2.0
+
+import contextlib
+import io
+import unittest
+from unittest import mock
+
+from podman_compose import PodmanComposeError
+from podman_compose import main
+
+
+class TestMain(unittest.TestCase):
+    @mock.patch("podman_compose.asyncio.run")
+    def test_main_shows_clean_error_for_podman_compose_error(self, mocked_run: mock.Mock) -> None:
+        def fake_asyncio_run(coro: object) -> None:
+            if hasattr(coro, "close"):
+                coro.close()  # prevent un-awaited coroutine warnings in this unit test
+            raise PodmanComposeError("External network [missing-net] does not exist")
+
+        mocked_run.side_effect = fake_asyncio_run
+        stderr = io.StringIO()
+
+        with contextlib.redirect_stderr(stderr), self.assertRaises(SystemExit) as ex:
+            main()
+
+        self.assertEqual(ex.exception.code, 1)
+        self.assertEqual(
+            stderr.getvalue().strip(),
+            "Error: External network [missing-net] does not exist",
+        )


### PR DESCRIPTION
Convert missing external network/volume failures to PodmanComposeError,
handle them cleanly in main() without Python traceback, and include
actionable create commands with quoted names.

Add unit tests for the network error path and main() error formatting.
Add a newsfragment for the user-facing bugfix.