### PR TITLE
fix: normalize after resolving extends

### DIFF
--- a/newsfragments/normalize_after_resolving_extends.bugfix
+++ b/newsfragments/normalize_after_resolving_extends.bugfix
@@ -1,0 +1,1 @@
+Fixed order of operations when populating defaults and using `extends` making sure the context points at the right directory

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2126,11 +2126,10 @@ def normalize_service_final(service: dict[str, Any], project_dir: str) -> dict[s
     return service
 
 
-def normalize_final(compose: dict[str, Any], project_dir: str) -> dict[str, Any]:
-    services = compose.get("services", {})
+def normalize_final(services: dict[str, Any], project_dir: str) -> dict[str, Any]:
     for service in services.values():
         normalize_service_final(service, project_dir)
-    return compose
+    return services
 
 
 def clone(value: Any) -> Any:
@@ -2752,8 +2751,6 @@ class PodmanCompose:
             compose.get("services") or {}, target, requested_profiles
         )
         compose["services"] = resolved_services
-        if not getattr(args, "no_normalize", None):
-            compose = normalize_final(compose, self.dirname)
         self.merged_yaml = yaml.safe_dump(compose)
         merged_json_b = json.dumps(
             self.original_configuration(compose), separators=(",", ":")
@@ -2780,6 +2777,9 @@ class PodmanCompose:
         service_names = sorted([(len(srv["_deps"]), name) for name, srv in services.items()])
         resolve_extends(services, [name for _, name in service_names], self.environ)
         flat_deps(services)
+
+        if not getattr(args, "no_normalize", None):
+            services = normalize_final(services, self.dirname)
 
         # networks: [...]
         nets = compose.get("networks") or {}

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2211,11 +2211,10 @@ def normalize_service_final(service: dict[str, Any], project_dir: str) -> dict[s
     return service
 
 
-def normalize_final(compose: dict[str, Any], project_dir: str) -> dict[str, Any]:
-    services = compose.get("services", {})
+def normalize_final(services: dict[str, Any], project_dir: str) -> dict[str, Any]:
     for service in services.values():
         normalize_service_final(service, project_dir)
-    return compose
+    return services
 
 
 def clone(value: Any) -> Any:
@@ -2889,8 +2888,6 @@ class PodmanCompose:
             compose.get("services") or {}, target, requested_profiles
         )
         compose["services"] = resolved_services
-        if not getattr(args, "no_normalize", None):
-            compose = normalize_final(compose, self.dirname)
         compose.pop("version", None)
         self.merged_yaml = yaml.safe_dump(compose)
         merged_json_b = json.dumps(
@@ -2918,6 +2915,9 @@ class PodmanCompose:
         service_names = sorted([(len(srv["_deps"]), name) for name, srv in services.items()])
         resolve_extends(services, [name for _, name in service_names], self.environ)
         flat_deps(services)
+
+        if not getattr(args, "no_normalize", None):
+            services = normalize_final(services, self.dirname)
 
         # networks: [...]
         nets = compose.get("networks") or {}

--- a/tests/integration/extends_w_file_subdir/docker-compose.yml
+++ b/tests/integration/extends_w_file_subdir/docker-compose.yml
@@ -6,3 +6,6 @@ services:
       service: webapp
     environment:
       - DEBUG=1
+    build:
+      args:
+        VERSION: 3.24

--- a/tests/integration/extends_w_file_subdir/sub/docker-compose.yml
+++ b/tests/integration/extends_w_file_subdir/sub/docker-compose.yml
@@ -4,9 +4,10 @@ services:
     build:
       context: docker/example
       dockerfile: Dockerfile
+      args:
+        VERSION: 3.24
     image: localhost/subdir_test:me
     ports:
       - "8000:8000"
     volumes:
       - "/data"
-

--- a/tests/integration/extends_w_file_subdir/sub/docker/example/Dockerfile
+++ b/tests/integration/extends_w_file_subdir/sub/docker/example/Dockerfile
@@ -1,1 +1,2 @@
-FROM nopush/podman-compose-test as base
+ARG VERSION=latest
+FROM alpine:${VERSION} as base

--- a/tests/unit/test_normalize_final_build.py
+++ b/tests/unit/test_normalize_final_build.py
@@ -107,9 +107,9 @@ class TestNormalizeFinalBuild(unittest.TestCase):
     @parameterized.expand(cases_simple_normalization)
     def test_normalize_returns_absolute_path_in_context(self, input, expected):
         project_dir = cwd
-        compose_test = {"services": {"test-service": input}}
-        compose_expected = {"services": {"test-service": expected}}
-        self.assertEqual(normalize_final(compose_test, project_dir), compose_expected)
+        services_test = {"test-service": input}
+        services_expected = {"test-service": expected}
+        self.assertEqual(normalize_final(services_test, project_dir), services_expected)
 
     @parameterized.expand(cases_simple_normalization)
     def test_parse_compose_file_when_single_compose(self, input, expected):


### PR DESCRIPTION
This fixes an issue with the order of resolving compose file extensions. Normalization expands relative paths and fills in defaults which should be taken from the base file as well