### PR TITLE
fix: support dict items in include directive

### DIFF
--- a/newsfragments/fix_include_dict_typeerror.bugfix
+++ b/newsfragments/fix_include_dict_typeerror.bugfix
@@ -1,0 +1,1 @@
+Fix TypeError when parsing 'include' items that are formatted as detailed mappings (dictionaries).

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2632,7 +2632,18 @@ class PodmanCompose:
             # If `include` is used, append included files to files
             include = compose.get("include")
             if include:
-                files.extend([os.path.join(os.path.dirname(filename), i) for i in include])
+                included_files = []
+                for i in include:
+                    if isinstance(i, dict):
+                        rel_path = i.get("path")
+                    elif isinstance(i, str):
+                        rel_path = i
+                    else:
+                        rel_path = None
+
+                    if rel_path:
+                        included_files.append(os.path.join(os.path.dirname(filename), rel_path))
+                files.extend(included_files)
                 # As compose obj is updated and tested with every loop, not deleting `include`
                 # from it, results in it being tested again and again, original values for
                 # `include` be appended to `files`, and, included files be processed for ever.

--- a/tests/unit/test_include.py
+++ b/tests/unit/test_include.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: GPL-2.0
+# pylint: disable=protected-access
+from __future__ import annotations
+
+import argparse
+import os
+import unittest
+from typing import Any
+
+import yaml
+
+from podman_compose import PodmanCompose
+
+
+class TestIncludeDict(unittest.TestCase):
+    def setUp(self) -> None:
+        self.test_files: list[str] = []
+
+    def tearDown(self) -> None:
+        for f in self.test_files:
+            if os.path.exists(f):
+                os.remove(f)
+
+    def write_yaml(self, name: str, content: dict[str, Any]) -> None:
+        with open(name, "w", encoding="utf-8") as f:
+            yaml.safe_dump(content, f)
+        self.test_files.append(name)
+
+    def test_parse_compose_file_with_include_dict(self) -> None:
+        # 1. Create a base compose file to be included
+        include_content = {"services": {"base_web": {"image": "nginx:alpine"}}}
+        self.write_yaml("test-compose-include.yaml", include_content)
+
+        # 2. Create a main compose file with include detailed format (dictionary)
+        main_content = {
+            "version": "3.8",
+            "include": [{"path": "./test-compose-include.yaml"}],
+            "services": {"web": {"image": "alpine:latest"}},
+        }
+        self.write_yaml("test-compose-main.yaml", main_content)
+
+        podman_compose = PodmanCompose()
+        podman_compose.global_args = argparse.Namespace()
+        podman_compose.global_args.file = ["test-compose-main.yaml"]
+        podman_compose.global_args.project_name = "test_project"
+        podman_compose.global_args.env_file = None
+        podman_compose.global_args.profile = []
+        podman_compose.global_args.in_pod = "false"
+        podman_compose.global_args.pod_args = None
+        podman_compose.global_args.no_normalize = True
+
+        # It should run successfully without raising a TypeError
+        podman_compose._parse_compose_file()
+
+        self.assertIn("web", podman_compose.services)
+        self.assertIn("base_web", podman_compose.services)


### PR DESCRIPTION
When using `include:` with detailed mapping (dict) format instead of plain strings, `podman-compose` fails with:
`TypeError: join() argument must be str, bytes, or os.PathLike object, not 'dict'`

This happens because the parser assumes all include items are strings. I've updated `_parse_compose_file` to support both string and dictionary items (extracting the `path` key when it is a dict), conforming to the Compose Spec:
https://github.com/compose-spec/compose-spec/blob/master/spec.md#include