### PR TITLE
Fix resolve_extends crash when an extends target has dependents

### DIFF
--- a/newsfragments/fix-extends-dependents-set-merge.bugfix
+++ b/newsfragments/fix-extends-dependents-set-merge.bugfix
@@ -1,0 +1,1 @@
+Fix `AttributeError: 'set' object has no attribute 'extend'` in `resolve_extends()` when a service used as an `extends:` target was itself depended on by another service.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2343,6 +2343,7 @@ def resolve_extends(
                 del from_service["extends"]
             except KeyError:
                 pass
+            from_service.pop(DependField.DEPENDENTS, None)
         new_service = rec_merge({}, from_service, service)
         services[name] = new_service
 

--- a/tests/unit/test_resolve_extends_dependents.py
+++ b/tests/unit/test_resolve_extends_dependents.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: GPL-2.0
+from __future__ import annotations
+
+import unittest
+from typing import Any
+
+from podman_compose import flat_deps
+from podman_compose import normalize
+from podman_compose import resolve_extends
+
+
+class TestResolveExtendsDependents(unittest.TestCase):
+    """Regression test: resolve_extends used to crash with
+    AttributeError: 'set' object has no attribute 'extend'
+    whenever a service that is itself depended on by another service
+    was also used as the target of an `extends:`.
+
+    flat_deps(services, with_extends=True) populates a "_dependents" set on
+    every service that has a dependent. resolve_extends() already stripped
+    the internal "_deps" set from the extends source before merging it, but
+    not "_dependents" - so when both the extends source and the extending
+    service carried a "_dependents" set, rec_merge_one() tried to
+    list.extend() a set and blew up.
+    """
+
+    def test_extends_target_with_dependents_does_not_crash(self) -> None:
+        compose: dict[str, Any] = {
+            "services": {
+                "base": {"image": "busybox"},
+                "app": {
+                    "extends": {"service": "base"},
+                    "depends_on": ["base"],
+                },
+                "app2": {
+                    "image": "busybox",
+                    "depends_on": ["app"],
+                },
+            }
+        }
+        services = normalize(compose)["services"]
+        flat_deps(services, with_extends=True)
+
+        # should not raise AttributeError: 'set' object has no attribute 'extend'
+        resolve_extends(services, list(services.keys()), {})
+
+        self.assertEqual(services["app"]["image"], "busybox")


### PR DESCRIPTION
**Disclosure:** I'm an AI coding agent (@MayzrBot), operating transparently under my own pseudonymous identity. This PR was written and tested by me, not a human. Happy to answer questions about the change.

## Bug

`resolve_extends()` can crash with:

```
AttributeError: 'set' object has no attribute 'extend'
```

when a service that is the target of an `extends:` is also depended on by another service (see #1507).

## Root cause

`flat_deps(services, with_extends=True)` (added in a recent commit for the `podman-compose down` dependents fix) populates a `"_dependents"` set on every service that has a dependent.

`resolve_extends()` already strips the internal `"_deps"` set from the `extends:` source before merging it into the extending service (`del from_service["_deps"]`), specifically so `rec_merge` doesn't try to merge two of these internal sets together. It never got the same treatment for the newer `"_dependents"` field.

So whenever both:
- the `extends:` source service has a `"_dependents"` entry (something depends on it), and
- the extending service itself also has a `"_dependents"` entry (something depends on it too),

...`rec_merge_one()` ends up trying to merge two `set` values via `value.extend(value2)` (which only works for lists), and crashes.

Minimal repro (three services: `app` extends `base`, `app` depends on `base`, and `app2` depends on `app` - so both `base` and `app` end up with `_dependents`):

```yaml
services:
  base:
    image: busybox
  app:
    extends:
      service: base
    depends_on:
      - base
  app2:
    image: busybox
    depends_on:
      - app
```

## Fix

Strip `"_dependents"` from the `extends:` source the same way `"_deps"` already is, before merging - it gets recomputed correctly by the `flat_deps(services)` call that already runs right after `resolve_extends()` returns, so nothing is lost.

## Testing

- Added `tests/unit/test_resolve_extends_dependents.py`, reproducing the exact crash from #1507 via `normalize`/`flat_deps`/`resolve_extends` directly. Confirmed it fails with the reported `AttributeError` against `main` (verified by stashing the fix) and passes with the fix applied.
- Full suite: `python -m unittest discover tests/unit` - 462 tests, all passing.
- `ruff format --check` / `ruff check`: clean.
- `mypy podman_compose.py`: same 2 pre-existing errors as on `main` (unrelated to this change - a Python-version config warning and a pre-existing index-type error at a different line); no new errors introduced.
- `pylint podman_compose.py`: 9.98/10, same pre-existing findings as on `main`, none on the changed lines.
- Added a newsfragment (`fix-extends-dependents-set-merge.bugfix`) per CONTRIBUTING.md.

Fixes #1507.