### PR TITLE
Avoid merging computed dependency metadata

### DIFF
--- a/newsfragments/fix_extends_dependency_merge.bugfix
+++ b/newsfragments/fix_extends_dependency_merge.bugfix
@@ -1,0 +1,1 @@
+Fix extending services with dependents failing while merging internal dependency metadata.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2333,12 +2333,13 @@ def resolve_extends(
             normalize_service(from_service, subdirectory)
         else:
             from_service = services.get(from_service_name, {}).copy()
-            try:
-                del from_service["_deps"]
-            except KeyError as e:
+            if DependField.DEPENDENCIES not in from_service:
                 raise KeyError(
                     f"{from_service_name} not found at services.{name}.extends definition"
-                ) from e
+                )
+            # These fields are computed again after all extends references are resolved.
+            for field in DependField:
+                from_service.pop(field, None)
             try:
                 del from_service["extends"]
             except KeyError:

--- a/tests/unit/test_rec_merge_depends_on.py
+++ b/tests/unit/test_rec_merge_depends_on.py
@@ -6,7 +6,9 @@ from typing import Any
 
 from parameterized import parameterized
 
+from podman_compose import flat_deps
 from podman_compose import rec_merge
+from podman_compose import resolve_extends
 
 
 class TestRecMergeDependsOn(unittest.TestCase):
@@ -89,4 +91,27 @@ class TestRecMergeDependsOn(unittest.TestCase):
                 },
                 "environment": {"FOO": "bar"},
             },
+        )
+
+    def test_extends_services_with_dependents(self) -> None:
+        services: dict[str, dict[str, Any]] = {
+            "base": {"image": "base"},
+            "child": {"extends": {"service": "base"}, "command": ["run"]},
+            "base_consumer": {
+                "depends_on": {"base": {"condition": "service_started"}},
+            },
+            "child_consumer": {
+                "depends_on": {"child": {"condition": "service_started"}},
+            },
+        }
+
+        flat_deps(services, with_extends=True)
+        service_names = sorted((len(service["_deps"]), name) for name, service in services.items())
+        resolve_extends(services, [name for _, name in service_names], {})
+
+        self.assertEqual(services["child"]["image"], "base")
+        self.assertEqual(services["child"]["command"], ["run"])
+        self.assertEqual(
+            {dependency.name for dependency in services["child"]["_dependents"]},
+            {"child_consumer"},
         )


### PR DESCRIPTION
## Summary

- discard computed dependency fields from base services before resolving `extends`
- prevent `_dependents` sets from reaching the list merge path
- add a regression test covering extended services that both have dependents
- add the required bugfix news fragment

Fixes #1507.

The implementation was prepared with OpenAI Codex and manually reviewed against the dependency-flattening and extends-resolution flow.

## Tests

- `python -m unittest -v tests.unit.test_depends_on tests.unit.test_rec_merge_depends_on` - 15 passed
- `ruff format --check podman_compose.py tests/unit/test_rec_merge_depends_on.py` - passed
- `ruff check podman_compose.py tests/unit/test_rec_merge_depends_on.py` - passed
- `git diff --check` - passed

`mypy .` still reaches repository/tooling baseline issues (unsupported configured Python 3.9, missing PyYAML stubs, and an existing error at `podman_compose.py:3274`). Integration tests requiring Podman were not run locally.