### PR TITLE
Fix/include relative path resolution

### DIFF
--- a/newsfragments/resolve-include-relative-paths.bugfix
+++ b/newsfragments/resolve-include-relative-paths.bugfix
@@ -1,0 +1,1 @@
+Resolve relative paths in included compose files against the included file's directory rather than the project root, matching the Compose Spec. Affects volumes, env_file, and build.context inside files referenced by include:. Fixes #1301.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2691,6 +2691,11 @@ class PodmanCompose:
         compose: dict[str, Any] = {}
         # Iterate over files primitively to allow appending to files in-loop
         files_iter = iter(files)
+        # Track files appended by ``include:`` so we can resolve their
+        # relative paths against the included file's directory per the
+        # Compose Spec, without changing the legacy merge behavior of
+        # files passed directly via ``-f``.
+        include_origin_files: set[str] = set()
 
         while True:
             try:
@@ -2707,7 +2712,22 @@ class PodmanCompose:
             if not isinstance(content, dict):
                 log.fatal("Compose file does not contain a top level object: %s", filename)
                 sys.exit(1)
-            content = normalize(content)
+            # For files arriving via ``include:``, paths inside the file must
+            # resolve against the included file's directory rather than the
+            # project root (Compose Spec, ``include`` section). Pass that as
+            # sub_dir so volumes / env_file / build.context get rewritten.
+            file_sub_dir = ""
+            if filename in include_origin_files:
+                file_dir = os.path.dirname(os.path.abspath(filename))
+                file_sub_dir = os.path.relpath(file_dir, self.dirname)
+                if file_sub_dir == ".":
+                    file_sub_dir = ""
+                elif not file_sub_dir.startswith((".", "/")):
+                    # Prefix with "./" so rewritten paths remain recognizable
+                    # as relative refs (is_relative_ref checks for "./"/".."
+                    # prefixes).
+                    file_sub_dir = "./" + file_sub_dir
+            content = normalize(content, file_sub_dir)
             # log(filename, json.dumps(content, indent = 2))
 
             # See also https://docs.docker.com/compose/how-tos/project-name/#set-a-project-name
@@ -2750,23 +2770,28 @@ class PodmanCompose:
                 if not isinstance(include, list):
                     raise RuntimeError("`include` must be a list")
 
+                new_includes: list[str] = []
                 for item in include:
                     if isinstance(item, str):
-                        files.append(os.path.join(os.path.dirname(filename), item))
+                        new_includes.append(os.path.join(os.path.dirname(filename), item))
                     elif isinstance(item, dict):
                         if "path" not in item:
                             raise RuntimeError("Missing required 'path' key in `include` block")
                         path = item["path"]
                         if isinstance(path, str):
-                            files.append(os.path.join(os.path.dirname(filename), path))
+                            new_includes.append(os.path.join(os.path.dirname(filename), path))
                         elif isinstance(path, list):
-                            files.extend([os.path.join(os.path.dirname(filename), p) for p in path])
+                            new_includes.extend(
+                                os.path.join(os.path.dirname(filename), p) for p in path
+                            )
                         else:
                             raise RuntimeError("'path' must be a string or a list of strings")
                     else:
                         raise RuntimeError(
                             "Items in `include` must be strings or dictionaries with a 'path' key"
                         )
+                files.extend(new_includes)
+                include_origin_files.update(new_includes)
                 # As compose obj is updated and tested with every loop, not deleting `include`
                 # from it, results in it being tested again and again, original values for
                 # `include` be appended to `files`, and, included files be processed for ever.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2108,16 +2108,33 @@ def normalize_service(service: dict[str, Any], sub_dir: str = "") -> dict[str, A
 
             new_volumes.append(v)
         service["volumes"] = new_volumes
+    if "env_file" in service and sub_dir:
+        new_env_file = []
+        for ef in service["env_file"]:
+            if isinstance(ef, str):
+                if is_relative_ref(ef):
+                    ef = os.path.join(sub_dir, ef)
+            elif isinstance(ef, dict):
+                path = ef.get("path")
+                if isinstance(path, str) and is_relative_ref(path):
+                    ef["path"] = os.path.join(sub_dir, path)
+            new_env_file.append(ef)
+        service["env_file"] = new_env_file
     return service
 
 
-def normalize(compose: dict[str, Any]) -> dict[str, Any]:
+def normalize(compose: dict[str, Any], sub_dir: str = "") -> dict[str, Any]:
     """
     convert compose dict of some keys from string or dicts into arrays
+
+    If ``sub_dir`` is provided, relative paths in ``volumes``, ``env_file`` and
+    ``build.context`` are rewritten to be relative to ``sub_dir`` (used when an
+    included file lives in a different directory than the project root, per
+    Compose Spec resolution of paths in ``include:``d files).
     """
     services = compose.get("services", {}) or {}
     for service in services.values():
-        normalize_service(service)
+        normalize_service(service, sub_dir)
     return compose
 
 

--- a/tests/integration/include_relative_paths/docker-compose.yaml
+++ b/tests/integration/include_relative_paths/docker-compose.yaml
@@ -1,0 +1,6 @@
+version: "3.6"
+
+name: include-relative-paths
+
+include:
+  - sub/included.yaml

--- a/tests/integration/include_relative_paths/sub/included.yaml
+++ b/tests/integration/include_relative_paths/sub/included.yaml
@@ -1,0 +1,15 @@
+services:
+  # All relative paths below should resolve against this file's directory
+  # (sub/), not the project root. So:
+  #   ./local.env       -> sub/local.env
+  #   ../shared.env     -> shared.env (in project root)
+  #   ./data:/data:ro   -> sub/data
+  #   ../assets:/assets:ro -> assets (in project root)
+  web:
+    image: nopush/podman-compose-test
+    env_file:
+      - ./local.env
+      - ../shared.env
+    volumes:
+      - ./data:/data:ro
+      - ../assets:/assets:ro

