### PR TITLE
Support COMPOSE_FILE in `.env` for compose file discovery

### DIFF
--- a/newsfragments/compose_file_from_env.bugfix
+++ b/newsfragments/compose_file_from_env.bugfix
@@ -1,0 +1,1 @@
+Honor ``COMPOSE_FILE`` from ``.env`` (and ``--env-file``) when no ``-f`` option is provided.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2635,8 +2635,24 @@ class PodmanCompose:
             os.chdir(project_dir)
         pathsep = os.environ.get("COMPOSE_PATH_SEPARATOR", os.pathsep)
 
+        # Load env files early to honor COMPOSE_FILE from .env
+        early_dotenv: dict[str, str | None] = {}
+        if not args.env_file:
+            project_dotenv_file = os.path.realpath(os.path.join(os.getcwd(), ".env"))
+            if os.path.exists(project_dotenv_file):
+                early_dotenv.update(dotenv_to_dict(project_dotenv_file))
+        else:
+            for env_file in args.env_file:
+                dotenv_path = os.path.realpath(env_file)
+                if not os.path.exists(dotenv_path):
+                    log.fatal("Couldn't find env file: %s", dotenv_path)
+                    sys.exit(1)
+                early_dotenv.update(dotenv_to_dict(dotenv_path))
+
         if not args.file:
             default_str = os.environ.get("COMPOSE_FILE")
+            if not default_str:
+                default_str = early_dotenv.get("COMPOSE_FILE")
             if default_str:
                 default_ls = default_str.split(pathsep)
                 args.file = list(filter(os.path.exists, default_ls))

--- a/tests/integration/compose_file_from_env/.env
+++ b/tests/integration/compose_file_from_env/.env
@@ -1,0 +1,1 @@
+COMPOSE_FILE=docker-compose-from-dotenv.yml

--- a/tests/integration/compose_file_from_env/custom.env
+++ b/tests/integration/compose_file_from_env/custom.env
@@ -1,0 +1,1 @@
+COMPOSE_FILE=docker-compose-explicit-env.yml

--- a/tests/integration/compose_file_from_env/docker-compose-explicit-env.yml
+++ b/tests/integration/compose_file_from_env/docker-compose-explicit-env.yml
@@ -1,0 +1,4 @@
+services:
+  explicit-env-service:
+    image: nopush/podman-compose-test
+    command: echo "from-explicit-env"

--- a/tests/integration/compose_file_from_env/docker-compose-explicit.yml
+++ b/tests/integration/compose_file_from_env/docker-compose-explicit.yml
@@ -1,0 +1,4 @@
+services:
+  explicit-service:
+    image: nopush/podman-compose-test
+    command: echo "explicit"

--- a/tests/integration/compose_file_from_env/docker-compose-from-dotenv.yml
+++ b/tests/integration/compose_file_from_env/docker-compose-from-dotenv.yml
@@ -1,0 +1,4 @@
+services:
+  dotenv-service:
+    image: nopush/podman-compose-test
+    command: echo "from-dotenv"

--- a/tests/integration/compose_file_from_env/docker-compose-var.yml
+++ b/tests/integration/compose_file_from_env/docker-compose-var.yml
@@ -1,0 +1,4 @@
+services:
+  var-service:
+    image: nopush/podman-compose-test
+    command: echo "var"

