### PR TITLE
fix: recursively pull explicitly depended services regardless of active profile

### DIFF
--- a/newsfragments/resolve_profiles_dependencies.bugfix
+++ b/newsfragments/resolve_profiles_dependencies.bugfix
@@ -1,0 +1,1 @@
+Recursively include explicitly depended services (via depends_on or extends) into the active execution graph regardless of profile exclusions, mirroring standard docker-compose behavior and fixing a KeyError in check_dep_conditions.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2810,7 +2810,8 @@ class PodmanCompose:
         the requested_profiles list.
 
         The returned service dictionary contains all services which do not include/reference a
-        profile in addition to services that match the requested_profiles.
+        profile in addition to services that match the requested_profiles, plus any services
+        they explicitly depend on.
 
         :param defined_services: The service dictionary
         :param requested_profiles: The profiles requested using the --profile arg.
@@ -2819,11 +2820,39 @@ class PodmanCompose:
             requested_profiles = set()
 
         services = {}
+        pending_services = set()
 
         for name, config in defined_services.items():
             service_profiles = set(config.get("profiles", []))
             if not service_profiles or requested_profiles.intersection(service_profiles):
                 services[name] = config
+                pending_services.add(name)
+
+        while pending_services:
+            current_name = pending_services.pop()
+            config = services[current_name]
+
+            dep_names = []
+
+            # Check depends_on
+            depends_on = config.get("depends_on", [])
+            if isinstance(depends_on, dict):
+                dep_names.extend(depends_on.keys())
+            elif isinstance(depends_on, list):
+                dep_names.extend(depends_on)
+
+            # Check extends
+            extends = config.get("extends", {})
+            if isinstance(extends, str):
+                dep_names.append(extends)
+            elif isinstance(extends, dict) and "service" in extends:
+                dep_names.append(extends["service"])
+
+            for dep in dep_names:
+                if isinstance(dep, str) and dep not in services and dep in defined_services:
+                    services[dep] = defined_services[dep]
+                    pending_services.add(dep)
+
         return services
 
     # Docker Compose specifies that services can have build-time dependencies on each other

--- a/tests/unit/test_resolve_profiles.py
+++ b/tests/unit/test_resolve_profiles.py
@@ -1,0 +1,168 @@
+import unittest
+from typing import Any
+
+from podman_compose import PodmanCompose
+
+class TestResolveProfiles(unittest.TestCase):
+    def setUp(self):
+        self.compose = PodmanCompose()
+
+    def test_no_profiles(self):
+        defined_services = {
+            "web": {"image": "nginx"},
+            "db": {"image": "postgres"},
+        }
+        services = self.compose._resolve_profiles(defined_services, {"test"})
+        self.assertIn("web", services)
+        self.assertIn("db", services)
+
+    def test_matching_profile(self):
+        defined_services = {
+            "web": {"image": "nginx", "profiles": ["frontend"]},
+            "db": {"image": "postgres", "profiles": ["backend"]},
+        }
+        services = self.compose._resolve_profiles(defined_services, {"frontend"})
+        self.assertIn("web", services)
+        self.assertNotIn("db", services)
+
+    def test_depends_on_pulls_dependency(self):
+        defined_services = {
+            "web": {
+                "image": "nginx",
+                "profiles": ["frontend"],
+                "depends_on": ["db"]
+            },
+            "db": {
+                "image": "postgres",
+                "profiles": ["backend"]
+            },
+            "cache": {
+                "image": "redis",
+                "profiles": ["backend"]
+            }
+        }
+        services = self.compose._resolve_profiles(defined_services, {"frontend"})
+        self.assertIn("web", services)
+        self.assertIn("db", services)
+        self.assertNotIn("cache", services)
+
+    def test_depends_on_dict_pulls_dependency(self):
+        defined_services = {
+            "web": {
+                "image": "nginx",
+                "profiles": ["frontend"],
+                "depends_on": {
+                    "db": {"condition": "service_healthy"}
+                }
+            },
+            "db": {
+                "image": "postgres",
+                "profiles": ["backend"]
+            }
+        }
+        services = self.compose._resolve_profiles(defined_services, {"frontend"})
+        self.assertIn("web", services)
+        self.assertIn("db", services)
+
+    def test_extends_pulls_dependency(self):
+        defined_services = {
+            "web": {
+                "image": "nginx",
+                "profiles": ["frontend"],
+                "extends": "base-web"
+            },
+            "base-web": {
+                "image": "nginx:alpine",
+                "profiles": ["backend"]
+            }
+        }
+        services = self.compose._resolve_profiles(defined_services, {"frontend"})
+        self.assertIn("web", services)
+        self.assertIn("base-web", services)
+
+    def test_extends_dict_pulls_dependency(self):
+        defined_services = {
+            "web": {
+                "image": "nginx",
+                "profiles": ["frontend"],
+                "extends": {"service": "base-web"}
+            },
+            "base-web": {
+                "image": "nginx:alpine",
+                "profiles": ["backend"]
+            }
+        }
+        services = self.compose._resolve_profiles(defined_services, {"frontend"})
+        self.assertIn("web", services)
+        self.assertIn("base-web", services)
+
+    def test_transitive_dependencies(self):
+        defined_services = {
+            "web": {
+                "image": "nginx",
+                "profiles": ["frontend"],
+                "depends_on": ["api"]
+            },
+            "api": {
+                "image": "node",
+                "profiles": ["backend"],
+                "depends_on": ["db"]
+            },
+            "db": {
+                "image": "postgres",
+                "profiles": ["database"]
+            }
+        }
+        services = self.compose._resolve_profiles(defined_services, {"frontend"})
+        self.assertIn("web", services)
+        self.assertIn("api", services)
+        self.assertIn("db", services)
+
+    def test_circular_dependencies(self):
+        defined_services = {
+            "a": {
+                "image": "alpine",
+                "profiles": ["group1"],
+                "depends_on": ["b"]
+            },
+            "b": {
+                "image": "alpine",
+                "profiles": ["group2"],
+                "depends_on": ["a"]
+            }
+        }
+        services = self.compose._resolve_profiles(defined_services, {"group1"})
+        self.assertIn("a", services)
+        self.assertIn("b", services)
+
+    def test_missing_dependency(self):
+        defined_services = {
+            "web": {
+                "image": "nginx",
+                "profiles": ["frontend"],
+                "depends_on": ["non_existent_service"]
+            }
+        }
+        services = self.compose._resolve_profiles(defined_services, {"frontend"})
+        self.assertIn("web", services)
+        self.assertNotIn("non_existent_service", services)
+
+    def test_invalid_dependency_format(self):
+        defined_services = {
+            "web": {
+                "image": "nginx",
+                "profiles": ["frontend"],
+                # Invalid format: depends_on should be list or dict
+                "depends_on": "db",
+                # Invalid format: extends should be str or dict
+                "extends": ["db"]
+            },
+            "db": {
+                "image": "postgres",
+                "profiles": ["backend"]
+            }
+        }
+        # It should not crash, and should just include 'web' without 'db'
+        services = self.compose._resolve_profiles(defined_services, {"frontend"})
+        self.assertIn("web", services)
+        self.assertNotIn("db", services)

