### PR TITLE
fix: scope --force-recreate to requested services only (#1177)

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -3745,6 +3745,8 @@ async def compose_up(compose: PodmanCompose, args: argparse.Namespace) -> int | 
             return 1
 
         if not args.no_recreate:
+            requested_services = set(args.services) if args.services else set()
+            always_recreate_deps = getattr(args, "always_recreate_deps", False)
             for c in existing_containers.values():
                 if (
                     c.service_name in excluded
@@ -3753,7 +3755,12 @@ async def compose_up(compose: PodmanCompose, args: argparse.Namespace) -> int | 
                     continue
 
                 service = compose.services[c.service_name]
-                if args.force_recreate or c.config_hash != compose.config_hash(service):
+                force_this = args.force_recreate and (
+                    not requested_services
+                    or c.service_name in requested_services
+                    or always_recreate_deps
+                )
+                if force_this or c.config_hash != compose.config_hash(service):
                     recreate_services.add(c.service_name)
 
                     # Running dependents of service are removed by down command

--- a/tests/integration/compose_up_behavior/test_compose_up_behavior.py
+++ b/tests/integration/compose_up_behavior/test_compose_up_behavior.py
@@ -136,6 +136,86 @@ class TestComposeUpBehavior(unittest.TestCase, RunSubprocessMixin):
                 "0",
             ])
 
+    @parameterized.expand([
+        (
+            "service_change_base",
+            ["up", "--force-recreate"],
+            {"app", "db", "no_deps"},
+        ),
+        (
+            "service_change_base",
+            ["up", "--force-recreate", "app"],
+            {"app"},
+        ),
+        (
+            "service_change_base",
+            ["up", "--force-recreate", "db"],
+            {"db", "app"},
+        ),
+        (
+            "service_change_base",
+            ["up", "--force-recreate", "no_deps"],
+            {"no_deps"},
+        ),
+        (
+            "service_change_base",
+            ["up", "--force-recreate", "--always-recreate-deps", "app"],
+            {"app", "db"},
+        ),
+    ])
+    def test_force_recreate_scoped_to_requested_services(
+        self,
+        running_scenario: str,
+        command_args: list[str],
+        expect_recreated_services: set[str],
+    ) -> None:
+        try:
+            self.run_subprocess_assert_returncode(
+                [podman_compose_path(), "-f", compose_yaml_path(running_scenario), "up", "-d"],
+            )
+
+            original_containers = self.get_existing_containers(running_scenario)
+
+            self.run_subprocess_assert_returncode(
+                [
+                    podman_compose_path(),
+                    "--verbose",
+                    "-f",
+                    compose_yaml_path(running_scenario),
+                    *command_args,
+                    "-d",
+                ],
+            )
+
+            new_containers = self.get_existing_containers(running_scenario)
+            recreated_services = {
+                c.get("service_name")
+                for c in original_containers.values()
+                if new_containers.get(c.get("name"), {}).get("id") != c.get("id")
+            }
+
+            self.assertEqual(
+                recreated_services,
+                expect_recreated_services,
+                msg=f"Expected services to be recreated: {expect_recreated_services}, "
+                f"but got: {recreated_services}, containers: "
+                f"[{original_containers}, {new_containers}]",
+            )
+            self.assertTrue(
+                all([c.get("exited") is False for c in new_containers.values()]),
+                msg="Not all containers are running after up command",
+            )
+
+        finally:
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path(running_scenario),
+                "down",
+                "-t",
+                "0",
+            ])
+
     @unittest.skipIf(
         get_podman_version() < version.parse("5.6.0"),
         "The image pull policy feature was only added as of Podman 5.6.0.",


### PR DESCRIPTION
When specific services are passed to `podman-compose up --force-recreate`, the force flag is applied to all non-excluded containers, including dependencies that were not explicitly requested. This causes dependencies to be unnecessarily torn down and recreated, even when their configuration has not changed.

For example, `podman-compose up -d --force-recreate app` also recreates `db` if `app` depends on it, despite `db` being unchanged. Docker Compose does not exhibit this behavior — it only force-recreates the named services and starts dependencies if needed without recreating them.

The root cause is that `get_excluded()` removes both the named service and its dependencies from the exclusion set, so when the recreate loop iterates over all non-excluded containers, `args.force_recreate` applies to dependencies as well.

This change scopes the force-recreate flag so it only applies to:
- explicitly requested services, or
- all services when no specific service is named (preserving existing behavior for bare `--force-recreate`)

Additionally, the previously parsed but unused `--always-recreate-deps` flag is now wired up: when combined with `--force-recreate`, it extends the force to dependency services as well, matching Docker Compose semantics.

Integration tests are added covering all five combinations:
- --force-recreate (no service): all services recreated
- --force-recreate <leaf>: only the named service recreated
- --force-recreate <dependency>: dependency + its dependents recreated
- --force-recreate <independent>: only the independent service recreated
- --force-recreate --always-recreate-deps <service>: service + deps

Fixes: #1177


## Contributor Checklist:

Please make sure to read development guidelines in CONTRIBUTING.md. Pull requests that do not
follow the guidelines WILL TAKE LONGER TO REVIEW as the first review comment will be to follow
these guidelines.

If this PR adds a new feature that improves compatibility with docker-compose, please add a link
to the exact part of compose spec that the PR touches.

For any user-visible change please add a release note to newsfragments directory, e.g.
newsfragments/my_feature.feature. See newsfragments/README.txt for more details.

All changes require additional unit tests.
