### PR TITLE
fix: prefer built image over registry when build: is set (#1445)

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -3368,6 +3368,17 @@ async def build_one(compose: PodmanCompose, args: argparse.Namespace, cnt: dict)
     status = await compose.podman.run([], "build", build_args)
     for c in cleanup_callbacks:
         c()
+
+    # When both build: and image: are specified, podman build tags the image
+    # as localhost/<image>, but podman run resolves the bare image name to
+    # the registry. Update the image reference to the localhost/ form so the
+    # locally built image is used instead of the registry one (matching
+    # docker-compose behaviour). See: #1445
+    if status == 0 and "image" in cnt:
+        image = cnt["image"]
+        if not image.startswith("localhost/") and "/" not in image:
+            cnt["image"] = f"localhost/{image}"
+
     return status
 
 

--- a/tests/unit/test_prefer_built_image.py
+++ b/tests/unit/test_prefer_built_image.py
@@ -1,0 +1,76 @@
+"""Test that when both build: and image: are specified, the built image
+is preferred over the registry image. See: #1445"""
+
+import unittest
+from argparse import Namespace
+from unittest import mock
+
+from podman_compose import build_one
+
+
+class TestPreferBuiltImageOverRegistry(unittest.IsolatedAsyncioTestCase):
+    @mock.patch("podman_compose.container_to_build_args", return_value=["build-args"])
+    @mock.patch("podman_compose.PodmanCompose")
+    async def test_build_updates_image_to_localhost(
+        self, compose_mock, build_args_mock
+    ):
+        """When build: and image: are both set and image has no registry prefix,
+        build_one should update cnt['image'] to localhost/<image> so the locally
+        built image is used instead of the registry one."""
+        compose_mock.podman.run = mock.AsyncMock(return_value=0)
+
+        cnt = {"build": {"context": "."}, "image": "caddy:alpine"}
+        args = Namespace(if_not_exists=None)
+
+        result = await build_one(compose_mock, args, cnt)
+
+        assert result == 0
+        assert cnt["image"] == "localhost/caddy:alpine"
+
+    @mock.patch("podman_compose.container_to_build_args", return_value=["build-args"])
+    @mock.patch("podman_compose.PodmanCompose")
+    async def test_build_does_not_double_prefix_localhost(
+        self, compose_mock, build_args_mock
+    ):
+        """If image already starts with localhost/, don't double-prefix."""
+        compose_mock.podman.run = mock.AsyncMock(return_value=0)
+
+        cnt = {"build": {"context": "."}, "image": "localhost/caddy:alpine"}
+        args = Namespace(if_not_exists=None)
+
+        result = await build_one(compose_mock, args, cnt)
+
+        assert result == 0
+        assert cnt["image"] == "localhost/caddy:alpine"
+
+    @mock.patch("podman_compose.container_to_build_args", return_value=["build-args"])
+    @mock.patch("podman_compose.PodmanCompose")
+    async def test_build_does_not_prefix_registry_image(
+        self, compose_mock, build_args_mock
+    ):
+        """If image has a registry prefix (contains /), don't add localhost/."""
+        compose_mock.podman.run = mock.AsyncMock(return_value=0)
+
+        cnt = {"build": {"context": "."}, "image": "ghcr.io/user/caddy:alpine"}
+        args = Namespace(if_not_exists=None)
+
+        result = await build_one(compose_mock, args, cnt)
+
+        assert result == 0
+        assert cnt["image"] == "ghcr.io/user/caddy:alpine"
+
+    @mock.patch("podman_compose.container_to_build_args", return_value=["build-args"])
+    @mock.patch("podman_compose.PodmanCompose")
+    async def test_build_failure_does_not_update_image(
+        self, compose_mock, build_args_mock
+    ):
+        """If the build fails, don't update the image name."""
+        compose_mock.podman.run = mock.AsyncMock(return_value=1)
+
+        cnt = {"build": {"context": "."}, "image": "caddy:alpine"}
+        args = Namespace(if_not_exists=None)
+
+        result = await build_one(compose_mock, args, cnt)
+
+        assert result == 1
+        assert cnt["image"] == "caddy:alpine"


### PR DESCRIPTION
## Problem

When both `build:` and `image:` keys are present in a service definition, `podman-compose` builds the image but then runs the registry image instead of the locally built one.

```yaml
web:
  image: caddy:alpine
  build: .
```

`podman build -t caddy:alpine` creates `localhost/caddy:alpine`, but `podman run caddy:alpine` resolves to `docker.io/library/caddy:alpine` (the registry image). This does not match docker-compose behaviour, where the built image is preferred.

Fixes #1445

## Root Cause

In `build_one()`, after a successful build, the `cnt["image"]` reference still holds the bare image name (e.g., `caddy:alpine`). When podman resolves this at run time, it looks up the registry instead of the locally built image (tagged as `localhost/caddy:alpine`).

## Fix

After a successful build, when the image name does not already have a `localhost/` prefix or a registry domain (no `/`), update `cnt["image"]` to the `localhost/` form. This ensures `podman run` resolves to the locally built image.

## Testing

Added 4 unit tests covering:
- **Bare image name** (e.g., `caddy:alpine`): gets prefixed with `localhost/`
- **Already localhost-prefixed**: no double-prefixing
- **Registry-prefixed** (e.g., `ghcr.io/user/caddy:alpine`): left unchanged
- **Build failure**: image name not modified

All 54 existing unit tests continue to pass.