### PR TITLE
add secret environment loading

### DIFF
--- a/newsfragments/environment_secrets.feature
+++ b/newsfragments/environment_secrets.feature
@@ -1,0 +1,1 @@
+Added support for loading secrets from the environment

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -794,6 +794,42 @@ async def get_mount_args(
     return ["--mount", args]
 
 
+async def create_secrets_from_environment(compose: PodmanCompose) -> None:
+    if not compose.declared_secrets:
+        return
+    for secret_name in compose.declared_secrets.keys():
+        secret_environment = compose.declared_secrets[secret_name].get("environment")
+        if secret_environment:
+            secret_environment_value = os.getenv(secret_environment)
+
+            if secret_environment_value is None:
+                raise ValueError(
+                    f"Environment variable '{secret_environment}' required"
+                    + " by secret '{secret_name}' is not set in the process environment."
+                )
+
+            log.debug(
+                "attempting creation of secret '%s' set to '%s'",
+                secret_name,
+                secret_environment_value,
+            )
+
+            assert compose.project_name is not None
+
+            await compose.podman.run(
+                [],
+                "secret",
+                [
+                    "create",
+                    "--label",
+                    "io.podman.compose.project=" + compose.project_name,
+                    "--env",
+                    f"{compose.project_name}_{secret_name}",
+                    secret_environment,
+                ],
+            )
+
+
 def get_secret_args(
     compose: PodmanCompose,
     cnt: dict[str, Any],
@@ -833,13 +869,10 @@ def get_secret_args(
         if podman_is_building:
             secret_id = secret_target if secret_target else secret_name
             return ["--secret", f"id={secret_id},env={source_env}"]
-        # TODO: Runtime support for environment secrets requires injecting the
-        # value into the container (e.g. via podman cp or podman secret create),
-        # which is beyond the scope of this arg-generating function.
-        raise ValueError(
-            f'ERROR: Secret "{secret_name}" uses environment source, '
-            "which is not supported for runtime secrets in podman-compose."
-        )
+
+        assert compose.project_name is not None
+        log.debug("mounting secret '%s'", secret_name)
+        return ["--secret", f"{compose.project_name}_{secret_name}"]
 
     if source_file:
         # assemble path for source file first, because we need it for all cases
@@ -3959,6 +3992,8 @@ async def compose_up(compose: PodmanCompose, args: argparse.Namespace) -> int | 
     existing_containers = await compose.podman.existing_containers(compose.project_name)
     recreate_services: set[str] = set()
     running_services = {c.service_name for c in existing_containers.values() if not c.exited}
+
+    await create_secrets_from_environment(compose)
 
     if existing_containers:
         if args.force_recreate and args.no_recreate:

--- a/tests/integration/secrets/docker-compose.yaml
+++ b/tests/integration/secrets/docker-compose.yaml
@@ -33,6 +33,7 @@ services:
         - source: podman_compose_test_secret
           target: ENV_SECRET
           type: env
+        - environment_secret
 
 secrets:
   podman_compose_test_secret:
@@ -46,3 +47,5 @@ secrets:
     name: podman_compose_test_secret_3
   file_secret:
     file: ./my_secret
+  environment_secret:
+    environment: "TEST_ENVIRONMENT"

--- a/tests/integration/secrets/test_podman_compose_secrets.py
+++ b/tests/integration/secrets/test_podman_compose_secrets.py
@@ -47,6 +47,7 @@ class TestComposeNoSecrets(unittest.TestCase, RunSubprocessMixin):
                     "up",
                     "test",
                 ],
+                env={"TEST_ENVIRONMENT": "important-secret-is-important"},
             )
 
             self.assertNotIn(
@@ -66,6 +67,7 @@ class TestComposeNoSecrets(unittest.TestCase, RunSubprocessMixin):
                 + b'/run/secrets/file_secret:important-secret-is-important\n'
                 + b'/run/secrets/podman_compose_test_secret:podman_compose_test_secret\n'
                 + b'/run/secrets/podman_compose_test_secret_3:podman_compose_test_secret_3\n'
+                + b'/run/secrets/secrets_environment_secret:important-secret-is-important\n'
                 + b'/run/secrets/unused_params_warning:important-secret-is-important\n'
                 + b'important-secret-is-important\n'
                 + b'podman_compose_test_secret\n'

--- a/tests/unit/test_container_to_args_secrets.py
+++ b/tests/unit/test_container_to_args_secrets.py
@@ -422,9 +422,19 @@ class TestContainerToArgsSecrets(unittest.IsolatedAsyncioTestCase):
         cnt = get_minimal_container()
         cnt['_service'] = 'test-service'
         cnt['secrets'] = ['my_secret']
-        with self.assertRaises(ValueError) as context:
-            await container_to_args(c, cnt)
-        self.assertIn('not supported for runtime secrets', str(context.exception))
+
+        args = await container_to_args(c, cnt)
+        self.assertEqual(
+            args,
+            [
+                '--name=project_name_service_name1',
+                '-d',
+                '--network=bridge:alias=service_name',
+                '--secret',
+                'test_project_name_my_secret',
+                'busybox',
+            ],
+        )
 
     async def test_external_secret_with_target_path_uid_gid_mode(self) -> None:
         """Reproduce the reported bug: external secret with custom target path, uid, gid, mode."""


### PR DESCRIPTION
# Actions

I implemented the loading of secrets from environment variables as defined in the specification.

Every time `podman-compoese up` is executed, it creates the secret environment variable that don't already exist with the currently set one and refuses to start if it is not present.

This partially resolves #655, but not fully.

## Specification

https://github.com/compose-spec/compose-spec/blob/main/09-secrets.md

Especially the first example of `Example 2`

## Contributor Checklist:

I've read through the whole document and run all commands except `python -m unittest discover -v tests/integration  # takes a while to run`, since it is run by GitHub CI on pull request anyway.

The commands returned no errors for which I believe my code changes are responsible, though there are some others, possibly because of my incomplete setup.

Since I'm new here, please tell me if there is anything I should change.