### PR TITLE
detect image changes and recreate affected containers

### DIFF
--- a/newsfragments/recreate_on_image_change.bugfix
+++ b/newsfragments/recreate_on_image_change.bugfix
@@ -1,0 +1,5 @@
+Detect image changes and recreate affected containers on ``up``.
+Previously, ``podman-compose up`` only compared the YAML config hash to
+decide whether a container needed recreation, missing the case where an
+image was updated (e.g. after ``pull``) while the compose file stayed the
+same.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1795,6 +1795,7 @@ class ExistingContainer:
     id: str
     service_name: str
     config_hash: str
+    image_id: str
     exited: bool
     state: str
     status: str
@@ -2024,6 +2025,7 @@ class Podman:
                     or c.get("Labels", {}).get("com.docker.compose.service", "")
                 ),
                 config_hash=c.get("Labels", {}).get("io.podman.compose.config-hash", ""),
+                image_id=c.get("ImageID", ""),
                 exited=c.get("Exited", False),
                 state=c.get("State", ""),
                 status=c.get("Status", ""),
@@ -4066,6 +4068,27 @@ async def compose_up(compose: PodmanCompose, args: argparse.Namespace) -> int | 
         if not args.no_recreate:
             requested_services = set(args.services) if args.services else set()
             always_recreate_deps = getattr(args, "always_recreate_deps", False)
+
+            # resolve current local image IDs for services with running containers
+            current_image_ids: dict[str, str] = {}
+            for c in existing_containers.values():
+                if (
+                    c.service_name in excluded
+                    or c.service_name not in compose.services
+                    or not c.image_id
+                ):
+                    continue
+                service = compose.services[c.service_name]
+                image = service.get("image")
+                if image and image not in current_image_ids:
+                    try:
+                        img_id = await compose.podman.output(
+                            [], "inspect", ["-t", "image", "-f", "{{.Id}}", image]
+                        )
+                        current_image_ids[image] = img_id.decode().strip()
+                    except subprocess.CalledProcessError:
+                        pass
+
             for c in existing_containers.values():
                 if (
                     c.service_name in excluded
@@ -4079,7 +4102,20 @@ async def compose_up(compose: PodmanCompose, args: argparse.Namespace) -> int | 
                     or c.service_name in requested_services
                     or always_recreate_deps
                 )
-                if force_this or c.config_hash != compose.config_hash(service):
+
+                image_changed = False
+                image = service.get("image")
+                if image and c.image_id:
+                    local_id = current_image_ids.get(image, "")
+                    if local_id and local_id != c.image_id:
+                        log.info(
+                            "Image changed for service %s (%s), will recreate",
+                            c.service_name,
+                            image,
+                        )
+                        image_changed = True
+
+                if force_this or image_changed or c.config_hash != compose.config_hash(service):
                     recreate_services.add(c.service_name)
 
                     # Running dependents of service are removed by down command

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -3,9 +3,14 @@ import subprocess
 
 
 def create_base_test_image() -> None:
+    base_image_dir = os.path.join(os.path.dirname(__file__), "base_image")
     subprocess.check_call(
         ['podman', 'build', '-t', 'nopush/podman-compose-test', '.'],
-        cwd=os.path.join(os.path.dirname(__file__), "base_image"),
+        cwd=base_image_dir,
+    )
+    subprocess.check_call(
+        ['podman', 'build', '-t', 'nopush/podman-compose-test2', '-f', 'Dockerfile.test2', '.'],
+        cwd=base_image_dir,
     )
 
 

--- a/tests/integration/base_image/Dockerfile.test2
+++ b/tests/integration/base_image/Dockerfile.test2
@@ -1,0 +1,2 @@
+FROM nopush/podman-compose-test
+RUN touch /nopush-podman-compose-test2

--- a/tests/integration/compose_up_behavior/docker-compose_build_image_change.yaml
+++ b/tests/integration/compose_up_behavior/docker-compose_build_image_change.yaml
@@ -1,0 +1,12 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile.image_change
+    image: nopush/podman-compose-test:build-image-change
+    command: ["sleep", "infinity"]
+    depends_on:
+      - db
+  db:
+    image: nopush/podman-compose-test
+    command: ["dumb-init", "/bin/busybox", "httpd", "-f", "-p", "8080"]

--- a/tests/integration/compose_up_behavior/docker-compose_image_change.yaml
+++ b/tests/integration/compose_up_behavior/docker-compose_image_change.yaml
@@ -1,0 +1,9 @@
+services:
+  app:
+    image: nopush/podman-compose-test:image-change-app
+    command: ["sh", "-c", "sleep 3600"]
+    depends_on:
+      - db
+  db:
+    image: nopush/podman-compose-test
+    command: ["dumb-init", "/bin/busybox", "httpd", "-f", "-p", "8080"]

--- a/tests/integration/compose_up_behavior/test_compose_up_behavior.py
+++ b/tests/integration/compose_up_behavior/test_compose_up_behavior.py
@@ -488,3 +488,162 @@ class TestComposeUpBehavior(unittest.TestCase, RunSubprocessMixin):
             self.run_subprocess_assert_returncode(
                 ["podman", "rmi", "-f", image],
             )
