### PR TITLE
Support `configs:` from Compose spec

### DIFF
--- a/newsfragments/1473.feature
+++ b/newsfragments/1473.feature
@@ -1,0 +1,1 @@
+Added support for `configs`

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2910,6 +2910,16 @@ class PodmanCompose:
         ]
         # other top-levels:
         self.declared_configs = compose.get("configs", {})
+        if (
+            self.declared_configs
+            and self.podman_version is not None
+            and strverscmp_lt(self.podman_version, "5.6.0")
+        ):
+            raise PodmanComposeError(
+                "Compose configs are only supported when running podman >= 5.6.0 "
+                f"(current version {self.podman_version})"
+            )
+
         self.declared_secrets = compose.get("secrets", {})
         given_containers = []
         container_names_by_service: dict[str, list[str]] = {}

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -585,7 +585,7 @@ async def assert_config_artifact(
     source_env = config.get("environment")
     source_content = config.get("content")
     source_external = config.get("external", False)
-    if not bool(source_file) ^ bool(source_env) ^ bool(source_content) ^ source_external:
+    if bool(source_file) + bool(source_env) + bool(source_content) + source_external != 1:
         raise ValueError(
             f'ERROR: Config "{config_name}" must specify one and only one of file, '
             'environment, content, or external.'

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -613,7 +613,7 @@ async def assert_config_artifact(
                 f"External config [{artifact_name}] does not exist. "
                 f"Create it first with: podman artifact add '{artifact_name}'"
             ) from e
-    except (json.JSONDecodeError, KeyError) as e:
+    except (json.JSONDecodeError, KeyError, TypeError) as e:
         raise PodmanComposeError(
             f'Artifact {artifact_name} exists, but the Manifest.layers[0].digest '
             f'field could not be parsed. Check the output of: '
@@ -4161,7 +4161,7 @@ async def compose_down(compose: PodmanCompose, args: argparse.Namespace) -> None
         for cnt in containers:
             if cnt["_service"] not in excluded:
                 continue
-            for cfg_name, cfg in cnt.get("configs", {}).items():
+            for cfg in cnt.get("configs", []):
                 src = cfg if isinstance(cfg, str) else cfg.get("source")
                 configs_to_keep.add(src)
 

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -567,6 +567,113 @@ def try_parse_bool(value: Any) -> bool | None:
     return None
 
 
+def default_config_artifact_name(compose: PodmanCompose, config_name: str) -> str:
+    return "localhost/podman-compose/" + compose.format_name("config", config_name) + ":latest"
+
+
+async def assert_config_artifact(
+    compose: PodmanCompose, config_name: str, config: dict[str, Any]
+) -> str | None:
+    """
+    inspect config artifact
+    create artifact if needed
+
+    Returns:
+        Artifact name and tag, or None if file source
+    """
+    source_file = config.get("file")
+    source_env = config.get("environment")
+    source_content = config.get("content")
+    source_external = config.get("external", False)
+    if not bool(source_file) ^ bool(source_env) ^ bool(source_content) ^ source_external:
+        raise ValueError(
+            f'ERROR: Config "{config_name}" must specify one and only one of file, '
+            'environment, content, or external.'
+        )
+
+    if source_file:
+        # File configs are mounted as volumes, not created as artifacts
+        return None
+
+    if "name" in config:
+        artifact_name = config["name"]
+    elif source_external:
+        artifact_name = config_name
+    else:
+        artifact_name = default_config_artifact_name(compose, config_name)
+
+    log.debug('podman artifact inspect %s || podman artifact add %s', artifact_name, artifact_name)
+    artifact_content_digest = None
+    try:
+        output = await compose.podman.output([], "artifact", ["inspect", artifact_name])
+        artifact_content_digest = json.loads(output)["Manifest"]["layers"][0]["digest"]
+    except subprocess.CalledProcessError as e:
+        if source_external:
+            raise PodmanComposeError(
+                f"External config [{artifact_name}] does not exist. "
+                f"Create it first with: podman artifact add '{artifact_name}'"
+            ) from e
+    except (json.JSONDecodeError, KeyError) as e:
+        raise PodmanComposeError(
+            f'Artifact {artifact_name} exists, but the Manifest.layers[0].digest '
+            f'field could not be parsed. Check the output of: '
+            f'podman artifact inspect {artifact_name}.'
+        ) from e
+
+    if source_external:
+        # External artifact exists, nothing to check
+        return artifact_name
+
+    config_content = b''
+    if source_env:
+        try:
+            config_content = os.environb[source_env.encode("utf-8")]
+        except KeyError as e:
+            raise PodmanComposeError(
+                f'Config "{config_name}" specifies an environment variable '
+                f'as its source, but "{source_env}" is not defined in the environment.'
+            ) from e
+    if source_content:
+        config_content = source_content.encode("utf-8")
+
+    if artifact_content_digest:
+        hash_alg, _, digest = artifact_content_digest.partition(':')
+        try:
+            compose_content_digest = hashlib.new(hash_alg, config_content, usedforsecurity=False)
+        except ValueError as e:
+            raise PodmanComposeError(
+                f'Artifact hash digest {hash_alg} is not supported. '
+                f'Check the output of: podman artifact inspect {artifact_name}.'
+            ) from e
+        if compose_content_digest.hexdigest() == digest:
+            # Stored artifact is the same, returning
+            return artifact_name
+
+    # Artifact didn't exist or digest differed, so (re-)create
+    args = [
+        "add",
+        "--replace",
+        "--file-type",
+        "application/octet-stream",
+        "--annotation",
+        f"io.podman.compose.project={compose.project_name}",
+        "--annotation",
+        f"com.docker.compose.project={compose.project_name}",
+        artifact_name,
+    ]
+    # Once requires-python is >=3.12, delete=False can be changed
+    # to delete_on_close=False and the call to os.unlink removed
+    with tempfile.NamedTemporaryFile(delete=False) as config_tempfile:
+        config_tempfile.write(config_content)
+        config_tempfile.close()
+        args.append(config_tempfile.name)
+        await compose.podman.output([], "artifact", args)
+        os.unlink(config_tempfile.name)
+    await compose.podman.output([], "artifact", ["inspect", artifact_name])
+
+    return artifact_name
+
+
 async def assert_volume(compose: PodmanCompose, mount_dict: dict[str, Any]) -> None:
     """
     inspect volume to get directory
@@ -907,6 +1014,71 @@ def get_secret_args(
     raise ValueError(
         'ERROR: unparsable secret: "{}", service: "{}"'.format(secret_name, cnt["_service"])
     )
+
+
+async def get_config_args(
+    compose: PodmanCompose,
+    cnt: dict[str, Any],
+    config: str | dict[str, Any],
+) -> list[str]:
+    assert compose.declared_configs is not None
+
+    config_name = config if isinstance(config, str) else config.get("source")
+    if not config_name or config_name not in compose.declared_configs.keys():
+        raise ValueError(f'ERROR: undeclared config: "{config}", service: {cnt["_service"]}')
+    declared_config = compose.declared_configs[config_name]
+
+    x_podman_relabel = declared_config.get("x-podman.relabel")
+
+    config_target = None
+    config_uid = None
+    config_gid = None
+    config_mode = None
+    if isinstance(config, dict):
+        config_target = config.get("target")
+        config_uid = config.get("uid")
+        config_gid = config.get("gid")
+        config_mode = config.get("mode")
+    if config_uid or config_gid or config_mode:
+        target_msg = f' (at target {config_target})' if config_target else ""
+        log.warning(
+            'WARNING: Service %s uses configs.%s%s '
+            "with uid, gid, or mode. These fields are not supported by this implementation "
+            "of the Compose file",
+            cnt["_service"],
+            config_name,
+            target_msg,
+        )
+
+    source_artifact = await assert_config_artifact(compose, config_name, declared_config)
+    dest_file = config_target or f"/{config_name}"
+
+    if source_artifact:
+        mount_ref = ["--mount", f"type=artifact,source={source_artifact},target={dest_file}"]
+
+        return mount_ref
+
+    if source_file := declared_config.get("file"):
+        # assemble path for source file first, because we need it for all cases
+        basedir = compose.dirname
+        source_file = os.path.realpath(os.path.join(basedir, os.path.expanduser(source_file)))
+
+        # pass file configs to "podman run" as volumes
+        mount_options = 'ro,rprivate,rbind'
+
+        selinux_relabel_to_mount_option_map = {None: "", "z": ",z", "Z": ",Z"}
+        try:
+            mount_options += selinux_relabel_to_mount_option_map[x_podman_relabel]
+        except KeyError as exc:
+            raise ValueError(
+                f'ERROR: Config "{config_name}" has invalid "relabel" option related '
+                + f' to SELinux "{x_podman_relabel}". Expected "z" "Z" or nothing.'
+            ) from exc
+        volume_ref = ["--volume", f"{source_file}:{dest_file}:{mount_options}"]
+
+        return volume_ref
+
+    raise ValueError(f'ERROR: unparsable config: "{config_name}", service: "{cnt["_service"]}"')
 
 
 def container_to_res_args(cnt: dict[str, Any], podman_args: list[str]) -> None:
@@ -1388,6 +1560,8 @@ async def container_to_args(
         podman_args.append(f'--log-driver={log_config.get("driver", "k8s-file")}')
         log_opts = log_config.get("options", {})
         podman_args += [f"--log-opt={name}={value}" for name, value in log_opts.items()]
+    for config in cnt.get("configs", []):
+        podman_args.extend(await get_config_args(compose, cnt, config))
     for secret in cnt.get("secrets", []):
         podman_args.extend(get_secret_args(compose, cnt, secret))
     for i in cnt.get("extra_hosts", []):
@@ -2292,6 +2466,7 @@ class PodmanCompose:
         self.vols: dict[str, Any] | None = None
         self.networks: dict[str, Any] = {}
         self.default_net: str | None = "default"
+        self.declared_configs: dict[str, Any] | None = None
         self.declared_secrets: dict[str, Any] | None = None
         self.container_names_by_service: dict[str, list[str]]
         self.container_by_name: dict[str, Any]
@@ -2734,7 +2909,7 @@ class PodmanCompose:
             "com.docker.compose.project.config_files=" + ",".join(relative_files),
         ]
         # other top-levels:
-        # configs: {...}
+        self.declared_configs = compose.get("configs", {})
         self.declared_secrets = compose.get("secrets", {})
         given_containers = []
         container_names_by_service: dict[str, list[str]] = {}
@@ -3981,8 +4156,70 @@ async def compose_down(compose: PodmanCompose, args: argparse.Namespace) -> None
             continue
         await compose.podman.run([], "rm", [cnt["name"]])
 
+    if compose.declared_configs is not None:
+        configs_to_keep = set()
+        for cnt in containers:
+            if cnt["_service"] not in excluded:
+                continue
+            for cfg_name, cfg in cnt.get("configs", {}).items():
+                src = cfg if isinstance(cfg, str) else cfg.get("source")
+                configs_to_keep.add(src)
+
+        configs_to_remove = {
+            name: config
+            for name, config in compose.declared_configs.items()
+            if not (name in configs_to_keep or config.get("external", False) or "file" in config)
+        }
+        for name, config in configs_to_remove.items():
+            artifact_name = config.get("name") or default_config_artifact_name(compose, name)
+            try:
+                output = await compose.podman.output([], "artifact", ["inspect", artifact_name])
+            except subprocess.CalledProcessError:
+                # Already removed
+                continue
+
+            try:
+                config_info = json.loads(output)["Manifest"]
+                config_annotations = config_info["annotations"]
+                config_project = config_annotations.get(
+                    "io.podman.compose.project"
+                ) or config_annotations.get("com.docker.compose.project")
+            except (json.JSONDecodeError, KeyError):
+                log.warning(
+                    'WARNING: Config %s has an associated artifact, but the output '
+                    "of podman artifact inspect %s couldn't be parsed.",
+                    name,
+                    artifact_name,
+                )
+                continue
+
+            if config_project is not None and config_project == compose.project_name:
+                try:
+                    await compose.podman.output([], "artifact", ["rm", artifact_name])
+                except subprocess.CalledProcessError:
+                    log.error(
+                        'ERROR: Failed to remove artifact %s associated with config %s.',
+                        artifact_name,
+                        name,
+                    )
+                    continue
+            else:
+                if config_project:
+                    msg = f'its annotated project name "{config_project}" does not match '
+                else:
+                    msg = 'it is not annotated with '
+
+                log.warning(
+                    f'WARNING: Config {name} has an associated artifact, but '
+                    + msg
+                    + f'the name of this Compose project, "{compose.project_name}". '
+                    + f'Check the output of podman artifact inspect {artifact_name}.'
+                )
+
     orphaned_images = set()
     if args.remove_orphans:
+        # TODO: if podman artifact ls gets a --filter option, then
+        # orphaned configs could be cleaned up
         orphaned_containers = (
             (
                 await compose.podman.output(

--- a/tests/integration/configs/docker-compose.yaml
+++ b/tests/integration/configs/docker-compose.yaml
@@ -1,0 +1,44 @@
+version: "3.8"
+services:
+    test:
+      image: busybox
+      command:
+        - /tmp/print_configs.sh
+      tmpfs:
+        - /run
+        - /tmp
+      volumes:
+        - ./print_configs.sh:/tmp/print_configs.sh:z
+      configs:
+        - podman_compose_test_config
+        - source: podman_compose_test_config_2
+          target: /podman_compose_test_config_2
+        - file_config
+        - source: file_config
+          target: /etc/custom_location
+        - source: file_config
+          # warning about unsupported "uid", "gid", "mode" fields
+          target: /unused_params_warning
+          uid: '103'
+          gid: '103'
+          mode: 400
+        - content_config
+        - content_config_with_var
+        - environment_config
+
+configs:
+  podman_compose_test_config:
+    external: true
+  podman_compose_test_config_2:
+    external: true
+    name: podman_compose_test_config_2
+  file_config:
+    file: ./my_config
+  content_config:
+    content: |
+      config-from-content
+  content_config_with_var:
+    content: |
+      config-with-${CONFIG_VAR}
+  environment_config:
+    environment: CONFIG_ENV

--- a/tests/integration/configs/my_config
+++ b/tests/integration/configs/my_config
@@ -1,0 +1,1 @@
+important-config-is-important

--- a/tests/integration/configs/print_configs.sh
+++ b/tests/integration/configs/print_configs.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+grep . \
+    /podman_compose_test_config \
+    /podman_compose_test_config_2 \
+    /file_config \
+    /etc/custom_location \
+    /unused_params_warning \
+    /content_config \
+    /content_config_with_var \
+    /environment_config

--- a/tests/integration/configs/test_podman_compose_configs.py
+++ b/tests/integration/configs/test_podman_compose_configs.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: GPL-2.0
+
+import os
+import subprocess
+import tempfile
+import unittest
+
+from tests.integration.test_utils import RunSubprocessMixin
+from tests.integration.test_utils import podman_compose_path
+from tests.integration.test_utils import test_path
+
+
+def compose_yaml_path() -> str:
+    return os.path.join(os.path.join(test_path(), "configs"), "docker-compose.yaml")
+
+
+class TestComposeConfigs(unittest.TestCase, RunSubprocessMixin):
+    created_configs = [
+        "podman_compose_test_config",
+        "podman_compose_test_config_2",
+    ]
+
+    def setUp(self) -> None:
+        for config in self.created_configs:
+            # Once requires-python is >=3.12, delete=False can be changed
+            # to delete_on_close=False and the call to os.unlink removed
+            with tempfile.NamedTemporaryFile(delete=False) as config_tempfile:
+                config_tempfile.write(config.encode('utf-8'))
+                config_tempfile.close()
+                subprocess.run([
+                    "podman",
+                    "artifact",
+                    "add",
+                    "--file-type",
+                    "text/plain",
+                    config,
+                    config_tempfile.name,
+                ])
+                os.unlink(config_tempfile.name)
+
+    def tearDown(self) -> None:
+        for config in self.created_configs:
+            self.run_subprocess_assert_returncode([
+                "podman",
+                "artifact",
+                "rm",
+                f"{config}",
+            ])
+
+    # test if configs are saved and available in respective files of a container
+    def test_configs(self) -> None:
+        try:
+            _, error = self.run_subprocess_assert_returncode(
+                [
+                    podman_compose_path(),
+                    "-f",
+                    compose_yaml_path(),
+                    "up",
+                    "test",
+                ],
+                env={
+                    "CONFIG_ENV": "config-from-environment",
+                    "CONFIG_VAR": "value-from-environment",
+                },
+            )
+
+            self.assertIn(
+                b'WARNING: Service test uses configs.file_config '
+                b'(at target /unused_params_warning) with uid, gid, or mode. '
+                b'These fields are not supported by this implementation of the Compose file\n',
+                error,
+            )
+
+            output, _ = self.run_subprocess_assert_returncode(["podman", "logs", "configs_test_1"])
+            expected_output = (
+                b'/podman_compose_test_config:podman_compose_test_config\n'
+                + b'/podman_compose_test_config_2:podman_compose_test_config_2\n'
+                + b'/file_config:important-config-is-important\n'
+                + b'/etc/custom_location:important-config-is-important\n'
+                + b'/unused_params_warning:important-config-is-important\n'
+                + b'/content_config:config-from-content\n'
+                + b'/content_config_with_var:config-with-value-from-environment\n'
+                + b'/environment_config:config-from-environment\n'
+            )
+            self.assertEqual(
+                expected_output.decode(errors='backslashreplace'),
+                output.decode(errors='backslashreplace'),
+            )
+        finally:
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path(),
+                "down",
+                "-t",
+                "0",
+            ])
+
+        output, _ = self.run_subprocess_assert_returncode([
+            "podman",
+            "artifact",
+            "ls",
+            "--noheading",
+            "--format",
+            "{{.Repository}}:{{.Tag}}",
+        ])
+        # assert external artifacts still present; not removed until self.tearDown()
+        self.assertIn(b'podman_compose_test_config', output)
+        # assert compose-created artifacts correctly removed during podman compose down
+        self.assertNotIn(b'localhost/podman-compose/configs_config_', output)

--- a/tests/integration/configs/test_podman_compose_configs.py
+++ b/tests/integration/configs/test_podman_compose_configs.py
@@ -5,7 +5,10 @@ import subprocess
 import tempfile
 import unittest
 
+from packaging import version
+
 from tests.integration.test_utils import RunSubprocessMixin
+from tests.integration.test_utils import get_podman_version
 from tests.integration.test_utils import podman_compose_path
 from tests.integration.test_utils import test_path
 
@@ -48,6 +51,10 @@ class TestComposeConfigs(unittest.TestCase, RunSubprocessMixin):
             ])
 
     # test if configs are saved and available in respective files of a container
+    @unittest.skipIf(
+        get_podman_version() < version.parse("5.6.0"),
+        "Configs supported on podman-5.6.0 and later.",
+    )
     def test_configs(self) -> None:
         try:
             _, error = self.run_subprocess_assert_returncode(

--- a/tests/unit/test_compose_down.py
+++ b/tests/unit/test_compose_down.py
@@ -1,0 +1,175 @@
+# SPDX-License-Identifier: GPL-2.0
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import unittest
+from typing import Any
+from typing import cast
+from unittest import mock
+from unittest.mock import call
+
+from podman_compose import PodmanCompose
+from podman_compose import compose_down
+from tests.unit.test_container_to_args_configs import artifact_qualified_name
+
+
+def create_compose_mock(project_name: str = "test_project_name") -> PodmanCompose:
+    compose = mock.Mock()
+    compose.project_name = project_name
+    compose.services = {}
+    type(compose).containers = mock.PropertyMock(
+        side_effect=lambda: [v | {"_service": k} for k, v in compose.services.items()]
+    )
+    compose.pods = []
+    # compose.dirname = "test_dirname"
+    # compose.container_names_by_service.get = mock.Mock(return_value=None)
+    # compose.join_name_parts = mock.Mock(side_effect=lambda *args: '_'.join(args))
+    compose.format_name = mock.Mock(side_effect=lambda *args: '_'.join([project_name, *args]))
+
+    artifact_store = {
+        artifact_qualified_name(project_name, "my_config_name"): "sha256:NOT_CHECKED_DURING_REMOVE",
+    }
+
+    async def podman_output(
+        podman_args: list[str], cmd: str = "", cmd_args: list[str] | None = None
+    ) -> bytes:
+        if cmd == "artifact":
+            assert type(cmd_args) is list and len(cmd_args) >= 2, (
+                "invalid number of arguments provided to podman artifact"
+            )
+            artifact_op = cmd_args[0]
+            if artifact_op == "add":
+                artifact_name = cmd_args[-2]
+                with open(cmd_args[-1], 'rb') as artifact_file:
+                    artifact_hash = hashlib.sha256(artifact_file.read())
+                artifact_store[artifact_name] = f'sha256:{artifact_hash.hexdigest()}'
+            elif artifact_op == "inspect":
+                artifact_name = cmd_args[-1]
+                if artifact_name not in artifact_store:
+                    raise subprocess.CalledProcessError(
+                        125,
+                        ["podman"] + podman_args + [cmd] + cmd_args,
+                        f'Error: {artifact_name}: artifact does not exist'.encode(),
+                    )
+                inspect_result = {
+                    "Manifest": {
+                        "layers": [
+                            {
+                                "digest": artifact_store[artifact_name],
+                                "annotations": {
+                                    "io.podman.compose.project": project_name,
+                                    "com.docker.compose.project": project_name,
+                                },
+                            }
+                        ],
+                        "annotations": {
+                            "io.podman.compose.project": project_name,
+                            "com.docker.compose.project": project_name,
+                        },
+                    },
+                    "Name": artifact_name,
+                }
+                return json.dumps(inspect_result, indent=4).encode()
+
+        return b''
+
+    compose.podman.output = mock.Mock(side_effect=podman_output)
+    compose.podman.run = mock.AsyncMock(return_value=0)
+    compose.podman.network_ls = mock.AsyncMock(return_value=[])
+
+    return compose
+
+
+def get_minimal_container(service_name: str = "service_name") -> dict[str, Any]:
+    return {
+        "name": "project_name_service_name1",
+        "service_name": service_name,
+        "image": "busybox",
+    }
+
+
+def get_compose_down_empty_args() -> argparse.Namespace:
+    args = argparse.Namespace()
+    args.volumes = False
+    args.remove_orphans = False
+    args.rmi = None
+    args.timeout = None
+    args.services = None
+
+    return args
+
+
+class TestComposeDown(unittest.IsolatedAsyncioTestCase):
+    async def test_removes_config_artifacts(self) -> None:
+        c = create_compose_mock()
+        c.declared_configs = {
+            "my_config_name": {
+                "content": "this-is-the-config-content",
+            }
+        }
+        cnt = get_minimal_container()
+        cnt["configs"] = [
+            {
+                "source": "my_config_name",
+            }
+        ]
+        c.services["service_name"] = cnt
+
+        down_args = get_compose_down_empty_args()
+        # TODO: self.assertNoLogs, available in Python >= 3.10, would be a useful
+        # check here that no warnings are issued when removing artifacts
+        await compose_down(c, down_args)
+
+        config_artifact_name = artifact_qualified_name(c.project_name, "my_config_name")
+        output_mock = cast(mock.Mock, c.podman.output)
+        output_mock.assert_has_calls([
+            call(
+                [],
+                "artifact",
+                ["inspect", config_artifact_name],
+            ),
+            call(
+                [],
+                "artifact",
+                ["rm", config_artifact_name],
+            ),
+        ])
+
+    async def test_keeps_artifacts_used_by_multiple_services(self) -> None:
+        c = create_compose_mock()
+        c.declared_configs = {
+            "my_config_name": {
+                "content": "this-is-the-config-content",
+            }
+        }
+        cnt = get_minimal_container("test-service-1")
+        cnt["configs"] = [
+            {
+                "source": "my_config_name",
+            }
+        ]
+        c.services["test-service-1"] = cnt
+        cnt2 = get_minimal_container("test-service-2")
+        cnt2["configs"] = [
+            {
+                "source": "my_config_name",
+            }
+        ]
+        c.services["test-service-2"] = cnt2
+
+        config_artifact_name = artifact_qualified_name(c.project_name, "my_config_name")
+        output_mock = cast(mock.Mock, c.podman.output)
+
+        down_args = get_compose_down_empty_args()
+        down_args.services = ["test-service-1"]
+        await compose_down(c, down_args)
+        # No configs to remove, so podman artifact is never called
+        output_mock.assert_not_called()
+
+        output_mock.reset_mock()
+        down2_args = get_compose_down_empty_args()
+        await compose_down(c, down2_args)
+        output_mock.assert_called_with([], "artifact", ["rm", config_artifact_name])

--- a/tests/unit/test_container_to_args_configs.py
+++ b/tests/unit/test_container_to_args_configs.py
@@ -389,9 +389,10 @@ class TestContainerToArgsConfigs(unittest.IsolatedAsyncioTestCase):
             ],
         )
 
-    @mock.patch.dict(os.environb, {b'CONFIG_VAL': b'config-from-environment'})
     async def test_environment_config(self) -> None:
         c = create_compose_mock()
+        # mock.patch.dict would be better, but doesn't work on Python 3.9
+        os.environ['CONFIG_VAL'] = 'config-from-environment'
         c.declared_configs = {
             "environment_config": {
                 "environment": "CONFIG_VAL",

--- a/tests/unit/test_container_to_args_configs.py
+++ b/tests/unit/test_container_to_args_configs.py
@@ -1,0 +1,519 @@
+# SPDX-License-Identifier: GPL-2.0
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import unittest
+from typing import cast
+from unittest import mock
+from unittest.mock import call
+
+from parameterized import parameterized
+
+from podman_compose import PodmanCompose
+from podman_compose import PodmanComposeError
+from podman_compose import container_to_args
+from tests.unit.test_container_to_args import create_compose_mock as super_compose_mock
+from tests.unit.test_container_to_args import get_minimal_container as super_minimal_container
+
+
+def create_compose_mock(project_name: str = "test_project_name") -> PodmanCompose:
+    compose = cast(mock.Mock, super_compose_mock(project_name))
+
+    artifact_store = {
+        "my_external_config": "sha256:EXTERNAL_IS_NOT_CHECKED",
+    }
+
+    async def podman_output(
+        podman_args: list[str], cmd: str = "", cmd_args: list[str] | None = None
+    ) -> bytes:
+        if cmd == "artifact":
+            assert type(cmd_args) is list and len(cmd_args) >= 2, (
+                "invalid number of arguments provided to podman artifact"
+            )
+            artifact_op = cmd_args[0]
+            if artifact_op == "add":
+                artifact_name = cmd_args[-2]
+                with open(cmd_args[-1], 'rb') as artifact_file:
+                    artifact_hash = hashlib.sha256(artifact_file.read())
+                artifact_store[artifact_name] = f'sha256:{artifact_hash.hexdigest()}'
+            elif artifact_op == "inspect":
+                artifact_name = cmd_args[-1]
+                if artifact_name not in artifact_store:
+                    raise subprocess.CalledProcessError(
+                        125,
+                        ["podman"] + podman_args + [cmd] + cmd_args,
+                        f'Error: {artifact_name}: artifact does not exist'.encode(),
+                    )
+                inspect_result = {
+                    "Manifest": {
+                        "layers": [
+                            {
+                                "digest": artifact_store[artifact_name],
+                                "annotations": {
+                                    "io.podman.compose.project": project_name,
+                                    "com.docker.compose.project": project_name,
+                                },
+                            }
+                        ],
+                    },
+                    "Name": artifact_name,
+                }
+                return json.dumps(inspect_result, indent=4).encode()
+
+        return b''
+
+    compose.podman.output = mock.Mock(side_effect=podman_output)
+
+    return compose
+
+
+def get_minimal_container(service_name: str = "test-service") -> dict:
+    cnt = super_minimal_container()
+    cnt["_service"] = service_name
+    return cnt
+
+
+def repo_root() -> str:
+    return os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+
+
+def artifact_qualified_name(project_name: str | None, artifact_name: str) -> str:
+    return f"localhost/podman-compose/{project_name}_config_{artifact_name}:latest"
+
+
+def artifact_add_args(project_name: str | None, artifact_name: str) -> list:
+    return [
+        "add",
+        "--replace",
+        "--file-type",
+        "application/octet-stream",
+        "--annotation",
+        f"io.podman.compose.project={project_name}",
+        "--annotation",
+        f"com.docker.compose.project={project_name}",
+        artifact_qualified_name(project_name, artifact_name),
+        mock.ANY,  # tempfile path
+    ]
+
+
+class TestContainerToArgsConfigs(unittest.IsolatedAsyncioTestCase):
+    @parameterized.expand([
+        (
+            "config_no_name",
+            {"my_config": "my_external_config", "external": True},
+            {},  # must have a name
+        ),
+        (
+            "no_config_name_in_declared_configs",
+            {},  # must have a name
+            {
+                "source": "my_external_config",
+            },
+        ),
+        (
+            "config_name_does_not_match_declared_configs_name",
+            {
+                "wrong_name": "my_config_name",
+            },
+            {
+                "source": "name",  # config name must match the one in declared_configs
+            },
+        ),
+        (
+            "config_name_empty_string",
+            {"": "my_config_name"},
+            {
+                "source": "",  # can not be empty string
+            },
+        ),
+    ])
+    async def test_config_name(
+        self, test_name: str, declared_configs: dict, add_to_minimal_container: dict
+    ) -> None:
+        c = create_compose_mock()
+        c.declared_configs = declared_configs
+
+        cnt = get_minimal_container()
+        cnt["configs"] = [add_to_minimal_container]
+
+        with self.assertRaises(ValueError) as context:
+            await container_to_args(c, cnt)
+        self.assertIn('ERROR: undeclared config: ', str(context.exception))
+
+    async def test_config_string_no_external_name_in_declared_configs(self) -> None:
+        c = create_compose_mock()
+        c.declared_configs = {"my_external_config": {"external": True}}
+        cnt = get_minimal_container()
+        cnt["configs"] = [
+            "my_external_config",
+        ]
+        args = await container_to_args(c, cnt)
+        self.assertEqual(
+            args,
+            [
+                "--name=project_name_service_name1",
+                "-d",
+                "--network=bridge:alias=service_name",
+                "--mount",
+                "type=artifact,source=my_external_config,target=/my_external_config",
+                "busybox",
+            ],
+        )
+
+    async def test_config_string_options_external_name_in_declared_configs(self) -> None:
+        c = create_compose_mock()
+        c.declared_configs = {
+            "my_config_name": {
+                "external": True,
+                "name": "my_external_config",
+            }
+        }
+        cnt = get_minimal_container()
+        cnt["configs"] = [
+            {
+                "source": "my_config_name",
+                "target": "/my_config_name",
+            }
+        ]
+
+        args = await container_to_args(c, cnt)
+        self.assertEqual(
+            args,
+            [
+                "--name=project_name_service_name1",
+                "-d",
+                "--network=bridge:alias=service_name",
+                "--mount",
+                "type=artifact,source=my_external_config,target=/my_config_name",
+                "busybox",
+            ],
+        )
+
+    async def test_config_string_external_name_in_declared_configs_does_not_match_config(
+        self,
+    ) -> None:
+        c = create_compose_mock()
+        c.declared_configs = {
+            "my_config_name": {
+                "external": True,
+                "name": "wrong_config_name",
+            }
+        }
+        cnt = get_minimal_container()
+        cnt["configs"] = [
+            "my_config_name",
+        ]
+
+        with self.assertRaises(PodmanComposeError) as context:
+            await container_to_args(c, cnt)
+        self.assertIn('External config [wrong_config_name] does not exist.', str(context.exception))
+
+    async def test_config_target_does_not_match_config_name(self) -> None:
+        c = create_compose_mock()
+        c.declared_configs = {
+            "my_external_config": {
+                "external": True,
+            }
+        }
+        cnt = get_minimal_container()
+        cnt["configs"] = [
+            {
+                "source": "my_external_config",
+                "target": "/tmp/custom_path",
+            }
+        ]
+
+        args = await container_to_args(c, cnt)
+        self.assertEqual(
+            args,
+            [
+                "--name=project_name_service_name1",
+                "-d",
+                "--network=bridge:alias=service_name",
+                "--mount",
+                "type=artifact,source=my_external_config,target=/tmp/custom_path",
+                "busybox",
+            ],
+        )
+
+    @parameterized.expand([
+        (
+            "no_config_target",
+            {
+                "file_config": {
+                    "file": "./my_config",
+                }
+            },
+            "file_config",
+            repo_root() + "/test_dirname/my_config:/file_config:ro,rprivate,rbind",
+        ),
+        (
+            "relabel",
+            {"file_config": {"file": "./my_config", "x-podman.relabel": "Z"}},
+            "file_config",
+            repo_root() + "/test_dirname/my_config:/file_config:ro,rprivate,rbind,Z",
+        ),
+        (
+            "relabel",
+            {"file_config": {"file": "./my_config", "x-podman.relabel": "z"}},
+            "file_config",
+            repo_root() + "/test_dirname/my_config:/file_config:ro,rprivate,rbind,z",
+        ),
+        (
+            "custom_target_name",
+            {
+                "file_config": {
+                    "file": "./my_config",
+                }
+            },
+            {
+                "source": "file_config",
+                "target": "/etc/custom_name",
+            },
+            repo_root() + "/test_dirname/my_config:/etc/custom_name:ro,rprivate,rbind",
+        ),
+        (
+            "no_custom_target_name",
+            {
+                "file_config": {
+                    "file": "./my_config",
+                }
+            },
+            {
+                "source": "file_config",
+            },
+            repo_root() + "/test_dirname/my_config:/file_config:ro,rprivate,rbind",
+        ),
+        (
+            "custom_location",
+            {
+                "file_config": {
+                    "file": "./my_config",
+                }
+            },
+            {
+                "source": "file_config",
+                "target": "/etc/custom_location",
+            },
+            repo_root() + "/test_dirname/my_config:/etc/custom_location:ro,rprivate,rbind",
+        ),
+    ])
+    async def test_file_config(
+        self,
+        test_name: str,
+        declared_configs: dict,
+        add_to_minimal_container: dict,
+        expected_volume_ref: str,
+    ) -> None:
+        c = create_compose_mock()
+        c.declared_configs = declared_configs
+        cnt = get_minimal_container()
+        cnt["configs"] = [add_to_minimal_container]
+        args = await container_to_args(c, cnt)
+        self.assertEqual(
+            args,
+            [
+                "--name=project_name_service_name1",
+                "-d",
+                "--network=bridge:alias=service_name",
+                "--volume",
+                expected_volume_ref,
+                "busybox",
+            ],
+        )
+
+    async def test_file_config_unused_params_warning(self) -> None:
+        c = create_compose_mock()
+        c.declared_configs = {
+            "file_config": {
+                "file": "./my_config",
+            }
+        }
+        cnt = get_minimal_container()
+        cnt["configs"] = [
+            {
+                "source": "file_config",
+                "target": "/unused_params_warning",
+                "uid": "103",
+                "gid": "103",
+                "mode": "400",
+            }
+        ]
+        with self.assertLogs() as cm:
+            args = await container_to_args(c, cnt)
+        self.assertEqual(len(cm.output), 1)
+        self.assertIn('with uid, gid, or mode.', cm.output[0])
+        self.assertIn('unused_params_warning', cm.output[0])
+
+        self.assertEqual(
+            args,
+            [
+                "--name=project_name_service_name1",
+                "-d",
+                "--network=bridge:alias=service_name",
+                "--volume",
+                repo_root() + "/test_dirname/my_config:/unused_params_warning:ro,rprivate,rbind",
+                "busybox",
+            ],
+        )
+
+    async def test_content_config(self) -> None:
+        c = create_compose_mock()
+        c.declared_configs = {
+            "content_config": {
+                "content": "this-is-the-config-content",
+            }
+        }
+        cnt = get_minimal_container()
+        cnt["configs"] = [
+            {
+                "source": "content_config",
+            }
+        ]
+        args = await container_to_args(c, cnt)
+
+        self.assertEqual(
+            args,
+            [
+                "--name=project_name_service_name1",
+                "-d",
+                "--network=bridge:alias=service_name",
+                "--mount",
+                "type=artifact,"
+                f"source=localhost/podman-compose/{c.project_name}_config_content_config:latest,"
+                "target=/content_config",
+                "busybox",
+            ],
+        )
+
+    @mock.patch.dict(os.environb, {b'CONFIG_VAL': b'config-from-environment'})
+    async def test_environment_config(self) -> None:
+        c = create_compose_mock()
+        c.declared_configs = {
+            "environment_config": {
+                "environment": "CONFIG_VAL",
+            }
+        }
+        cnt = get_minimal_container()
+        cnt["configs"] = [
+            {
+                "source": "environment_config",
+            }
+        ]
+        args = await container_to_args(c, cnt)
+
+        self.assertEqual(
+            args,
+            [
+                "--name=project_name_service_name1",
+                "-d",
+                "--network=bridge:alias=service_name",
+                "--mount",
+                "type=artifact,"
+                f"source=localhost/podman-compose/{c.project_name}_config_environment_config:latest,"
+                "target=/environment_config",
+                "busybox",
+            ],
+        )
+
+    async def test_artifact_idempotent_creation(self) -> None:
+        c = create_compose_mock()
+        output_mock = cast(mock.Mock, c.podman.output)
+        c.declared_configs = {
+            "content_config": {
+                "content": "this-is-the-config-content",
+            }
+        }
+        cnt = get_minimal_container()
+        cnt["configs"] = [
+            {
+                "source": "content_config",
+            }
+        ]
+        cnt2 = get_minimal_container("test-service-2")
+        cnt2["configs"] = [
+            {
+                "source": "content_config",
+            }
+        ]
+
+        INSPECT_ARTIFACT = call(
+            [],
+            "artifact",
+            ["inspect", artifact_qualified_name(c.project_name, "content_config")],
+        )
+        ADD_ARTIFACT = call([], "artifact", artifact_add_args(c.project_name, "content_config"))
+
+        await container_to_args(c, cnt)
+        output_mock.assert_has_calls([
+            # Doesn't exist yet
+            INSPECT_ARTIFACT,
+            # Created
+            ADD_ARTIFACT,
+            # Validated after creation
+            INSPECT_ARTIFACT,
+        ])
+
+        output_mock.reset_mock()
+        await container_to_args(c, cnt2)
+        # Existence checked when second service references it
+        output_mock.assert_called_once_with(*INSPECT_ARTIFACT.args)
+
+    async def test_artifact_recreate_on_change(self) -> None:
+        c = create_compose_mock()
+        output_mock = cast(mock.Mock, c.podman.output)
+        c.declared_configs = {
+            "content_config": {
+                "content": "this-is-the-config-content",
+            }
+        }
+        cnt = get_minimal_container()
+        cnt["configs"] = [
+            {
+                "source": "content_config",
+            }
+        ]
+
+        INSPECT_ARTIFACT = call(
+            [],
+            "artifact",
+            ["inspect", artifact_qualified_name(c.project_name, "content_config")],
+        )
+        ADD_ARTIFACT = call([], "artifact", artifact_add_args(c.project_name, "content_config"))
+
+        await container_to_args(c, cnt)
+        output_mock.assert_has_calls([
+            # Doesn't exist yet
+            INSPECT_ARTIFACT,
+            # Created
+            ADD_ARTIFACT,
+            # Validated after creation
+            INSPECT_ARTIFACT,
+        ])
+
+        output_mock.reset_mock()
+        await container_to_args(c, cnt)
+        # Validate that it is not re-created if the content does not change
+        output_mock.assert_called_once_with(*INSPECT_ARTIFACT.args)
+
+        # Modify the content, then call container_to_args again, as if podman compose up were run
+        # a second time
+        c.declared_configs = {
+            "content_config": {
+                "content": "this-is-CHANGED-config-content",
+            }
+        }
+
+        output_mock.reset_mock()
+        await container_to_args(c, cnt)
+        output_mock.assert_has_calls([
+            # Exists and metadata retrieved
+            INSPECT_ARTIFACT,
+            # Re-created because hash doesn't match
+            ADD_ARTIFACT,
+            # Validated after creation
+            INSPECT_ARTIFACT,
+        ])


### PR DESCRIPTION
`configs:` and `services.*.configs:` allow content specified in the compose file, in environment variables, in local files, and in OCI artifacts to be mounted in the container. They are similar to volume-mounting a single file but with more options for where the content is stored. See https://github.com/compose-spec/compose-spec/blob/main/08-configs.md and https://github.com/compose-spec/compose-spec/blob/main/05-services.md#configs for details.

Resolves #835.