### PR TITLE
Add `ls` command to list running compose projects

### DIFF
--- a/newsfragments/add_ls_command.feature
+++ b/newsfragments/add_ls_command.feature
@@ -1,0 +1,1 @@
+Add command `ls` to list all running containers.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -3094,6 +3094,60 @@ class cmd_parse:  # pylint: disable=invalid-name,too-few-public-methods
 ###################
 
 
+@cmd_run(podman_compose, "ls", "List running compose projects")
+async def list_running_projects(compose: PodmanCompose, args: argparse.Namespace) -> None:
+    img_containers = [cnt for cnt in compose.containers if "image" in cnt]
+    parsed_args = vars(args)
+    _format = parsed_args.get("format", "table")
+    data: list[Any] = []
+    if _format == "table":
+        data.append(["NAME", "STATUS", "CONFIG_FILES"])
+
+    for img in img_containers:
+        try:
+            name = img["name"]
+            output = await compose.podman.output(
+                [],
+                "inspect",
+                [
+                    name,
+                    "--format",
+                    '''
+                    {{ .State.Status }}
+                    {{ .State.Running }}
+                    {{ index .Config.Labels "com.docker.compose.project.working_dir" }}
+                    {{ index .Config.Labels "com.docker.compose.project.config_files" }}
+                    ''',
+                ],
+            )
+            command_output = output.decode().split()
+            running = bool(json.loads(command_output[1]))
+            status = f"{command_output[0]}({1 if running else 0})"
+            path = os.path.join(command_output[2], command_output[3])
+
+            if _format == "table":
+                if isinstance(command_output, list):
+                    data.append([name, status, path])
+
+            elif _format == "json":
+                # Replicate how docker compose returns the list
+                json_obj = {"Name": name, "Status": status, "ConfigFiles": path}
+                data.append(json_obj)
+        except Exception:
+            break
+
+    if _format == "table":
+        column_widths = [max(map(len, column)) for column in zip(*data)]
+
+        for row in data:
+            formatted_row = [cell.ljust(width) for cell, width in zip(row, column_widths)]
+            formatted_row[-2:] = ["\t".join(formatted_row[-2:]).strip()]
+            print("\t".join(formatted_row))
+
+    elif _format == "json":
+        print(data)
+
+
 @cmd_run(podman_compose, "version", "show version")
 async def compose_version(compose: PodmanCompose, args: argparse.Namespace) -> None:
     if getattr(args, "short", False):
@@ -5060,6 +5114,17 @@ def compose_format_parse(parser: argparse.ArgumentParser) -> None:
         "--format",
         type=str,
         help="Pretty-print container statistics to JSON or using a Go template",
+    )
+
+
+@cmd_parse(podman_compose, "ls")
+def compose_ls_parse(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "-f",
+        "--format",
+        choices=["table", "json"],
+        default="table",
+        help="Format the output",
     )
 
 

--- a/tests/integration/compose_ls_behavior/docker-compose.yml
+++ b/tests/integration/compose_ls_behavior/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3.6'
+
+services:
+  service_1:
+    image: nopush/podman-compose-test
+    command: ["dumb-init", "/bin/busybox", "httpd", "-f", "-h", ".", "-p", "8003"]
+  service_2:
+    image: nopush/podman-compose-test
+    command: ["dumb-init", "/bin/busybox", "httpd", "-f", "-h", ".", "-p", "8003"]
+  service_3:
+    image: nopush/podman-compose-test
+    command: ["dumb-init", "/bin/busybox", "httpd", "-f", "-h", ".", "-p", "8003"]
+

--- a/tests/integration/compose_ls_behavior/test_compose_ls_behavior.py
+++ b/tests/integration/compose_ls_behavior/test_compose_ls_behavior.py
@@ -1,0 +1,67 @@
+import os
+import unittest
+
+from tests.integration.test_utils import RunSubprocessMixin
+from tests.integration.test_utils import podman_compose_path
+from tests.integration.test_utils import test_path
+
+
+def compose_yaml_path() -> str:
+    return os.path.join(os.path.join(test_path(), "compose_ls_behavior"), "docker-compose.yml")
+
+
+class TestPodmanComposeLsBehavior(unittest.TestCase, RunSubprocessMixin):
+    def test_compose_list(self) -> None:
+        path = compose_yaml_path()
+        try:
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                path,
+                "up",
+                "-d",
+            ])
+
+            out, _ = self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                path,
+                "ls",
+            ])
+
+            expected = (
+                f'NAME                           \tSTATUS    \tCONFIG_FILES\n'
+                f'compose_ls_behavior_service_1_1\trunning(1)\t{path}\n'
+                f'compose_ls_behavior_service_2_1\trunning(1)\t{path}\n'
+                f'compose_ls_behavior_service_3_1\trunning(1)\t{path}\n'
+            )
+            self.assertEqual(out.decode(), expected)
+
+            # Test for json view
+            out, _ = self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                path,
+                "ls",
+                "--format",
+                "json",
+            ])
+
+            expected = (
+                f"[{{'Name': 'compose_ls_behavior_service_1_1', 'Status': 'running(1)', "
+                f"'ConfigFiles': '{path}'}}, "
+                f"{{'Name': 'compose_ls_behavior_service_2_1', 'Status': 'running(1)', "
+                f"'ConfigFiles': '{path}'}}, "
+                f"{{'Name': 'compose_ls_behavior_service_3_1', 'Status': 'running(1)', "
+                f"'ConfigFiles': '{path}'}}]\n"
+            )
+            self.assertEqual(out.decode(), expected)
+        finally:
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                path,
+                "down",
+                "-t",
+                "0",
+            ])


### PR DESCRIPTION
 `docker-compose ls` lists running Compose projects and their paths. Adding this feature brings `podman-compose` closer to `docker-compose` functionality.

Reference: https://docs.docker.com/reference/cli/docker/compose/ls/

This PR builds on PR https://github.com/containers/podman-compose/pull/1334, thanks to https://github.com/antonpetrov145.
Fixes https://github.com/containers/podman-compose/issues/1307.