--- a/tests/unit/test_resolve_profiles.py
+++ b/tests/unit/test_resolve_profiles.py
@@ -1,7 +1,7 @@
 import unittest
-from typing import Any
 
 from podman_compose import PodmanCompose
+
 
 class TestResolveProfiles(unittest.TestCase):
     def setUp(self):
@@ -27,19 +27,9 @@ class TestResolveProfiles(unittest.TestCase):
 
     def test_depends_on_pulls_dependency(self):
         defined_services = {
-            "web": {
-                "image": "nginx",
-                "profiles": ["frontend"],
-                "depends_on": ["db"]
-            },
-            "db": {
-                "image": "postgres",
-                "profiles": ["backend"]
-            },
-            "cache": {
-                "image": "redis",
-                "profiles": ["backend"]
-            }
+            "web": {"image": "nginx", "profiles": ["frontend"], "depends_on": ["db"]},
+            "db": {"image": "postgres", "profiles": ["backend"]},
+            "cache": {"image": "redis", "profiles": ["backend"]},
         }
         services = self.compose._resolve_profiles(defined_services, {"frontend"})
         self.assertIn("web", services)
@@ -51,14 +41,9 @@ class TestResolveProfiles(unittest.TestCase):
             "web": {
                 "image": "nginx",
                 "profiles": ["frontend"],
-                "depends_on": {
-                    "db": {"condition": "service_healthy"}
-                }
+                "depends_on": {"db": {"condition": "service_healthy"}},
             },
-            "db": {
-                "image": "postgres",
-                "profiles": ["backend"]
-            }
+            "db": {"image": "postgres", "profiles": ["backend"]},
         }
         services = self.compose._resolve_profiles(defined_services, {"frontend"})
         self.assertIn("web", services)
@@ -66,15 +51,8 @@ class TestResolveProfiles(unittest.TestCase):
 
     def test_extends_pulls_dependency(self):
         defined_services = {
-            "web": {
-                "image": "nginx",
-                "profiles": ["frontend"],
-                "extends": "base-web"
-            },
-            "base-web": {
-                "image": "nginx:alpine",
-                "profiles": ["backend"]
-            }
+            "web": {"image": "nginx", "profiles": ["frontend"], "extends": "base-web"},
+            "base-web": {"image": "nginx:alpine", "profiles": ["backend"]},
         }
         services = self.compose._resolve_profiles(defined_services, {"frontend"})
         self.assertIn("web", services)
