### PR TITLE
Add `copy` command to copy files/folders

### DIFF
--- a/newsfragments/add_cp_command.feature
+++ b/newsfragments/add_cp_command.feature
@@ -1,0 +1,1 @@
+Add command `cp` to copy files/folders between a service container and the local filesystem.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -4162,10 +4162,14 @@ def compose_run_update_container_from_args(
     podman_compose, "cp", "copy files/folders between a service container and the local filesystem"
 )
 async def compose_cp(compose: PodmanCompose, args: argparse.Namespace) -> None:
-    if ':' in args.src:
+    if ':' in args.src and ':' not in args.dst:
         service = args.src.split(':', 1)[0]
-    elif ':' in args.dst:
+    elif ':' in args.dst and ':' not in args.src:
         service = args.dst.split(':', 1)[0]
+    else:
+        raise ValueError(
+            f"Invalid copy arguments format: source = {args.src}, destination = {args.dst}."
+        )
     compose.assert_services(service)
     container_names = compose.container_names_by_service[service]
     podman_args = compose_cp_args(container_names[0], args)

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -4158,6 +4158,42 @@ def compose_run_update_container_from_args(
         del cnt["restart"]
 
 
+@cmd_run(
+    podman_compose, "cp", "copy files/folders between a service container and the local filesystem"
+)
+async def compose_cp(compose: PodmanCompose, args: argparse.Namespace) -> None:
+    service = {s.split(':', 1)[0] for s in args.cpy_from_to if ':' in s}
+    service = next(iter(service))
+    compose.assert_services(service)
+    container_names = compose.container_names_by_service[service]
+    podman_args = compose_cp_args(container_names[0], args)
+    p = await compose.podman.run([], "cp", podman_args)
+    sys.exit(p)
+
+
+def compose_cp_args(container_name: str, args: argparse.Namespace) -> list[str]:
+    podman_args = []
+    cnt_path = [item.split(":", 1)[1] for item in args.cpy_from_to if ":" in item][0]
+    local_path = [item for item in args.cpy_from_to if ":" not in item]
+
+    if args.archive:
+        podman_args += ["--archive"]
+    if args.overwrite:
+        podman_args += ["--overwrite"]
+
+    # need to determine which argument came first so we know the transfer direction
+    args_position = next((i for i, item in enumerate(args.cpy_from_to) if ":" in item), 1)
+    if args_position == 0:
+        # container -> local
+        podman_args += [container_name + ':' + cnt_path]
+        podman_args += local_path
+    else:
+        # local -> container
+        podman_args += local_path
+        podman_args += [container_name + ':' + cnt_path]
+    return podman_args
+
+
 @cmd_run(podman_compose, "exec", "execute a command in a running container")
 async def compose_exec(compose: PodmanCompose, args: argparse.Namespace) -> None:
     compose.assert_services(args.service)
@@ -4708,6 +4744,30 @@ def compose_exec_parse(parser: argparse.ArgumentParser) -> None:
         metavar="command",
         nargs=argparse.REMAINDER,
         help="command and its arguments",
+    )
+
+
+@cmd_parse(podman_compose, "cp")
+def compose_parse_cp(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "-a",
+        "--archive",
+        help=(
+            "Chown copied files to the primary uid/gid of the destination container (default=True)"
+        ),
+        default=True,
+    )
+    parser.add_argument(
+        "--overwrite",
+        help="Allow to overwrite directories with non-directories and vice versa (default=None)",
+        default=None,
+    )
+    parser.add_argument(
+        "cpy_from_to",
+        metavar="src_path destination_path",
+        nargs="*",
+        default=None,
+        help="service:src_path destination_path | src_path service:destination_path",
     )
 
 

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -4162,8 +4162,10 @@ def compose_run_update_container_from_args(
     podman_compose, "cp", "copy files/folders between a service container and the local filesystem"
 )
 async def compose_cp(compose: PodmanCompose, args: argparse.Namespace) -> None:
-    service = {s.split(':', 1)[0] for s in args.cpy_from_to if ':' in s}
-    service = next(iter(service))
+    if ':' in args.src:
+        service = args.src.split(':', 1)[0]
+    elif ':' in args.dst:
+        service = args.dst.split(':', 1)[0]
     compose.assert_services(service)
     container_names = compose.container_names_by_service[service]
     podman_args = compose_cp_args(container_names[0], args)