--- a/tests/integration/compose_file_from_env/test_podman_compose_compose_file_from_env.py
+++ b/tests/integration/compose_file_from_env/test_podman_compose_compose_file_from_env.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: GPL-2.0
+
+import unittest
+from pathlib import Path
+
+from tests.integration.test_utils import RunSubprocessMixin
+from tests.integration.test_utils import podman_compose_path
+
+
+def compose_base_path() -> Path:
+    return Path(__file__).parent
+
+
+class TestComposeFileFromEnv(unittest.TestCase, RunSubprocessMixin):
+    """Test that COMPOSE_FILE from .env is honored when no -f is given."""
+
+    def test_compose_file_from_dotenv(self) -> None:
+        base_path = compose_base_path()
+        out, _ = self.run_subprocess_assert_returncode(
+            [podman_compose_path(), "config"],
+            0,
+            cwd=base_path,
+        )
+        self.assertEqual(
+            out.decode("utf-8"),
+            'services:\n'
+            '  dotenv-service:\n'
+            '    command: echo "from-dotenv"\n'
+            '    image: nopush/podman-compose-test\n'
+            '\n',
+        )
+
+    def test_compose_file_from_explicit_env_file(self) -> None:
+        base_path = compose_base_path()
+
+        out, _ = self.run_subprocess_assert_returncode(
+            [
+                podman_compose_path(),
+                "--env-file",
+                str(base_path / "custom.env"),
+                "config",
+            ],
+            0,
+            cwd=base_path,
+        )
+        self.assertEqual(
+            out.decode("utf-8"),
+            'services:\n'
+            '  explicit-env-service:\n'
+            '    command: echo "from-explicit-env"\n'
+            '    image: nopush/podman-compose-test\n'
+            '\n',
+        )
+
+    def test_explicit_f_overrides_compose_file_from_dotenv(self) -> None:
+        base_path = compose_base_path()
+        explicit_compose_file = base_path / "docker-compose-explicit.yml"
+
+        out, _ = self.run_subprocess_assert_returncode(
+            [
+                podman_compose_path(),
+                "-f",
+                str(explicit_compose_file),
+                "config",
+            ],
+            0,
+            cwd=base_path,
+        )
+        self.assertEqual(
+            out.decode("utf-8"),
+            'services:\n'
+            '  explicit-service:\n'
+            '    command: echo "explicit"\n'
+            '    image: nopush/podman-compose-test\n'
+            '\n',
+        )
+
+    def test_env_var_compose_file_takes_precedence_over_dotenv(self) -> None:
+        base_path = compose_base_path()
+
+        out, _ = self.run_subprocess_assert_returncode(
+            [podman_compose_path(), "config"],
+            0,
+            env={"COMPOSE_FILE": str(base_path / "docker-compose-var.yml")},
+            cwd=base_path,
+        )
+        self.assertEqual(
+            out.decode("utf-8"),
+            'services:\n'
+            '  var-service:\n'
+            '    command: echo "var"\n'
+            '    image: nopush/podman-compose-test\n'
+            '\n',
+        )
+
+    def test_missing_env_file_from_flag_fails(self) -> None:
+        base_path = compose_base_path()
+
+        _, err = self.run_subprocess_assert_returncode(
+            [
+                podman_compose_path(),
+                "--env-file",
+                str(base_path / "missing.env"),
+                "config",
+            ],
+            1,
+            cwd=base_path,
+        )
+        self.assertIn(b"Couldn't find env file", err)

--- a/tests/integration/test_utils.py
+++ b/tests/integration/test_utils.py
@@ -98,8 +98,9 @@ class RunSubprocessMixin:
         expected_returncode: int = 0,
         env: dict[str, str] = {},
         timeout: Optional[float] = None,
+        cwd: Optional[Path] = None,
     ) -> tuple[bytes, bytes]:
-        out, err, returncode = self.run_subprocess(args, env=env, timeout=timeout)
+        out, err, returncode = self.run_subprocess(args, env=env, timeout=timeout, cwd=cwd)
         decoded_out = out.decode('utf-8')
         decoded_err = err.decode('utf-8')
         self.assertEqual(  # type: ignore[attr-defined]


### PR DESCRIPTION
Previously, podman-compose only checked the shell environment for `COMPOSE_FILE` when resolving the default compose file. It did not consider `.env` or `--env-file` during this phase, so project-level defaults were silently ignored.

This changes loads env file(s) early (before compose file discovery) so that `COMPOSE_FILE` defined in `.env` or via `--env-file` is honored when no `-f` flag is provided.

Relevant Docker Compose documentation:
https://docs.docker.com/compose/how-tos/environment-variables/envvars-precedence/

Fixes https://github.com/containers/podman-compose/issues/475.
