### PR TITLE
add --no-hosts cli argument for compose up

### DIFF
--- a/newsfragments/added_--no-hosts.feature
+++ b/newsfragments/added_--no-hosts.feature
@@ -1,0 +1,1 @@
+Implemented --no-hosts for podman-compose up.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -3824,6 +3824,8 @@ async def compose_up(compose: PodmanCompose, args: argparse.Namespace) -> int | 
         ):
             log.debug("** skipping create: %s", cnt["name"])
             continue
+        if getattr(args, "no_hosts", False):
+            cnt["x-podman.no_hosts"] = True
         podman_args = await container_to_args(compose, cnt, detached=False, no_deps=args.no_deps)
         exit_code = await compose.podman.run([], "create", podman_args)
         create_error_codes.append(exit_code)
@@ -4552,6 +4554,11 @@ def compose_up_parse(parser: argparse.ArgumentParser) -> None:
         default=None,
         help="Return the exit code of the selected service container. "
         "Implies --abort-on-container-exit.",
+    )
+    parser.add_argument(
+        "--no-hosts",
+        action="store_true",
+        help="Do not modify the /etc/hosts file in the container.",
     )
 
 

--- a/tests/integration/no_hosts/compose.yaml
+++ b/tests/integration/no_hosts/compose.yaml
@@ -1,0 +1,5 @@
+services:
+  app:
+    image: nopush/podman-compose-test
+    container_name: test_no_hosts
+    command: ["cat", "/etc/hosts"]

--- a/tests/integration/no_hosts/test_podman_compose_no_hosts.py
+++ b/tests/integration/no_hosts/test_podman_compose_no_hosts.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: GPL-2.0
+
+import os
+import unittest
+
+from tests.integration.test_utils import RunSubprocessMixin
+from tests.integration.test_utils import podman_compose_path
+from tests.integration.test_utils import test_path
+
+
+def compose_yaml_path() -> str:
+    return os.path.join(os.path.join(test_path(), "no_hosts"), "compose.yaml")
+
+
+class TestComposeNoHosts(unittest.TestCase, RunSubprocessMixin):
+    def tearDown(self) -> None:
+        self.run_subprocess_assert_returncode([
+            podman_compose_path(),
+            "-f",
+            compose_yaml_path(),
+            "down",
+        ])
+
+    def test_no_hosts_flag(self) -> None:
+        """--no-hosts CLI flag should omit podman-managed entries"""
+        out, _ = self.run_subprocess_assert_returncode(
+            [
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path(),
+                "up",
+                "--no-hosts",
+            ],
+        )
+        self.assertNotIn("host.containers.internal", out.decode("utf-8"))
+
+    def test_without_no_hosts_flag(self) -> None:
+        """without --no-hosts, container should have podman-managed entries"""
+        out, _ = self.run_subprocess_assert_returncode(
+            [podman_compose_path(), "-f", compose_yaml_path(), "up"],
+        )
+
+        self.assertIn("host.containers.internal", out.decode("utf-8"))


### PR DESCRIPTION
## Contributor Checklist:

Please make sure to read development guidelines in CONTRIBUTING.md. Pull requests that do not
follow the guidelines WILL TAKE LONGER TO REVIEW as the first review comment will be to follow
these guidelines.

If this PR adds a new feature that improves compatibility with docker-compose, please add a link
to the exact part of compose spec that the PR touches.

For any user-visible change please add a release note to newsfragments directory, e.g.
newsfragments/my_feature.feature. See newsfragments/README.txt for more details.

All changes require additional unit tests.

fixes: https://github.com/containers/podman-compose/issues/1447

## Summary

The functionality for the --no-hosts argument exists from https://github.com/containers/podman-compose/pull/1060, this PR allows it to be utilized from the ```compose up``` command.