@@ -4173,24 +4175,21 @@ async def compose_cp(compose: PodmanCompose, args: argparse.Namespace) -> None:
 
 def compose_cp_args(container_name: str, args: argparse.Namespace) -> list[str]:
     podman_args = []
-    cnt_path = [item.split(":", 1)[1] for item in args.cpy_from_to if ":" in item][0]
-    local_path = [item for item in args.cpy_from_to if ":" not in item]
-
     if args.archive:
         podman_args += ["--archive"]
     if args.overwrite:
         podman_args += ["--overwrite"]
 
-    # need to determine which argument came first so we know the transfer direction
-    args_position = next((i for i, item in enumerate(args.cpy_from_to) if ":" in item), 1)
-    if args_position == 0:
+    # Determine which argument has the colon so we know the direction
+    if ':' in args.src:
         # container -> local
-        podman_args += [container_name + ':' + cnt_path]
-        podman_args += local_path
-    else:
+        cnt_path = args.src.split(":", 1)[1]
+        podman_args += [container_name + ':' + cnt_path, args.dst]
+    elif ':' in args.dst:
         # local -> container
-        podman_args += local_path
-        podman_args += [container_name + ':' + cnt_path]
+        cnt_path = args.dst.split(":", 1)[1]
+        podman_args += [args.src, container_name + ':' + cnt_path]
+
     return podman_args
 
 
@@ -4763,11 +4762,16 @@ def compose_parse_cp(parser: argparse.ArgumentParser) -> None:
         default=None,
     )
     parser.add_argument(
-        "cpy_from_to",
-        metavar="src_path destination_path",
-        nargs="*",
+        "src",
+        metavar="SOURCE",
+        help="Source path. Use SERVICE:PATH for container paths, or just PATH for local paths",
         default=None,
-        help="service:src_path destination_path | src_path service:destination_path",
+    )
+    parser.add_argument(
+        "dst",
+        metavar="DESTINATION",
+        help="Destination path. Use SERVICE:PATH for container paths, or just PATH for local paths",
+        default=None,
     )
 
 

--- a/tests/integration/compose_cp_behavior/docker-compose.yaml
+++ b/tests/integration/compose_cp_behavior/docker-compose.yaml
@@ -1,0 +1,9 @@
+services:
+  my-service:
+    image: nopush/podman-compose-test
+    command:
+      - /bin/bash
+      - -c
+      - |
+        echo 'This is a test file inside the container.' > /tmp/container_file.txt
+        exec tail -f /dev/null