+
+    def test_recreate_on_image_changed(self) -> None:
+        """Verify that containers are recreated when their image changes.
+
+        Simulates pulling a new version of an image by re-tagging a different
+        base image under the same tag. Only the service whose image changed
+        should be recreated; the unchanged service should keep its container.
+        """
+        compose_file = compose_yaml_path("image_change")
+        tag = "nopush/podman-compose-test:image-change-app"
+
+        try:
+            # create the tagged image from the existing base image
+            self.run_subprocess_assert_returncode([
+                "podman",
+                "tag",
+                "nopush/podman-compose-test",
+                tag,
+            ])
+
+            # start containers
+            self.run_subprocess_assert_returncode(
+                [podman_compose_path(), "-f", compose_file, "up", "-d"],
+            )
+
+            original_containers = self.get_existing_containers("image_change")
+
+            # simulate a new image version: re-tag a different image under the same tag
+            self.run_subprocess_assert_returncode([
+                "podman",
+                "tag",
+                "nopush/podman-compose-test2",
+                tag,
+            ])
+
+            # verify the app container exists
+            self.assertIn(
+                "compose_up_behavior_app_1",
+                original_containers,
+                "app container should exist after initial up",
+            )
+
+            # run up again — should detect the changed image and recreate app
+            self.run_subprocess_assert_returncode(
+                [podman_compose_path(), "-f", compose_file, "up", "-d"],
+            )
+
+            new_containers = self.get_existing_containers("image_change")
+
+            # app should be recreated (different container ID)
+            self.assertNotEqual(
+                original_containers["compose_up_behavior_app_1"]["id"],
+                new_containers["compose_up_behavior_app_1"]["id"],
+                "app container should be recreated when its image changes",
+            )
+
+            # db should NOT be recreated (same container ID)
+            self.assertEqual(
+                original_containers["compose_up_behavior_db_1"]["id"],
+                new_containers["compose_up_behavior_db_1"]["id"],
+                "db container should not be recreated when its image did not change",
+            )
+
+            # all containers should be running
+            self.assertTrue(
+                all(c["exited"] is False for c in new_containers.values()),
+                "Not all containers are running after up command",
+            )
+
+        finally:
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_file,
+                "down",
+                "-t",
+                "0",
+            ])
+            self.run_subprocess_assert_returncode(
+                ["podman", "rmi", "-f", tag],
+            )
+
+    def test_recreate_on_build_image_changed(self) -> None:
+        """Verify that containers are recreated when a locally built image changes.
+
+        Builds an image from a Dockerfile, starts containers, modifies the
+        Dockerfile to produce a different image, rebuilds with --build, and
+        verifies that the service whose image changed is recreated while the
+        unchanged service keeps its container.
+        """
+        compose_file = compose_yaml_path("build_image_change")
+        tag = "nopush/podman-compose-test:build-image-change"
+        dockerfile = os.path.join(
+            os.path.join(test_path(), "compose_up_behavior"),
+            "Dockerfile.image_change",
+        )
+
+        try:
+            # create the Dockerfile for the initial build
+            with open(dockerfile, "w") as f:
+                f.write("FROM nopush/podman-compose-test\n")
+
+            # build and start containers
+            self.run_subprocess_assert_returncode(
+                [podman_compose_path(), "-f", compose_file, "up", "-d", "--build"],
+            )
+
+            original_containers = self.get_existing_containers("build_image_change")
+
+            self.assertIn(
+                "compose_up_behavior_app_1",
+                original_containers,
+                "app container should exist after initial up",
+            )
+
+            # modify the Dockerfile to produce a different image
+            with open(dockerfile, "w") as f:
+                f.write("FROM nopush/podman-compose-test\nRUN touch /marker\n")
+
+            # rebuild and restart — should detect the changed image and recreate app
+            self.run_subprocess_assert_returncode(
+                [podman_compose_path(), "-f", compose_file, "up", "-d", "--build"],
+            )
+
+            new_containers = self.get_existing_containers("build_image_change")
+
+            # app should be recreated (different container ID)
+            self.assertNotEqual(
+                original_containers["compose_up_behavior_app_1"]["id"],
+                new_containers["compose_up_behavior_app_1"]["id"],
+                "app container should be recreated when its built image changes",
+            )
+
+            # db should NOT be recreated (same container ID)
+            self.assertEqual(
+                original_containers["compose_up_behavior_db_1"]["id"],
+                new_containers["compose_up_behavior_db_1"]["id"],
+                "db container should not be recreated when its image did not change",
+            )
+
+            # all containers should be running
+            self.assertTrue(
+                all(c["exited"] is False for c in new_containers.values()),
+                "Not all containers are running after up command",
+            )
+
+        finally:
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_file,
+                "down",
+                "-t",
+                "0",
+            ])
+            self.run_subprocess_assert_returncode(
+                ["podman", "rmi", "-f", tag],
+            )
+            os.remove(dockerfile)


### PR DESCRIPTION
podman-compose up currently only compares the YAML config hash to decide whether a container needs to be recreated.  This misses the case where an image has been updated (e.g. after a pull) while the compose file itself stays the same — the container keeps running the old image.

Add an image_id field to ExistingContainer, populated from the ImageID returned by podman ps.  Before the recreation loop, resolve the current local image ID for each service via podman inspect and compare it against the running container's image ID.  When they differ, mark the service for recreation.

Fixes: #1453, #466
