### PR TITLE
fix --podman-args

### DIFF
--- a/newsfragments/podman-args.bugfix
+++ b/newsfragments/podman-args.bugfix
@@ -1,0 +1,1 @@
+Fix --podman-args args not passed to podman.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1784,7 +1784,7 @@ class Podman:
         async with self.semaphore:
             cmd_args = cmd_args or []
             xargs = self.compose.get_podman_args(cmd) if cmd else []
-            cmd_ls = [self.podman_path, *podman_args, cmd] + xargs + cmd_args
+            cmd_ls = [self.podman_path, *podman_args] + xargs + cmd_args
             log.info(str(cmd_ls))
             p = await asyncio.create_subprocess_exec(
                 *cmd_ls, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
@@ -1856,7 +1856,7 @@ class Podman:
     ) -> None:
         cmd_args = list(map(str, cmd_args or []))
         xargs = self.compose.get_podman_args(cmd) if cmd else []
-        cmd_ls = [self.podman_path, *podman_args, cmd] + xargs + cmd_args
+        cmd_ls = [self.podman_path, *podman_args] + xargs + cmd_args
         log.info(" ".join([str(i) for i in cmd_ls]))
         os.execlp(self.podman_path, *cmd_ls)
 
@@ -1873,7 +1873,7 @@ class Podman:
         async with self.semaphore:
             cmd_args = list(map(str, cmd_args or []))
             xargs = self.compose.get_podman_args(cmd) if cmd else []
-            cmd_ls = [self.podman_path, *podman_args, cmd] + xargs + cmd_args
+            cmd_ls = [self.podman_path, *podman_args] + xargs + cmd_args
             log.info(" ".join([str(i) for i in cmd_ls]))
             if self.dry_run:
                 return None
@@ -2323,6 +2323,7 @@ class PodmanCompose:
         xargs = []
         for args in self.global_args.podman_args:
             xargs.extend(shlex.split(args))
+        xargs += [cmd]
         cmd_norm = cmd if cmd != "create" else "run"
         cmd_args = self.global_args.__dict__.get(f"podman_{cmd_norm}_args", [])
         for args in cmd_args:


### PR DESCRIPTION
This change fixes #707 by ensuring that arguments specified with --podman-args are inserted before the subcommand.
This allows global podman options such as --remote to work as expected.