--- a/tests/integration/compose_cp_behavior/test_compose_cp_behavior.py
+++ b/tests/integration/compose_cp_behavior/test_compose_cp_behavior.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: GPL-2.0
+
+import os
+import unittest
+from pathlib import Path
+
+from tests.integration.test_utils import RunSubprocessMixin
+from tests.integration.test_utils import podman_compose_path
+from tests.integration.test_utils import test_path
+
+
+def compose_yaml_path() -> str:
+    return os.path.join(os.path.join(test_path(), "compose_cp_behavior"), "docker-compose.yaml")
+
+
+class TestComposeCpBehavior(unittest.TestCase, RunSubprocessMixin):
+    def test_copy_command(self) -> None:
+        host_file = Path("host_file.txt")
+        host_file.parent.mkdir(parents=True, exist_ok=True)
+        host_file.write_text("This is a test file inside the host.")
+
+        output, _ = self.run_subprocess_assert_returncode(["cat", "host_file.txt"])
+        self.assertEqual(b"This is a test file inside the host.", output)
+
+        container_file = "/tmp/copied_from_host.txt"
+
+        try:
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path(),
+                "up",
+                "-d",
+            ])
+            host_file = Path("./container_file.txt")
+            assert not host_file.exists(), f"{host_file} must not exist before cp."
+
+            # copy file container_file.txt from container to host
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path(),
+                "cp",
+                "my-service:/tmp/container_file.txt",
+                ".",
+            ])
+
+            assert host_file.exists(), f"{host_file} must exist after cp."
+
+            output, _ = self.run_subprocess_assert_returncode(["cat", "container_file.txt"])
+            self.assertEqual(b"This is a test file inside the container.\n", output)
+
+            # copy file host_file.txt from host to container
+            # first, check if file does not exist in the container yet
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path(),
+                "exec",
+                "my-service",
+                "bash",
+                "-c",
+                f"test ! -f {container_file}",
+            ])
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path(),
+                "cp",
+                "host_file.txt",
+                f"my-service:{container_file}",
+            ])
+            output, _ = self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path(),
+                "exec",
+                "my-service",
+                "cat",
+                container_file,
+            ])
+            self.assertEqual(b"This is a test file inside the host.", output)
+
+            # assert that the command fails gracefully when the source path
+            # doesn't exist in the container
+            _, error = self.run_subprocess_assert_returncode(
+                [
+                    podman_compose_path(),
+                    "-f",
+                    compose_yaml_path(),
+                    "cp",
+                    "my-service:/tmp/nonexistent.txt",
+                    ".",
+                ],
+                expected_returncode=125,
+            )
+            self.assertIn(
+                b'"/tmp/nonexistent.txt" could not be found on container '
+                b'compose_cp_behavior_my-service_1',
+                error,
+            )
+
+            # assert that the command fails gracefully when copy arguments
+            # format is invalid
+            _, error = self.run_subprocess_assert_returncode(
+                [
+                    podman_compose_path(),
+                    "-f",
+                    compose_yaml_path(),
+                    "cp",
+                    "my-service:/tmp/container_file.txt",
+                    "my-service:/tmp/host_file.txt",
+                ],
+                1,
+            )
+            expected = (
+                b'Invalid copy arguments format: source = my-service:/tmp/container_file.txt,'
+                b' destination = my-service:/tmp/host_file.txt.'
+            )
+            self.assertIn(expected, error)
+
+            _, error = self.run_subprocess_assert_returncode(
+                [
+                    podman_compose_path(),
+                    "-f",
+                    compose_yaml_path(),
+                    "cp",
+                    "host_file.txt",
+                    "my-service!container_file.txt",
+                ],
+                1,
+            )
+            expected = (
+                b'Invalid copy arguments format: source = host_file.txt, '
+                b'destination = my-service!container_file.txt.\n'
+            )
+            self.assertIn(expected, error)
+        finally:
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path(),
+                "down",
+                "-t",
+                "0",
+            ])
+            host_file.unlink(missing_ok=True)

--- a/tests/unit/test_compose_cp_args.py
+++ b/tests/unit/test_compose_cp_args.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: GPL-2.0
+
+import argparse
+import unittest
+
+from podman_compose import compose_cp_args
+
+
+class TestComposeCpArgs(unittest.TestCase):
+    def test_cp_host_to_container(self) -> None:
+        args = get_minimal_args()
+        args.src = "host_file.txt"
+        args.dst = "my-service:/tmp/copied_from_host.txt"
+
+        self.assertEqual(
+            compose_cp_args("container_name", args),
+            ['--archive', 'host_file.txt', 'container_name:/tmp/copied_from_host.txt'],
+        )
+
+    def test_cp_container_to_host(self) -> None:
+        args = get_minimal_args()
+        args.src = "container_name:host_file.txt"
+        args.dst = "/tmp/container_file.txt"
+
+        self.assertEqual(
+            compose_cp_args("container_name", args),
+            ['--archive', 'container_name:host_file.txt', '/tmp/container_file.txt'],
+        )
+
+    def test_archive_and_overwrite_non_default(self) -> None:
+        args = get_minimal_args()
+        args.archive = False
+        args.overwrite = True
+        args.src = "container_name:host_file.txt"
+        args.dst = "/tmp/container_file.txt"
+
+        self.assertEqual(
+            compose_cp_args("container_name", args),
+            ['--overwrite', 'container_name:host_file.txt', '/tmp/container_file.txt'],
+        )
+
+
+def get_minimal_args() -> argparse.Namespace:
+    return argparse.Namespace(archive=True, overwrite=None)


### PR DESCRIPTION
`docker-compose cp` can copy files/folders between a service container and the local filesystem. Adding this feature brings `podman-compose` closer to `docker-compose` functionality.
    
Reference: https://docs.docker.com/reference/cli/docker/compose/cp/

This PR builds on PR https://github.com/containers/podman-compose/pull/1353, thanks to https://github.com/tomastechlab.
Fixes https://github.com/containers/podman-compose/issues/1315.