### PR TITLE
Stop remaining containers on `--abort-on-container-exit`

### DIFF
--- a/newsfragments/abort_on_container_exit_stop_containers.bugfix
+++ b/newsfragments/abort_on_container_exit_stop_containers.bugfix
@@ -1,0 +1,1 @@
+Fixed `--abort-on-container-exit` and `--exit-code-from` so that remaining containers are explicitly stopped when one container exits, instead of being left running in the background.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1936,6 +1936,7 @@ class Podman:
         log_formatter: str | None = None,
         *,
         suppress_output: bool = False,
+        container_name: str | None = None,
         # Intentionally mutable default argument to hold references to tasks
         task_reference: set[asyncio.Task] = set(),
     ) -> int | None:
@@ -1988,6 +1989,12 @@ class Podman:
             except asyncio.CancelledError:
                 log.info("Sending termination signal")
                 p.terminate()
+                if container_name:
+                    log.info("Stopping container %s", container_name)
+                    try:
+                        await self.run([], "stop", ["-t", "10", container_name])
+                    except Exception as e:  # pylint: disable=broad-exception-caught
+                        log.warning("Error stopping container %s: %s", container_name, e)
                 try:
                     exit_code = await wait_with_timeout(p.wait(), 10)
                 except TimeoutError:
@@ -3893,7 +3900,7 @@ async def run_container(
     # start the container
     log.debug("Starting task for container %s", name)
     return await compose.podman.run(  # type: ignore[misc]
-        *command, log_formatter=log_formatter, suppress_output=suppress_output
+        *command, log_formatter=log_formatter, suppress_output=suppress_output, container_name=name
     )
 
 

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1945,6 +1945,7 @@ class Podman:
         log_formatter: str | None = None,
         *,
         suppress_output: bool = False,
+        container_name: str | None = None,
         # Intentionally mutable default argument to hold references to tasks
         task_reference: set[asyncio.Task] = set(),
     ) -> int | None:
@@ -1997,6 +1998,12 @@ class Podman:
             except asyncio.CancelledError:
                 log.info("Sending termination signal")
                 p.terminate()
+                if container_name:
+                    log.info("Stopping container %s", container_name)
+                    try:
+                        await self.run([], "stop", ["-t", "10", container_name])
+                    except Exception as e:  # pylint: disable=broad-exception-caught
+                        log.warning("Error stopping container %s: %s", container_name, e)
                 try:
                     exit_code = await wait_with_timeout(p.wait(), 10)
                 except TimeoutError:
@@ -3938,7 +3945,7 @@ async def run_container(
     # start the container
     log.debug("Starting task for container %s", name)
     return await compose.podman.run(  # type: ignore[misc]
-        *command, log_formatter=log_formatter, suppress_output=suppress_output
+        *command, log_formatter=log_formatter, suppress_output=suppress_output, container_name=name
     )
 
 

--- a/tests/integration/exit_from/docker-compose.yaml
+++ b/tests/integration/exit_from/docker-compose.yaml
@@ -1,15 +1,7 @@
-version: "3"
 services:
     sh1:
       image: nopush/podman-compose-test
       command: ["dumb-init", "/bin/busybox", "sh", "-c", "sleep 1; exit 1"]
-      tmpfs:
-        - /run
-        - /tmp
     sh2:
       image: nopush/podman-compose-test
       command: ["dumb-init", "/bin/busybox", "sh", "-c", "sleep 1; exit 2"]
-      tmpfs:
-        - /run
-        - /tmp
-

--- a/tests/integration/exit_from/test_podman_compose_exit_from.py
+++ b/tests/integration/exit_from/test_podman_compose_exit_from.py
@@ -65,3 +65,43 @@ class TestComposeExitFrom(unittest.TestCase, RunSubprocessMixin):
 
         self.run_subprocess_assert_returncode(up_cmd + ["--exit-code-from", "sh1"], 1)
         self.run_subprocess_assert_returncode(up_cmd + ["--exit-code-from", "sh2"], 2)
+
+    def test_abort_all_containers_on_container_exit(self) -> None:
+        try:
+            out, err, returncode = self.run_subprocess(
+                [
+                    podman_compose_path(),
+                    "-f",
+                    compose_yaml_path(),
+                    "up",
+                    "--abort-on-container-exit",
+                ],
+                timeout=30,
+            )
+            # After one container exits, the others should be stopped.
+            # The command should complete within the timeout (all containers stop).
+            self.assertNotEqual(
+                returncode, -9, "Command was killed by timeout, containers were not stopped"
+            )
+
+            # Verify all containers are stopped
+            out2, _, _ = self.run_subprocess([
+                "podman",
+                "ps",
+                "-a",
+                "--filter",
+                "label=io.podman.compose.project=exit_from",
+                "--format",
+                "{{.Names}} {{.Status}}",
+            ])
+            self.assertEqual(
+                out2.decode("utf-8").strip().count("Exited"),
+                2,
+            )
+        finally:
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path(),
+                "down",
+            ])

--- a/tests/integration/exit_from/test_podman_compose_exit_from.py
+++ b/tests/integration/exit_from/test_podman_compose_exit_from.py
@@ -2,6 +2,9 @@
 
 import os
 import unittest
+from typing import Optional
+
+from parameterized import parameterized
 
 from tests.integration.test_utils import RunSubprocessMixin
 from tests.integration.test_utils import podman_compose_path
@@ -65,3 +68,46 @@ class TestComposeExitFrom(unittest.TestCase, RunSubprocessMixin):
 
         self.run_subprocess_assert_returncode(up_cmd + ["--exit-code-from", "sh1"], 1)
         self.run_subprocess_assert_returncode(up_cmd + ["--exit-code-from", "sh2"], 2)
+
+    @parameterized.expand([
+        ("--abort-on-container-exit", None, 0),
+        ("--exit-code-from", "sh1", 1),
+    ])
+    def test_abort_all_containers(
+        self, option: str, service: Optional[str], expected_exit_code: int
+    ) -> None:
+        up_args = [option]
+        if service:
+            up_args.append(service)
+        try:
+            self.run_subprocess_assert_returncode(
+                [
+                    podman_compose_path(),
+                    "-f",
+                    compose_yaml_path(),
+                    "up",
+                    *up_args,
+                ],
+                expected_exit_code,
+                timeout=30,
+            )
+
+            # Verify no containers are still running
+            out, _, _ = self.run_subprocess([
+                "podman",
+                "ps",
+                "--filter",
+                "label=io.podman.compose.project=exit_from",
+                "--filter",
+                "status=running",
+                "--format",
+                "{{.Names}}",
+            ])
+            self.assertEqual(out.decode("utf-8").strip(), "")
+        finally:
+            self.run_subprocess_assert_returncode([
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path(),
+                "down",
+            ])


### PR DESCRIPTION
Before this change, when using `--abort-on-container-exit` or `--exit-code-from`, exiting one container would leave the remaining containers running in the background. Now, remaining containers are properly stopped when one container exits.

Fixes https://github.com/containers/podman-compose/issues/679.