### PR TITLE
Support COMPOSE_ENV_FILES

### DIFF
--- a/newsfragments/compose_env_files.bugfix
+++ b/newsfragments/compose_env_files.bugfix
@@ -1,0 +1,2 @@
+Load the comma-separated environment files from ``COMPOSE_ENV_FILES`` when no
+``--env-file`` option is provided.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -3032,6 +3032,10 @@ class PodmanCompose:
                 cmd_parser(subparser)
         self.global_args = parser.parse_args(argv)
 
+        compose_env_files = os.environ.get("COMPOSE_ENV_FILES")
+        if not self.global_args.env_file and compose_env_files:
+            self.global_args.env_file = compose_env_files.split(",")
+
         if self.global_args.version:
             self.global_args.command = "version"
         if not self.global_args.command or self.global_args.command == "help":

--- a/tests/unit/test_parse_args.py
+++ b/tests/unit/test_parse_args.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: GPL-2.0
+
+import os
+import unittest
+from unittest import mock
+
+from podman_compose import PodmanCompose
+
+
+class TestParseArgs(unittest.TestCase):
+    def test_compose_env_files(self) -> None:
+        compose = PodmanCompose()
+
+        with mock.patch.dict(
+            os.environ,
+            {"COMPOSE_ENV_FILES": ".env.default,.env.override"},
+        ):
+            args = compose._parse_args(["--version"])  # pylint: disable=protected-access
+
+        self.assertEqual(args.env_file, [".env.default", ".env.override"])
+
+    def test_env_file_flag_overrides_compose_env_files(self) -> None:
+        compose = PodmanCompose()
+
+        with mock.patch.dict(
+            os.environ,
+            {"COMPOSE_ENV_FILES": ".env.default,.env.override"},
+        ):
+            args = compose._parse_args(  # pylint: disable=protected-access
+                ["--env-file", ".env.cli", "--version"]
+            )
+
+        self.assertEqual(args.env_file, [".env.cli"])


### PR DESCRIPTION
Closes #1501

Load the comma-separated files from `COMPOSE_ENV_FILES` when the CLI does not provide `--env-file`. Explicit `--env-file` arguments retain higher precedence, and the existing project `.env` fallback remains unchanged when neither source is set.

This matches Docker Compose's documented behavior: https://docs.docker.com/compose/how-tos/environment-variables/envvars/#compose_env_files

## Verification

- `python -m unittest discover tests/unit` (448 tests)
- `ruff format --check`
- `ruff check`
- `mypy .`
- `pylint podman_compose.py`

AI disclosure: Codex assisted with issue research, implementation, and validation. I reviewed the Compose precedence requirements, final diff, and test results before submission.

## Contributor Checklist

- [x] Read and followed `CONTRIBUTING.md`
- [x] Added focused unit tests
- [x] Added a `newsfragments` bug-fix entry
- [x] Signed off the commit