@@ -82,15 +60,8 @@ class TestResolveProfiles(unittest.TestCase):
 
     def test_extends_dict_pulls_dependency(self):
         defined_services = {
-            "web": {
-                "image": "nginx",
-                "profiles": ["frontend"],
-                "extends": {"service": "base-web"}
-            },
-            "base-web": {
-                "image": "nginx:alpine",
-                "profiles": ["backend"]
-            }
+            "web": {"image": "nginx", "profiles": ["frontend"], "extends": {"service": "base-web"}},
+            "base-web": {"image": "nginx:alpine", "profiles": ["backend"]},
         }
         services = self.compose._resolve_profiles(defined_services, {"frontend"})
         self.assertIn("web", services)
@@ -98,20 +69,9 @@ class TestResolveProfiles(unittest.TestCase):
 
     def test_transitive_dependencies(self):
         defined_services = {
-            "web": {
-                "image": "nginx",
-                "profiles": ["frontend"],
-                "depends_on": ["api"]
-            },
-            "api": {
-                "image": "node",
-                "profiles": ["backend"],
-                "depends_on": ["db"]
-            },
-            "db": {
-                "image": "postgres",
-                "profiles": ["database"]
-            }
+            "web": {"image": "nginx", "profiles": ["frontend"], "depends_on": ["api"]},
+            "api": {"image": "node", "profiles": ["backend"], "depends_on": ["db"]},
+            "db": {"image": "postgres", "profiles": ["database"]},
         }
         services = self.compose._resolve_profiles(defined_services, {"frontend"})
         self.assertIn("web", services)
@@ -120,16 +80,8 @@ class TestResolveProfiles(unittest.TestCase):
 
     def test_circular_dependencies(self):
         defined_services = {
-            "a": {
-                "image": "alpine",
-                "profiles": ["group1"],
-                "depends_on": ["b"]
-            },
-            "b": {
-                "image": "alpine",
-                "profiles": ["group2"],
-                "depends_on": ["a"]
-            }
+            "a": {"image": "alpine", "profiles": ["group1"], "depends_on": ["b"]},
+            "b": {"image": "alpine", "profiles": ["group2"], "depends_on": ["a"]},
         }
         services = self.compose._resolve_profiles(defined_services, {"group1"})
         self.assertIn("a", services)
@@ -140,7 +92,7 @@ class TestResolveProfiles(unittest.TestCase):
             "web": {
                 "image": "nginx",
                 "profiles": ["frontend"],
-                "depends_on": ["non_existent_service"]
+                "depends_on": ["non_existent_service"],
             }
         }
         services = self.compose._resolve_profiles(defined_services, {"frontend"})
@@ -155,12 +107,9 @@ class TestResolveProfiles(unittest.TestCase):
                 # Invalid format: depends_on should be list or dict
                 "depends_on": "db",
                 # Invalid format: extends should be str or dict
-                "extends": ["db"]
+                "extends": ["db"],
             },
-            "db": {
-                "image": "postgres",
-                "profiles": ["backend"]
-            }
+            "db": {"image": "postgres", "profiles": ["backend"]},
         }
         # It should not crash, and should just include 'web' without 'db'
         services = self.compose._resolve_profiles(defined_services, {"frontend"})


### PR DESCRIPTION
## Contributor Checklist:

Please make sure to read development guidelines in CONTRIBUTING.md. Pull requests that do not
follow the guidelines WILL TAKE LONGER TO REVIEW as the first review comment will be to follow
these guidelines.

If this PR adds a new feature that improves compatibility with docker-compose, please add a link
to the exact part of compose spec that the PR touches.
- Compatibility improved: [Docker Compose Profiles Documentation](https://docs.docker.com/compose/profiles/#resolving-dependencies)

For any user-visible change please add a release note to newsfragments directory, e.g.
newsfragments/my_feature.feature. See newsfragments/README.txt for more details.
- [x] Added `newsfragments/resolve_profiles_dependencies.bugfix`

All changes require additional unit tests.
- [x] Added unit tests in `tests/unit/test_resolve_profiles.py` (all passing)

---

### Description

**Bug:**
When using `podman-compose --profile X up`, if a service in profile `X` contains a `depends_on` block pointing to another service `Y` that is NOT part of profile `X`, `podman-compose` crashes with a `KeyError: 'Y'`. The filtering of profiles happened before dependency trees were validated, causing targeted dependencies to be stripped entirely from parsed compose data.

**Fix:**
This PR updates the `_resolve_profiles` method to recursively walk through explicitly defined dependencies (via `depends_on` and `extends`). If an active service targets an excluded service, that target service is now securely pulled back into the active execution graph regardless of its underlying profile structure.

This ensures proper fallback parity with `docker-compose`'s Go implementation where "explicitly depended services are always started."

**Testing:**
Added comprehensive unit tests inside `test_resolve_profiles.py` which validate:
- Explicit dict/list structure inclusions for `depends_on`.
- Explicit dict/str structure inclusions for `extends`.
- Multi-tier transitive dependencies (e.g. `A` -> `B` -> `C`).
- Circular and non-existent edge-cases.
