### PR TITLE
fix: coerce depends_on list to dict in rec_merge_one when types differ

### DIFF
--- a/newsfragments/fix_depends_on_merge.bugfix
+++ b/newsfragments/fix_depends_on_merge.bugfix
@@ -1,0 +1,1 @@
+Fixed ``ValueError: can't merge value of depends_on`` when using ``extends`` with mixed list and dict ``depends_on`` forms.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2187,6 +2187,14 @@ def rec_merge_one(target: dict[str, Any], source: dict[str, Any]) -> dict[str, A
         if value is None and isinstance(value2, dict):
             target[key] = value = {}
 
+        # normalizing inputs to dicts
+        if key == "depends_on":
+            if is_list(value) and isinstance(value2, dict):
+                value = {x: {} for x in value}
+                target[key] = value
+            elif isinstance(value, dict) and is_list(value2):
+                value2 = {x: {} for x in value2}
+
         if not isinstance(value2, type(value)):
             value_type = type(value)
             value2_type = type(value2)

--- a/tests/unit/test_rec_merge_depends_on.py
+++ b/tests/unit/test_rec_merge_depends_on.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: GPL-2.0
+from __future__ import annotations
+
+import unittest
+from typing import Any
+
+from parameterized import parameterized
+
+from podman_compose import rec_merge
+
+
+class TestRecMergeDependsOn(unittest.TestCase):
+    """Test rec_merge with mixed list/dict depends_on."""
+
+    @parameterized.expand([
+        (
+            "dict_target_list_source",
+            {"depends_on": {"db": {"condition": "service_healthy"}}},
+            {"depends_on": ["redis"]},
+            {
+                "depends_on": {
+                    "db": {"condition": "service_healthy"},
+                    "redis": {},
+                },
+            },
+        ),
+        (
+            "list_target_dict_source",
+            {"depends_on": ["db", "redis"]},
+            {"depends_on": {"cache": {"condition": "service_started"}}},
+            {
+                "depends_on": {
+                    "db": {},
+                    "redis": {},
+                    "cache": {"condition": "service_started"},
+                },
+            },
+        ),
+        (
+            "dict_target_list_source_overlapping_keys",
+            {"depends_on": {"db": {"condition": "service_healthy"}}},
+            {"depends_on": ["db", "redis"]},
+            {
+                "depends_on": {
+                    "db": {"condition": "service_healthy"},
+                    "redis": {},
+                },
+            },
+        ),
+        (
+            "list_target_dict_source_overlapping_keys",
+            {"depends_on": ["db", "redis"]},
+            {"depends_on": {"db": {"condition": "service_healthy"}}},
+            {
+                "depends_on": {
+                    "db": {"condition": "service_healthy"},
+                    "redis": {},
+                },
+            },
+        ),
+    ])
+    def test_rec_merge_depends_on(
+        self,
+        name: str,
+        target: dict[str, Any],
+        source: dict[str, Any],
+        expected: dict[str, Any],
+    ) -> None:
+        result = rec_merge(target, source)
+        self.assertEqual(result, expected)
+
+    def test_three_way_mixed_depends_on(self) -> None:
+        from_service: dict[str, Any] = {
+            "image": "myimage:latest",
+            "depends_on": {"db": {"condition": "service_healthy"}},
+        }
+        service: dict[str, Any] = {
+            "depends_on": ["db", "redis"],
+            "environment": {"FOO": "bar"},
+        }
+        result = rec_merge({}, from_service, service)
+        self.assertEqual(
+            result,
+            {
+                "image": "myimage:latest",
+                "depends_on": {
+                    "db": {"condition": "service_healthy"},
+                    "redis": {},
+                },
+                "environment": {"FOO": "bar"},
+            },
+        )


### PR DESCRIPTION
## Summary

Normalize `depends_on` list to dict in `rec_merge_one` before the type check, so mixed forms merge correctly.

Fixes #859