--- a/tests/integration/include_relative_paths/test_podman_compose_include_relative_paths.py
+++ b/tests/integration/include_relative_paths/test_podman_compose_include_relative_paths.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: GPL-2.0
+
+"""
+Tests that relative paths (volumes, env_file) inside an included compose
+file are resolved against the included file's directory, not the project
+root. See https://github.com/containers/podman-compose/issues/1301 and the
+Compose Spec include resolution rules.
+"""
+
+import os
+import textwrap
+import unittest
+
+from tests.integration.test_utils import RunSubprocessMixin
+from tests.integration.test_utils import podman_compose_path
+from tests.integration.test_utils import test_path
+
+
+def compose_file() -> str:
+    return os.path.join(test_path(), "include_relative_paths", "docker-compose.yaml")
+
+
+class TestIncludeRelativePaths(unittest.TestCase, RunSubprocessMixin):
+    def test_relative_paths_in_included_file(self) -> None:
+        """
+        The included file at ``sub/included.yaml`` references
+        ``./local.env``, ``../shared.env``, ``./data:/data:ro`` and
+        ``../assets:/assets:ro``. After include resolution these must point
+        at paths under ``sub/`` for the ``./`` forms and at the project
+        root for the ``../`` forms.
+        """
+        out, _ = self.run_subprocess_assert_returncode([
+            "coverage",
+            "run",
+            podman_compose_path(),
+            "-f",
+            compose_file(),
+            "config",
+        ])
+
+        expected = textwrap.dedent("""\
+            name: include-relative-paths
+            services:
+              web:
+                env_file:
+                - ./sub/./local.env
+                - ./sub/../shared.env
+                image: nopush/podman-compose-test
+                volumes:
+                - ./sub/./data:/data:ro
+                - ./sub/../assets:/assets:ro
+            version: '3.6'
+
+            """)
+        self.assertEqual(out.decode("utf-8"), expected)

--- a/tests/unit/test_normalize_service.py
+++ b/tests/unit/test_normalize_service.py
@@ -78,6 +78,18 @@ class TestNormalizeService(unittest.TestCase):
                 ]
             },
         ),
+        (
+            {"env_file": "./.env"},
+            {"env_file": ["./sub_dir/./.env"]},
+        ),
+        (
+            {"env_file": ["./.env", "../shared.env"]},
+            {"env_file": ["./sub_dir/./.env", "./sub_dir/../shared.env"]},
+        ),
+        (
+            {"env_file": [{"path": "./.env", "required": False}]},
+            {"env_file": [{"path": "./sub_dir/./.env", "required": False}]},
+        ),
     ])
     def test_normalize_service_with_sub_dir(
         self, input: dict[str, Any], expected: dict[str, Any]


### PR DESCRIPTION
> **Disclaimer**: I authored this PR with LLM assistance. This description is written entirely by an LLM.

Fixes #1301.

## Compose Spec reference

[`include` — path resolution](https://github.com/compose-spec/compose-spec/blob/main/14-include.md):

> Each path listed in the `include` section is loaded as an individual Compose
> application model, with its own project directory, in order to resolve
> relative paths.

podman-compose previously resolved relative paths inside `include`d files
against the top-level project root instead of the included file's directory.

## The bug

Given:

```
project/
├── compose.yml         (include: [compose/sub.yml])
├── compose/sub.yml     (volumes: [../fixtures/seed.sql:/seed.sql:ro])
└── fixtures/seed.sql
```

The bind mount source resolved to `project/../fixtures/seed.sql` rather than
`project/fixtures/seed.sql`, and podman silently created an empty directory
at the wrong path. Same problem affected `env_file` and `build.context`.

## The fix

- Track which files in the parse loop arrived via `include:` (as opposed to
  via `-f` on the command line).
- For included files only, compute the file's directory relative to the
  project root and pass it as `sub_dir` to `normalize()`.
- `normalize_service` already had `sub_dir` handling for `volumes` and
  `build.context`; this PR extends it to `env_file` (string and
  `{path, required}` dict forms).

Files passed directly with `-f` keep their existing relative-path
behavior, so the legacy `-f`-merge semantics covered by
`tests/integration/multicompose` are preserved.

## Commits

1. **Extend `normalize_service` to rewrite env_file paths under `sub_dir`** —
   also threads `sub_dir` through `normalize()` (backward-compatible
   default). I judged the signature change too trivial to split into its
   own commit; happy to split if reviewers prefer.
2. **Resolve relative paths in included compose files against the included
   file** — the actual bug fix, plus newsfragment and an integration test.

## Verification

- All 473 unit tests pass at each commit (bisectable).
- New `tests/integration/include_relative_paths` integration test passes on
  this branch, **fails on `main`** with the exact bug signature
  (`./local.env` left unrewritten as `./local.env` instead of
  `sub/./local.env`).
- `tests/integration/multicompose` (which exercises legacy `-f` merge
  behavior) continues to pass — the fix is scoped to files added via
  `include:`.
- `ruff format`, `ruff check`, `pylint podman_compose.py` (10/10), `mypy .`
  all clean (the 4 mypy errors that exist are pre-existing on `main` —
  missing type stubs in unrelated test files).

## Known limitation (out of scope)

`${VAR:-default}` env-var interpolation runs *after* `normalize()`, so a
volume like `${X:-../config/foo}:/...` won't get the prefix applied even
with this fix. Worth a separate issue if anyone hits it.
