### PR TITLE
add packaging, requests, tzlocal, types-PyYAML to development dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,10 @@ devel = [
     "ruff",
     "mypy",
     "pylint",
+    "packaging",
+    "requests",
+    "tzlocal",
+    "types-PyYAML"
 ]
 
 [project.scripts]


### PR DESCRIPTION
This PR changes nothing user-facing, just adding the packages reported by `mypy .` to be missing.

This reduces the `mypy .` output on a fresh install following the `CONTRIBUTING.md` guide to this sole error message:

```
pyproject.toml: [mypy]: python_version: Python 3.9 is not supported (must be 3.10 or higher)
podman_compose.py:3274: error: Invalid index type "list[str] | str" for "dict[str, Any]"; expected type "str"  [index]
                self.compose.commands[cmd_name]._parse_args.append(wrapped)
                                      ^~~~~~~~
Found 1 error in 1 file (checked 158 source files)
```

This last one is actually correct, but appears to not be addressed.