### PR TITLE
Allow multiple env files as arguments in `--env-file` flag

### DIFF
--- a/newsfragments/allow_multiple_env_file_flags.feature
+++ b/newsfragments/allow_multiple_env_file_flags.feature
@@ -1,0 +1,1 @@
+Allow multiple ``--env-file`` flags on the command line, later files override earlier ones.

--- a/newsfragments/warn_on_missing_env_file.change
+++ b/newsfragments/warn_on_missing_env_file.change
@@ -1,0 +1,1 @@
+When no ``--env-file`` is given, only the ``.env`` file in the project directory (compose file's directory) is loaded (the old default ``.env`` in the current working directory is no longer loaded automatically).

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2626,17 +2626,22 @@ class PodmanCompose:
         dir_basename = os.path.basename(dirname)
         self.dirname = dirname
 
-        # env-file is relative to the CWD
         dotenv_dict = {}
-        if args.env_file:
-            # Load .env from the Compose file's directory to preserve
-            # behavior prior to 1.1.0 and to match with Docker Compose (v2).
-            if ".env" == args.env_file:
-                project_dotenv_file = os.path.realpath(os.path.join(dirname, ".env"))
-                if os.path.exists(project_dotenv_file):
-                    dotenv_dict.update(dotenv_to_dict(project_dotenv_file))
-            dotenv_path = os.path.realpath(args.env_file)
-            dotenv_dict.update(dotenv_to_dict(dotenv_path))
+        if not args.env_file:
+            # No --env-file specified: load the default .env from the
+            # compose file's directory
+            project_dotenv_file = os.path.realpath(os.path.join(dirname, ".env"))
+            if os.path.exists(project_dotenv_file):
+                dotenv_dict.update(dotenv_to_dict(project_dotenv_file))
+        else:
+            # User-specified env files are resolved relative to the CWD
+            # Later files override earlier ones
+            for env_file in args.env_file:
+                dotenv_path = os.path.realpath(env_file)
+                if not os.path.exists(dotenv_path):
+                    log.fatal("Couldn't find env file: %s", dotenv_path)
+                    sys.exit(1)
+                dotenv_dict.update(dotenv_to_dict(dotenv_path))
 
         os.environ.update({
             key: value  # type: ignore[misc]
@@ -3060,10 +3065,10 @@ class PodmanCompose:
         )
         parser.add_argument(
             "--env-file",
-            help="Specify an alternate environment file",
+            help="Specify an alternate environment file (can be specified multiple times)",
             metavar="env_file",
-            type=str,
-            default=".env",
+            action="append",
+            default=[],
         )
         parser.add_argument(
             "-f",

--- a/tests/integration/env_file_tests/project/container-compose-multiple-env-files.yaml
+++ b/tests/integration/env_file_tests/project/container-compose-multiple-env-files.yaml
@@ -1,0 +1,7 @@
+services:
+  app:
+    image: busybox
+    command: ["/bin/busybox", "sh", "-c", "env | grep ZZ"]
+    environment:
+      ZZVAR1: $ZZVAR1
+      ZZVAR3: $ZZVAR3

--- a/tests/integration/env_file_tests/test_podman_compose_env_file.py
+++ b/tests/integration/env_file_tests/test_podman_compose_env_file.py
@@ -44,6 +44,56 @@ class TestComposeEnvFile(unittest.TestCase, RunSubprocessMixin):
                 "down",
             ])
 
+    def test_path_env_file_inline_many(self) -> None:
+        base_path = compose_base_path()
+        path_compose_file = os.path.join(
+            base_path, "project/container-compose-multiple-env-files.yaml"
+        )
+        try:
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                path_compose_file,
+                "--env-file",
+                os.path.join(base_path, "env-files/project-1.env"),
+                "--env-file",
+                os.path.join(base_path, "env-files/project-2.env"),
+                "up",
+            ])
+            output, _ = self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                path_compose_file,
+                "logs",
+                "--no-log-prefix",
+                "--no-color",
+            ])
+            # ZZVAR1 is overridden by the following --env-file and ZZVAR3 is added
+            self.assertEqual(output, b"ZZVAR1=podman-rocks-223\nZZVAR3=podman-rocks-125\n")
+        finally:
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                path_compose_file,
+                "down",
+            ])
+
+    def test_path_env_file_inline_missing_fails(self) -> None:
+        base_path = compose_base_path()
+        path_compose_file = os.path.join(base_path, "project/container-compose.yaml")
+        out, err = self.run_subprocess_assert_returncode(
+            [
+                podman_compose_path(),
+                "-f",
+                path_compose_file,
+                "--env-file",
+                os.path.join(base_path, "env-files/nonexistent.env"),
+                "up",
+            ],
+            expected_returncode=1,
+        )
+        self.assertIn(b"Couldn't find env file", err)
+
     def test_path_env_file_flat_in_compose_file(self) -> None:
         # Test taking env variable value from env-file/project-1.env which was declared in
         # compose file's env_file


### PR DESCRIPTION
This PR adds support for specifying multiple `--env-file` flags on the `podman-compose` command line, matching Docker Compose behavior.
When multiple env files are provided, they are merged in order with later files taking precedence over earlier ones (Docker Compose documentation for reference: https://docs.docker.com/compose/how-tos/environment-variables/variable-interpolation/#substitute-with---env-file)
    
When no `--env-file` is specified, the old code loaded both the project-directory .env and the CWD .env (because .env was the string default).
The new code loads only the project-directory .env and this is also how Docker Compose behaves (Docker Compose documentation for reference: https://docs.docker.com/compose/how-tos/environment-variables/envvars/)

This PR builds on https://github.com/containers/podman-compose/pull/1380, thanks to https://github.com/GerkinDev.

PR fixes https://github.com/containers/podman-compose/issues/813.

