### PR TITLE
Fix `service_completed_successfully` to require exit code 0

### DIFF
--- a/newsfragments/service_completed_succesfully-exit-code-0.bugfix
+++ b/newsfragments/service_completed_succesfully-exit-code-0.bugfix
@@ -1,0 +1,1 @@
+Fix `service_completed_successfully` to require exit code 0.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1588,6 +1588,7 @@ class ServiceDependencyCondition(Enum):
     STOPPED = "stopped"
     STOPPING = "stopping"
     UNHEALTHY = "unhealthy"
+    SERVICE_COMPLETED_SUCCESSFULLY = "service_completed_successfully"
 
     @classmethod
     def from_value(cls, value: str) -> ServiceDependencyCondition:
@@ -1600,7 +1601,9 @@ class ServiceDependencyCondition(Enum):
         docker_to_podman_cond = {
             "service_healthy": ServiceDependencyCondition.HEALTHY,
             "service_started": ServiceDependencyCondition.RUNNING,
-            "service_completed_successfully": ServiceDependencyCondition.STOPPED,
+            "service_completed_successfully": (
+                ServiceDependencyCondition.SERVICE_COMPLETED_SUCCESSFULLY
+            ),
         }
         try:
             return docker_to_podman_cond[value]
@@ -3664,6 +3667,57 @@ def get_excluded(
     return excluded
 
 
+async def _validate_completed_successfully(
+    compose: PodmanCompose, container_names: list[str]
+) -> None:
+    # Poll until all containers have left the 'created' state
+    # This prevents podman wait from racing against container startup
+    last_log_time = 0.0
+    while True:
+        try:
+            statuses_raw = await compose.podman.output(
+                [], "inspect", ["--format={{.State.Status}}"] + container_names
+            )
+            statuses = statuses_raw.decode().split()
+            if all(s != "created" for s in statuses if s):
+                break
+        except subprocess.CalledProcessError as exc:
+            log.debug(
+                "podman inspect failed while polling for created states: %s",
+                exc,
+            )
+
+        now = asyncio.get_event_loop().time()
+        if now - last_log_time >= 1.0:
+            log.debug(
+                "Waiting for dependency containers to leave 'created' state: %s",
+                ', '.join(container_names),
+            )
+            last_log_time = now
+        await asyncio.sleep(0.05)
+
+    # podman does not actually support value "service_completed_successfully"
+    # default value "stopped" is sent instead
+    await compose.podman.output([], "wait", ["--condition=stopped"] + container_names)
+
+    for container_name in container_names:
+        try:
+            inspect_output = await compose.podman.output([], "inspect", [container_name])
+        except subprocess.CalledProcessError as exc:
+            raise RuntimeError(
+                f"Container {container_name} disappeared after waiting for stop"
+            ) from exc
+        container_info = json.loads(inspect_output)[0]
+
+        exit_code = container_info.get("State", {}).get("ExitCode", -1)
+        if exit_code != 0:
+            error_msg = (
+                f"Container {container_name} didn't complete successfully: exit code {exit_code}"
+            )
+            log.error(error_msg)
+            raise RuntimeError(error_msg)
+
+
 async def check_dep_conditions(compose: PodmanCompose, deps: set) -> None:
     """Enforce that all specified conditions in deps are met"""
     if not deps:
@@ -3694,9 +3748,12 @@ async def check_dep_conditions(compose: PodmanCompose, deps: set) -> None:
             # podman wait will return always with a rc -1.
             while True:
                 try:
-                    await compose.podman.output(
-                        [], "wait", [f"--condition={condition.value}"] + deps_cd
-                    )
+                    if condition == ServiceDependencyCondition.SERVICE_COMPLETED_SUCCESSFULLY:
+                        await _validate_completed_successfully(compose, deps_cd)
+                    else:
+                        await compose.podman.output(
+                            [], "wait", [f"--condition={condition.value}"] + deps_cd
+                        )
                     log.debug(
                         "dependencies for condition %s have been fulfilled on containers %s",
                         condition.value,

--- a/tests/integration/deps/docker-compose-conditional-completed-failed.yaml
+++ b/tests/integration/deps/docker-compose-conditional-completed-failed.yaml
@@ -1,0 +1,11 @@
+version: "3.7"
+services:
+  failing_oneshot:
+    image: nopush/podman-compose-test
+    command: ["sh", "-c", "echo 'Task failed!' && exit 1"]
+  should_not_start:
+    image: nopush/podman-compose-test
+    command: ["sh", "-c", "echo 'This should not run' && sleep 3600"]
+    depends_on:
+      failing_oneshot:
+        condition: service_completed_successfully

--- a/tests/integration/deps/docker-compose-conditional-completed.yaml
+++ b/tests/integration/deps/docker-compose-conditional-completed.yaml
@@ -1,0 +1,11 @@
+version: "3.7"
+services:
+  oneshot:
+    image: nopush/podman-compose-test
+    command: ["sh", "-c", "echo 'Task completed successfully' && exit 0"]
+  longrunning:
+    image: nopush/podman-compose-test
+    command: ["sh", "-c", "echo 'Starting after oneshot completes' && sleep 3600"]
+    depends_on:
+      oneshot:
+        condition: service_completed_successfully

--- a/tests/integration/deps/docker-compose-conditional-stopped.yaml
+++ b/tests/integration/deps/docker-compose-conditional-stopped.yaml
@@ -1,0 +1,21 @@
+version: "3.7"
+services:
+  failing_oneshot:
+    image: nopush/podman-compose-test
+    command: ["sh", "-c", "echo 'Task failed!' && exit 1"]
+  should_start_when_fail:
+    image: nopush/podman-compose-test
+    command: ["sh", "-c", "echo 'Starting after oneshot completes' && sleep 3600"]
+    depends_on:
+      failing_oneshot:
+        condition: stopped
+
+  success_oneshot:
+    image: nopush/podman-compose-test
+    command: ["sh", "-c", "echo 'Task completed successfully' && exit 0"]
+  should_start_when_success:
+    image: nopush/podman-compose-test
+    command: ["sh", "-c", "echo 'Starting after oneshot completes' && sleep 3600"]
+    depends_on:
+      success_oneshot:
+        condition: stopped

--- a/tests/integration/deps/test_podman_compose_deps.py
+++ b/tests/integration/deps/test_podman_compose_deps.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0
+import json
 import os
 import unittest
 
@@ -190,6 +191,139 @@ class TestComposeConditionalDeps(unittest.TestCase, RunSubprocessMixin):
                 "-f",
                 compose_yaml_path(suffix),
                 "down",
+            ])
+
+    def test_deps_completed_successfully(self) -> None:
+        suffix = "-conditional-completed"
+        try:
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path(suffix),
+                "up",
+                "-d",
+            ])
+            output, _ = self.run_subprocess_assert_returncode([
+                "podman",
+                "ps",
+                "-a",
+                "--filter",
+                "name=deps_",
+                "--format",
+                "json",
+            ])
+            # build a dict by name for easy lookup
+            by_name = {c["Names"][0]: c for c in json.loads(output)}
+
+            # assert on stable fields, otherwise test is flaky due to relative timestamps
+            # of CREATED and STATUS
+            self.assertIn("deps_oneshot_1", by_name)
+            self.assertEqual(by_name["deps_oneshot_1"]["State"], "exited")
+            self.assertEqual(by_name["deps_oneshot_1"]["ExitCode"], 0)
+
+            self.assertIn("deps_longrunning_1", by_name)
+            self.assertEqual(by_name["deps_longrunning_1"]["State"], "running")
+        finally:
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path(suffix),
+                "down",
+                "-t",
+                "0",
+            ])
+
+    def test_deps_completed_failed(self) -> None:
+        suffix = "-conditional-completed-failed"
+        try:
+            output, stderr = self.run_subprocess_assert_returncode(
+                [
+                    podman_compose_path(),
+                    "-f",
+                    compose_yaml_path(suffix),
+                    "up",
+                    "-d",
+                ],
+                1,
+            )
+            self.assertIn(b"didn't complete successfully: exit code 1", stderr)
+
+            output, _ = self.run_subprocess_assert_returncode([
+                "podman",
+                "ps",
+                "-a",
+                "--filter",
+                "name=deps_",
+                "--format",
+                "json",
+            ])
+            # build a dict by name for easy lookup
+            by_name = {c["Names"][0]: c for c in json.loads(output)}
+
+            # assert on stable fields, otherwise test is flaky due to relative timestamps
+            # of CREATED and STATUS
+            self.assertIn("deps_failing_oneshot_1", by_name)
+            self.assertEqual(by_name["deps_failing_oneshot_1"]["State"], "exited")
+            self.assertEqual(by_name["deps_failing_oneshot_1"]["ExitCode"], 1)
+
+            self.assertIn("deps_should_not_start_1", by_name)
+            self.assertEqual(by_name["deps_should_not_start_1"]["State"], "created")
+        finally:
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path(suffix),
+                "down",
+                "-t",
+                "0",
+            ])
+
+    def test_deps_stopped(self) -> None:
+        suffix = "-conditional-stopped"
+        try:
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path(suffix),
+                "up",
+                "-d",
+            ])
+            output, _ = self.run_subprocess_assert_returncode([
+                "podman",
+                "ps",
+                "-a",
+                "--filter",
+                "name=deps_",
+                "--format",
+                "json",
+            ])
+            # build a dict by name for easy lookup
+            by_name = {c["Names"][0]: c for c in json.loads(output)}
+
+            # assert on stable fields, otherwise test is flaky due to relative timestamps
+            # of CREATED and STATUS
+            self.assertIn("deps_failing_oneshot_1", by_name)
+            self.assertEqual(by_name["deps_failing_oneshot_1"]["State"], "exited")
+            self.assertEqual(by_name["deps_failing_oneshot_1"]["ExitCode"], 1)
+
+            # stopped condition should start dependents regardless of exit code
+            self.assertIn("deps_should_start_when_fail_1", by_name)
+            self.assertEqual(by_name["deps_should_start_when_fail_1"]["State"], "running")
+
+            self.assertIn("deps_success_oneshot_1", by_name)
+            self.assertEqual(by_name["deps_success_oneshot_1"]["State"], "exited")
+            self.assertEqual(by_name["deps_success_oneshot_1"]["ExitCode"], 0)
+
+            self.assertIn("deps_should_start_when_success_1", by_name)
+            self.assertEqual(by_name["deps_should_start_when_success_1"]["State"], "running")
+        finally:
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path(suffix),
+                "down",
+                "-t",
+                "0",
             ])
 
 

