### PR TITLE
Activate profiles of a given targeted service or services

### DIFF
--- a/newsfragments/activate_profiles_of_given_services.bugfix
+++ b/newsfragments/activate_profiles_of_given_services.bugfix
@@ -1,0 +1,1 @@
+Activate profiles of a given targeted service or services.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2575,6 +2575,15 @@ class PodmanCompose:
         }
         requested_profiles = set(args.profile).union(profiles_from_env)
 
+        target_service = getattr(
+            args, "service", None
+        )  # example: command `run` can only have one service
+        target_services = getattr(
+            args, "services", None
+        )  # example: command `build` can have several services
+
+        target = [target_service] if target_service else target_services or []
+
         compose: dict[str, Any] = {}
         # Iterate over files primitively to allow appending to files in-loop
         files_iter = iter(files)
@@ -2661,7 +2670,7 @@ class PodmanCompose:
                 # having `include` present and correctly processed in included files
                 del compose["include"]
         resolved_services = self._resolve_profiles(
-            compose.get("services") or {}, requested_profiles
+            compose.get("services") or {}, target, requested_profiles
         )
         compose["services"] = resolved_services
         if not getattr(args, "no_normalize", None):
@@ -2685,7 +2694,7 @@ class PodmanCompose:
         if not services:
             log.warning("WARNING: No services defined")
         # include services with no profile defined or the selected profiles
-        services = self._resolve_profiles(services, requested_profiles)
+        services = self._resolve_profiles(services, target, requested_profiles)
 
         # NOTE: maybe add "extends.service" to _deps at this stage
         flat_deps(services, with_extends=True)
@@ -2824,20 +2833,28 @@ class PodmanCompose:
         self.container_by_name = {c["name"]: c for c in given_containers}
 
     def _resolve_profiles(
-        self, defined_services: dict[str, Any], requested_profiles: set[str] | None = None
+        self,
+        defined_services: dict[str, Any],
+        target: list[str],
+        requested_profiles: set[str] | None = None,
     ) -> dict[str, Any]:
         """
         Returns a service dictionary (key = service name, value = service config) compatible with
-        the requested_profiles list.
+        the requested_profiles list and target service or services.
 
         The returned service dictionary contains all services which do not include/reference a
-        profile in addition to services that match the requested_profiles.
+        profile, match the requested_profiles, and match profiles of an explicitly targeted service
+        or services.
 
         :param defined_services: The service dictionary
         :param requested_profiles: The profiles requested using the --profile arg.
+        :param target: Name of service or services targeted by the current command
         """
         if requested_profiles is None:
             requested_profiles = set()
+
+        for service in target:
+            requested_profiles.update(defined_services.get(service, {}).get("profiles", []))
 
         services = {}
 

--- a/tests/integration/profile/Dockerfile
+++ b/tests/integration/profile/Dockerfile
@@ -1,0 +1,1 @@
+FROM nopush/podman-compose-test

--- a/tests/integration/profile/docker-compose-only-profiles.yml
+++ b/tests/integration/profile/docker-compose-only-profiles.yml
@@ -1,0 +1,15 @@
+version: "3"
+services:
+    test:
+      image: test:latest
+      command: ["echo", "test"]
+      profiles: [test_profile]
+      build:
+        context: .
+        dockerfile: Dockerfile
+    test_2:
+      image: test_2:latest
+      profiles: [test_2_profile]
+      build:
+        context: .
+        dockerfile: Dockerfile

--- a/tests/integration/profile/test_podman_compose_targeted_service.py
+++ b/tests/integration/profile/test_podman_compose_targeted_service.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: GPL-2.0
+
+"""
+test_podman_compose_targeted_service.py
+
+Tests that the podman-compose `build` and `run` commands activate their
+profiles when a specific service (or services) is targeted.
+"""
+
+# pylint: disable=redefined-outer-name
+import os
+import unittest
+
+from tests.integration.test_utils import RunSubprocessMixin
+from tests.integration.test_utils import podman_compose_path
+from tests.integration.test_utils import test_path
+
+
+def compose_yaml_path() -> str:
+    return os.path.join(test_path(), "profile", "docker-compose-only-profiles.yml")
+
+
+class TestComposeTargetedServices(unittest.TestCase, RunSubprocessMixin):
+    def test_build_profile_one_target_service(self) -> None:
+        try:
+            out, _ = self.run_subprocess_assert_returncode(
+                [
+                    "coverage",
+                    "run",
+                    podman_compose_path(),
+                    "-f",
+                    compose_yaml_path(),
+                    "build",
+                    "test_2",
+                ],
+                0,
+            )
+            self.assertIn(b"FROM nopush/podman-compose-test", out)
+            self.run_subprocess_assert_returncode(["podman", "image", "exists", "test_2:latest"], 0)
+        finally:
+            self.run_subprocess_assert_returncode(
+                [
+                    "podman",
+                    "rmi",
+                    "test_2:latest",
+                ],
+                0,
+            )
+
+    def test_build_profile_two_target_services(self) -> None:
+        # "build" command can have several target services
+        try:
+            out, _ = self.run_subprocess_assert_returncode(
+                [
+                    "coverage",
+                    "run",
+                    podman_compose_path(),
+                    "-f",
+                    compose_yaml_path(),
+                    "build",
+                    "test",
+                    "test_2",
+                ],
+                0,
+            )
+            self.assertIn(b"FROM nopush/podman-compose-test", out)
+            self.run_subprocess_assert_returncode(["podman", "image", "exists", "test:latest"], 0)
+            self.run_subprocess_assert_returncode(["podman", "image", "exists", "test_2:latest"], 0)
+        finally:
+            self.run_subprocess_assert_returncode(
+                [
+                    "podman",
+                    "rmi",
+                    "test:latest",
+                    "test_2:latest",
+                ],
+                0,
+            )
+
+    def test_run_profile_one_target_service(self) -> None:
+        # "run" command can only have one target service
+        try:
+            out, _ = self.run_subprocess_assert_returncode(
+                [
+                    "coverage",
+                    "run",
+                    podman_compose_path(),
+                    "-f",
+                    compose_yaml_path(),
+                    "run",
+                    "--rm",
+                    "test",
+                ],
+                0,
+            )
+            self.assertIn(b'test\r\n', out)
+        finally:
+            self.run_subprocess_assert_returncode(
+                [
+                    "podman",
+                    "rmi",
+                    "test:latest",
+                ],
+                0,
+            )
+
+    def test_targeted_service_is_not_provided_for_profile(self) -> None:
+        # without specific service name, profile is not activated
+        compose_yaml_path = os.path.join(test_path(), "profile", "docker-compose-only-profiles.yml")
+        out, error = self.run_subprocess_assert_returncode(
+            [
+                "coverage",
+                "run",
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path,
+                "build",
+            ],
+            0,
+        )
+        self.assertIn(b"WARNING: No services defined", error)


### PR DESCRIPTION
This PR is based on https://github.com/containers/podman-compose/pull/1297, thanks to https://github.com/Kache.

Previously, `podman-compose` did not automatically activate the profiles of explicitly targeted services. This change ensures that targeting a service adds its profile to the active set, aligning behavior with `docker-compose`.

Per the Docker Compose documentation:
    > A service is ignored by Compose when none of the listed profiles
    > match the active ones, unless the service is explicitly targeted by
    > a command. In that case its profile is added to the set of active
    > profiles.
    
https://docs.docker.com/reference/compose-file/profiles/

Fixes https://github.com/containers/podman-compose/issues/930.

