### PR TITLE
Raise PodmanComposeError for missing required variables

### DIFF
--- a/newsfragments/clean_error_on_missing_required_variable.change
+++ b/newsfragments/clean_error_on_missing_required_variable.change
@@ -1,0 +1,1 @@
+Raise PodmanComposeError without a traceback for missing required variables.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -317,7 +317,7 @@ def var_interpolate(value: str, env: dict[str, Any]) -> str:
                     interpolated_operand = (
                         interpolate_str(self.operand, env) if self.operand else ''
                     )
-                    raise ValueError(
+                    raise PodmanComposeError(
                         f"required variable {self.name} is missing a value: {interpolated_operand}"
                     )
                 return var_value
@@ -327,7 +327,7 @@ def var_interpolate(value: str, env: dict[str, Any]) -> str:
                     interpolated_operand = (
                         interpolate_str(self.operand, env) if self.operand else ''
                     )
-                    raise ValueError(
+                    raise PodmanComposeError(
                         f"required variable {self.name} is missing a value: {interpolated_operand}"
                     )
                 return var_value

--- a/tests/integration/interpolation/test_podman_compose_interpolation.py
+++ b/tests/integration/interpolation/test_podman_compose_interpolation.py
@@ -56,3 +56,33 @@ class TestComposeInterpolation(unittest.TestCase, RunSubprocessMixin):
                 compose_yaml_path(),
                 "down",
             ])
+
+    def test_required_nonempty_variable_missing(self) -> None:
+        compose_yaml_path = os.path.join(
+            os.path.join(test_path(), "interpolation"), "docker-compose-colon-question-error.yml"
+        )
+        out, err = self.run_subprocess_assert_returncode(
+            [
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path,
+                "up",
+            ],
+            1,
+        )
+        self.assertIn(b"required variable NOT_A_VARIABLE is missing a value: Missing variable", err)
+
+    def test_required_set_variable_missing(self) -> None:
+        compose_yaml_path = os.path.join(
+            os.path.join(test_path(), "interpolation"), "docker-compose-question-error.yml"
+        )
+        out, err = self.run_subprocess_assert_returncode(
+            [
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path,
+                "up",
+            ],
+            1,
+        )
+        self.assertIn(b"required variable NOT_A_VARIABLE is missing a value: Missing variable", err)

--- a/tests/unit/test_var_interpolate.py
+++ b/tests/unit/test_var_interpolate.py
@@ -6,6 +6,7 @@ from typing import Union
 
 from parameterized import parameterized
 
+from podman_compose import PodmanComposeError
 from podman_compose import var_interpolate
 
 
@@ -31,14 +32,18 @@ class TestVarInterpolate(unittest.TestCase):
         (
             "Path: ${TEST_PATH:?TEST_PATH required}",
             {},
-            ValueError("required variable TEST_PATH is missing a value: TEST_PATH required"),
+            PodmanComposeError(
+                "required variable TEST_PATH is missing a value: TEST_PATH required"
+            ),
             True,
         ),
         # 9. Required variable fails when empty (since :?)
         (
             "Path: ${TEST_PATH:?TEST_PATH required}",
             {"TEST_PATH": ""},
-            ValueError("required variable TEST_PATH is missing a value: TEST_PATH required"),
+            PodmanComposeError(
+                "required variable TEST_PATH is missing a value: TEST_PATH required"
+            ),
             True,
         ),
         # 10. Required variable (no colon, fails only if unset)
@@ -47,7 +52,7 @@ class TestVarInterpolate(unittest.TestCase):
         (
             "Config: ${CFG?missing}",
             {},
-            ValueError("required variable CFG is missing a value: missing"),
+            PodmanComposeError("required variable CFG is missing a value: missing"),
             True,
         ),
         # 12. Required variable passes even if empty (no colon)
@@ -96,7 +101,7 @@ class TestVarInterpolate(unittest.TestCase):
         (
             "${MAIN:-${BACKUP:?Missing BACKUP}}",
             {},
-            ValueError("required variable BACKUP is missing a value: Missing BACKUP"),
+            PodmanComposeError("required variable BACKUP is missing a value: Missing BACKUP"),
             True,
         ),
         # 29. Nested default with error in inner fallback
@@ -105,7 +110,7 @@ class TestVarInterpolate(unittest.TestCase):
         (
             "${X:-${Y:?Y required}}",
             {},
-            ValueError("required variable Y is missing a value: Y required"),
+            PodmanComposeError("required variable Y is missing a value: Y required"),
             True,
         ),
         # 31. Inner nested default that is never triggered because outer value is used
@@ -129,7 +134,7 @@ class TestVarInterpolate(unittest.TestCase):
         (
             "${REQ:?Missing ${ALT:-something}}",
             {},
-            ValueError("required variable REQ is missing a value: Missing something"),
+            PodmanComposeError("required variable REQ is missing a value: Missing something"),
             True,
         ),
         # 38. Nested alternative chain
@@ -179,16 +184,16 @@ class TestVarInterpolate(unittest.TestCase):
         self,
         to_interpolate: str,
         var_values: dict[str, str],
-        expected: Union[str, ValueError],
+        expected: Union[str, PodmanComposeError, ValueError],
         compare_shell_evaluation: bool,
     ) -> None:
         try:
             result = var_interpolate(to_interpolate, var_values)
             self.assertEqual(result, expected)
-        except ValueError as e:
+        except (PodmanComposeError, ValueError) as e:
             self.assertTrue(
-                isinstance(expected, ValueError),
-                msg=f"Expected ValueError for input: {to_interpolate}",
+                isinstance(expected, (PodmanComposeError, ValueError)),
+                msg=f"Expected PodmanComposeError or ValueError for input: {to_interpolate}",
             )
             self.assertEqual(str(e), str(expected))
 
@@ -206,7 +211,7 @@ class TestVarInterpolate(unittest.TestCase):
         stdout, _ = process.communicate()
         shell_result = stdout.rstrip(b'\n').decode()
         exit_code = process.returncode
-        if isinstance(expected, ValueError):
+        if isinstance(expected, (PodmanComposeError, ValueError)):
             error_msg = f"Expected non-zero return code success for input: {to_interpolate}"
             self.assertNotEqual(exit_code, 0, msg=error_msg)
         else:


### PR DESCRIPTION
Previously, variable interpolation with missing required variables caused the full traceback to be printed. This replaces it with a proper PodmanComposeError for cleaner error output.


Fixes https://github.com/containers/podman-compose/issues/895.