--- a/tests/unit/test_service_dependency_condition.py
+++ b/tests/unit/test_service_dependency_condition.py
@@ -1,0 +1,35 @@
+import unittest
+
+from podman_compose import ServiceDependencyCondition
+
+
+class TestServiceDependencyCondition(unittest.TestCase):
+    def test_service_completed_successfully_maps_to_service_completed_successfully(self) -> None:
+        condition = ServiceDependencyCondition.from_value("service_completed_successfully")
+        self.assertEqual(condition, ServiceDependencyCondition.SERVICE_COMPLETED_SUCCESSFULLY)
+
+    def test_service_healthy_maps_correctly(self) -> None:
+        condition = ServiceDependencyCondition.from_value("service_healthy")
+        self.assertEqual(condition, ServiceDependencyCondition.HEALTHY)
+
+    def test_service_started_maps_to_running(self) -> None:
+        condition = ServiceDependencyCondition.from_value("service_started")
+        self.assertEqual(condition, ServiceDependencyCondition.RUNNING)
+
+    def test_direct_condition_values(self) -> None:
+        self.assertEqual(
+            ServiceDependencyCondition.from_value("stopped"),
+            ServiceDependencyCondition.STOPPED,
+        )
+        self.assertEqual(
+            ServiceDependencyCondition.from_value("healthy"),
+            ServiceDependencyCondition.HEALTHY,
+        )
+        self.assertEqual(
+            ServiceDependencyCondition.from_value("running"),
+            ServiceDependencyCondition.RUNNING,
+        )
+
+    def test_invalid_condition_raises_error(self) -> None:
+        with self.assertRaises(ValueError):
+            ServiceDependencyCondition.from_value("invalid_condition")


### PR DESCRIPTION
Fix `service_completed_successfully` to verify the dependency exits with code 0, per the Docker Compose spec. Previously, it only checked that the container had stopped, ignoring non-zero exit codes and allowing dependent services to start even if the dependency failed.

Docker Compose implementation reference:
https://github.com/docker/compose/blob/v2.29.7/pkg/compose/convergence.go#L433

This PR builds on https://github.com/containers/podman-compose/pull/1337 thanks to [mrIncompetent](https://github.com/mrIncompetent).


Fixes https://github.com/containers/podman-compose/issues/1330, https://github.com/containers/podman-compose/issues/575.