### PR TITLE
pass stop_grace_period as --stop-timeout to podman create

### DIFF
--- a/newsfragments/stop_grace_period.bugfix
+++ b/newsfragments/stop_grace_period.bugfix
@@ -1,0 +1,1 @@
+Pass ``stop_grace_period`` as ``--stop-timeout`` to ``podman create`` so containers respect the configured grace period instead of using podman's 10-second default.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1430,6 +1430,11 @@ async def container_to_args(
         podman_args.append("-i")
     if cnt.get("stop_signal"):
         podman_args.extend(["--stop-signal", cnt["stop_signal"]])
+    stop_grace = cnt.get("stop_grace_period")
+    if stop_grace:
+        timeout = str_to_seconds(stop_grace)
+        if timeout is not None:
+            podman_args.extend(["--stop-timeout", str(timeout)])
 
     sysctls = cnt.get("sysctls")
     if sysctls is not None:

--- a/tests/unit/test_container_to_args.py
+++ b/tests/unit/test_container_to_args.py
@@ -1279,3 +1279,41 @@ class TestContainerToArgs(unittest.IsolatedAsyncioTestCase):
             ValueError, r"invalid ipc mode \[service:invalid\], service \[invalid\] does not exist"
         ):
             await container_to_args(c, cnt)
+
+    async def test_stop_grace_period(self) -> None:
+        c = create_compose_mock()
+
+        cnt = get_minimal_container()
+        cnt["stop_grace_period"] = "30s"
+
+        args = await container_to_args(c, cnt)
+        self.assertEqual(
+            args,
+            [
+                "--name=project_name_service_name1",
+                "-d",
+                "--network=bridge:alias=service_name",
+                "--stop-timeout",
+                "30",
+                "busybox",
+            ],
+        )
+
+    async def test_stop_grace_period_minutes(self) -> None:
+        c = create_compose_mock()
+
+        cnt = get_minimal_container()
+        cnt["stop_grace_period"] = "1m30s"
+
+        args = await container_to_args(c, cnt)
+        self.assertEqual(
+            args,
+            [
+                "--name=project_name_service_name1",
+                "-d",
+                "--network=bridge:alias=service_name",
+                "--stop-timeout",
+                "90",
+                "busybox",
+            ],
+        )


### PR DESCRIPTION
podman-compose passes stop_signal to podman create via --stop-signal but never passes stop_grace_period as --stop-timeout.  This means containers are created with podman's default stop timeout of 10 seconds regardless of the compose file setting.

When podman stops a container (e.g. during recreation on up), it uses the container's embedded stop timeout, causing a premature SIGKILL after 10 seconds even when stop_grace_period is set to a higher value.

Parse stop_grace_period with str_to_seconds and pass it as --stop-timeout to podman create, matching how stop_signal is already handled.
