### PR TITLE
logs: Allow custom `container_name` as a log prefix

### DIFF
--- a/newsfragments/use_custom_container_name_for_logs.misc
+++ b/newsfragments/use_custom_container_name_for_logs.misc
@@ -1,0 +1,1 @@
+Use the custom `container_name` from `compose.yml` as the log prefix.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2854,6 +2854,11 @@ class PodmanCompose:
                     name = service_desc.get("container_name", name0)
                 else:
                     name = name0
+
+                if service_desc.get("container_name", False):
+                    log_prefix = name
+                else:
+                    log_prefix = f"{service_name}_{num}"
                 container_names_by_service[service_name].append(name)
                 # log(service_name,service_desc)
                 cnt = {
@@ -2861,6 +2866,7 @@ class PodmanCompose:
                     "name": name,
                     "num": num,
                     "service_name": service_name,
+                    "log_prefix": log_prefix,
                     **service_desc,
                 }
                 x_podman = service_desc.get("x-podman")
@@ -3722,6 +3728,46 @@ def deps_from_container(args: argparse.Namespace, cnt: dict) -> set:
     return cnt['_deps']
 
 
+def get_service_info(compose: PodmanCompose, service: str) -> tuple[dict, int] | None:
+    for index, cnt in enumerate(compose.containers):
+        service_name = cnt["_service"]
+        if service == service_name:
+            return (cnt, index)
+    return None
+
+
+def create_format_logs_task(
+    compose: PodmanCompose,
+    args: argparse.Namespace,
+    service: str,
+    podman_args: list,
+    max_service_length: int,
+) -> asyncio.Task | None:
+    result = get_service_info(compose, service)
+    if result is None:
+        return None
+
+    container, index = result
+    # Add colored service prefix to output by piping output through sed
+    if args.no_log_prefix:
+        log_formatter = None
+    else:
+        color_idx = index % len(compose.console_colors)
+        if args.no_color:  # monochrome output
+            color = '\x1b[0m'
+        else:
+            color = compose.console_colors[color_idx]
+
+        log_prefix = container["log_prefix"]
+        space_suffix = " " * (max_service_length - len(log_prefix) + 1)
+        log_formatter = f"{color}[{log_prefix}]{space_suffix}|\x1b[0m"
+
+    target_service = compose.container_names_by_service[service]
+    return asyncio.create_task(
+        compose.podman.run([], "logs", podman_args + target_service, log_formatter=log_formatter)
+    )
+
+
 @dataclass
 class PullImageSettings:
     POLICY_PRIORITY: ClassVar[dict[str, int]] = {
@@ -4433,9 +4479,7 @@ async def compose_restart(compose: PodmanCompose, args: argparse.Namespace) -> N
 
 
 @cmd_run(podman_compose, "logs", "show logs from services")
-async def compose_logs(
-    compose: PodmanCompose, args: argparse.Namespace, log_formatter: str | None = None
-) -> None:
+async def compose_logs(compose: PodmanCompose, args: argparse.Namespace) -> None:
     container_names_by_service = compose.container_names_by_service
     if not args.services and not args.latest:
         args.services = container_names_by_service.keys()
@@ -4462,27 +4506,12 @@ async def compose_logs(
         podman_args.extend(["--until", args.until])
 
     max_service_length = 0
-    tasks = []
+    tasks: list[asyncio.Task[Any]] = []
     max_service_length = max(len(service) for service in args.services)
-    for i, service in enumerate(args.services):
-        # Add colored service prefix to output by piping output through sed
-        if args.no_log_prefix:
-            log_formatter = None
-        else:
-            color_idx = i % len(compose.console_colors)
-            if args.no_color:  # monochrome output
-                color = '\x1b[0m'
-            else:
-                color = compose.console_colors[color_idx]
-            space_suffix = " " * (max_service_length - len(service) + 1)
-            log_formatter = f"{color}[{service}]{space_suffix}|\x1b[0m"
-
-        podman_args_with_target = podman_args + container_names_by_service[service]
-        tasks.append(
-            asyncio.create_task(
-                compose.podman.run([], "logs", podman_args_with_target, log_formatter=log_formatter)
-            )
-        )
+    for service in args.services:
+        task = create_format_logs_task(compose, args, service, podman_args, max_service_length)
+        if task:
+            tasks.append(task)
     await asyncio.gather(*tasks)
 
 

--- a/tests/integration/logs/docker-compose.yml
+++ b/tests/integration/logs/docker-compose.yml
@@ -9,3 +9,7 @@ services:
   test3:
     image: busybox
     command: ["echo", "test3"]
+  test4:
+    image: busybox
+    command: ["echo", "test4"]
+    container_name: custom_name

--- a/tests/integration/logs/test_podman_compose_logs.py
+++ b/tests/integration/logs/test_podman_compose_logs.py
@@ -18,9 +18,9 @@ class TestLogs(unittest.TestCase, RunSubprocessMixin):
             [],
             [
                 b'',
-                b'\x1b[1;32m[test1] |\x1b[0m \x1b[37mtest1\x1b[0m',
-                b'\x1b[1;33m[test2] |\x1b[0m \x1b[37mtest2\x1b[0m',
-                b'\x1b[1;34m[test3] |\x1b[0m \x1b[37mtest3\x1b[0m',
+                b'\x1b[1;32m[test1_1]|\x1b[0m \x1b[37mtest1\x1b[0m',
+                b'\x1b[1;33m[test2_1]|\x1b[0m \x1b[37mtest2\x1b[0m',
+                b'\x1b[1;34m[test3_1]|\x1b[0m \x1b[37mtest3\x1b[0m',
             ],
         ),
         (
@@ -28,9 +28,9 @@ class TestLogs(unittest.TestCase, RunSubprocessMixin):
             ["--no-color"],
             [
                 b'',
-                b'\x1b[0m[test1] |\x1b[0m test1',
-                b'\x1b[0m[test2] |\x1b[0m test2',
-                b'\x1b[0m[test3] |\x1b[0m test3',
+                b'\x1b[0m[test1_1]|\x1b[0m test1',
+                b'\x1b[0m[test2_1]|\x1b[0m test2',
+                b'\x1b[0m[test3_1]|\x1b[0m test3',
             ],
         ),
         (
@@ -46,12 +46,12 @@ class TestLogs(unittest.TestCase, RunSubprocessMixin):
         (
             "one_service_no_flag",
             ["test1"],
-            [b'', b'\x1b[1;32m[test1] |\x1b[0m \x1b[37mtest1\x1b[0m'],
+            [b'', b'\x1b[1;32m[test1_1]|\x1b[0m \x1b[37mtest1\x1b[0m'],
         ),
         (
             "one_service_flag_no_color",
             ["test1", "--no-color"],
-            [b'', b'\x1b[0m[test1] |\x1b[0m test1'],
+            [b'', b'\x1b[0m[test1_1]|\x1b[0m test1'],
         ),
         (
             "one_service_flag_no_log_prefix",
@@ -68,14 +68,14 @@ class TestLogs(unittest.TestCase, RunSubprocessMixin):
             ["test2", "test3"],
             [
                 b'',
-                b'\x1b[1;32m[test2] |\x1b[0m \x1b[37mtest2\x1b[0m',
-                b'\x1b[1;33m[test3] |\x1b[0m \x1b[37mtest3\x1b[0m',
+                b'\x1b[1;33m[test2_1]|\x1b[0m \x1b[37mtest2\x1b[0m',
+                b'\x1b[1;34m[test3_1]|\x1b[0m \x1b[37mtest3\x1b[0m',
             ],
         ),
         (
             "two_services_flag_no_color",
             ["test2", "test3", "--no-color"],
-            [b'', b'\x1b[0m[test2] |\x1b[0m test2', b'\x1b[0m[test3] |\x1b[0m test3'],
+            [b'', b'\x1b[0m[test2_1]|\x1b[0m test2', b'\x1b[0m[test3_1]|\x1b[0m test3'],
         ),
         (
             "two_services_flag_no_log_prefix",

--- a/tests/integration/logs/test_podman_compose_logs.py
+++ b/tests/integration/logs/test_podman_compose_logs.py
@@ -21,6 +21,7 @@ class TestLogs(unittest.TestCase, RunSubprocessMixin):
                 b'\x1b[1;32m[test1_1]|\x1b[0m \x1b[37mtest1\x1b[0m',
                 b'\x1b[1;33m[test2_1]|\x1b[0m \x1b[37mtest2\x1b[0m',
                 b'\x1b[1;34m[test3_1]|\x1b[0m \x1b[37mtest3\x1b[0m',
+                b'\x1b[1;35m[custom_name]|\x1b[0m \x1b[37mtest4\x1b[0m',
             ],
         ),
         (
@@ -28,6 +29,7 @@ class TestLogs(unittest.TestCase, RunSubprocessMixin):
             ["--no-color"],
             [
                 b'',
+                b'\x1b[0m[custom_name]|\x1b[0m test4',
                 b'\x1b[0m[test1_1]|\x1b[0m test1',
                 b'\x1b[0m[test2_1]|\x1b[0m test2',
                 b'\x1b[0m[test3_1]|\x1b[0m test3',
@@ -36,12 +38,18 @@ class TestLogs(unittest.TestCase, RunSubprocessMixin):
         (
             "all_services_flag_no_log_prefix",
             ["--no-log-prefix"],
-            [b'', b'\x1b[37mtest1\x1b[0m', b'\x1b[37mtest2\x1b[0m', b'\x1b[37mtest3\x1b[0m'],
+            [
+                b'',
+                b'\x1b[37mtest1\x1b[0m',
+                b'\x1b[37mtest2\x1b[0m',
+                b'\x1b[37mtest3\x1b[0m',
+                b'\x1b[37mtest4\x1b[0m',
+            ],
         ),
         (
             "all_services_flag_no_color_no_log_prefix",
             ["--no-color", "--no-log-prefix"],
-            [b'', b'test1', b'test2', b'test3'],
+            [b'', b'test1', b'test2', b'test3', b'test4'],
         ),
         (
             "one_service_no_flag",
@@ -86,6 +94,15 @@ class TestLogs(unittest.TestCase, RunSubprocessMixin):
             "two_services_flag_no_color_no_log_prefix",
             ["test2", "test3", "--no-color", "--no-log-prefix"],
             [b'', b'test2', b'test3'],
+        ),
+        (
+            "custom_container_name",
+            ["test2", "test4"],
+            [
+                b'',
+                b'\x1b[1;33m[test2_1]|\x1b[0m \x1b[37mtest2\x1b[0m',
+                b'\x1b[1;35m[custom_name]|\x1b[0m \x1b[37mtest4\x1b[0m',
+            ],
         ),
     ])
     def test_logs(


### PR DESCRIPTION
Previously, the `logs` command by default used the service name as the prefix, ignoring any custom `container_name` specified in `compose.yml`. Container number was also not provided with service name prefix. 
Docker-compose, by contrast, uses `container_name` as the prefix when available, and falls back to the service name concatenated with the container number.
 
This change brings `podman-compose logs` command behavior closer to `docker-compose`.
