### PR TITLE
Resolve short-form env vars in `podman-compose config`

### DIFF
--- a/newsfragments/fix_config_short_syntax_env.bugfix
+++ b/newsfragments/fix_config_short_syntax_env.bugfix
@@ -1,0 +1,1 @@
+Fixed `podman-compose config` printing `null` for short-form environment variables instead of resolving them to their actual values from `.env` files or the process environment.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -484,6 +484,11 @@ def rec_subs(value: dict | str | Iterable, subs_dict: dict[str, Any]) -> dict | 
             svc_envs = rec_subs(svc_envs, subs_dict)
             subs_dict.update(svc_envs)
 
+            # Resolve short-form environment variables (value is None) to their actual values
+            for env_k, env_v in value['environment'].items():
+                if env_v is None and env_k in subs_dict:
+                    value['environment'][env_k] = subs_dict[env_k]
+
         value = {rec_subs(k, subs_dict): rec_subs(v, subs_dict) for k, v in value.items()}
     elif isinstance(value, str):
         value = var_interpolate(value, subs_dict)

--- a/tests/integration/command_config/.env
+++ b/tests/integration/command_config/.env
@@ -1,0 +1,1 @@
+ZZVAR3=TEST

--- a/tests/integration/command_config/docker-compose.yml
+++ b/tests/integration/command_config/docker-compose.yml
@@ -1,7 +1,0 @@
-version: '3'
-services:
-  test:
-    image: nopush/podman-compose-test
-    environment:
-      - VAR1=var1
-      - VAR2=var2

--- a/tests/integration/command_config/docker-compose_quiet.yaml
+++ b/tests/integration/command_config/docker-compose_quiet.yaml
@@ -1,0 +1,3 @@
+services:
+  test:
+    image: nopush/podman-compose-test

--- a/tests/integration/command_config/docker-compose_short_syntax.yaml
+++ b/tests/integration/command_config/docker-compose_short_syntax.yaml
@@ -1,0 +1,6 @@
+services:
+  app:
+    image: nopush/podman-compose-test
+    command: ["/bin/busybox", "sh", "-c", "env | grep ZZVAR3"]
+    environment:
+        - ZZVAR3

--- a/tests/integration/command_config/test_podman_compose_config_command.py
+++ b/tests/integration/command_config/test_podman_compose_config_command.py
@@ -8,10 +8,10 @@ from tests.integration.test_utils import podman_compose_path
 from tests.integration.test_utils import test_path
 
 
-def compose_yaml_path() -> str:
-    """ "Returns the path to the compose file used for this test module"""
-    base_path = os.path.join(test_path(), "commands_fail_exit_code")
-    return os.path.join(base_path, "docker-compose.yml")
+def compose_yaml_path(scenario: str) -> str:
+    return os.path.join(
+        os.path.join(test_path(), "command_config"), f"docker-compose_{scenario}.yaml"
+    )
 
 
 class TestConfigCommand(unittest.TestCase, RunSubprocessMixin):
@@ -24,7 +24,7 @@ class TestConfigCommand(unittest.TestCase, RunSubprocessMixin):
             "run",
             podman_compose_path(),
             "-f",
-            compose_yaml_path(),
+            compose_yaml_path("quiet"),
             "config",
             "--quiet",
         ]

--- a/tests/integration/command_config/test_podman_compose_config_command.py
+++ b/tests/integration/command_config/test_podman_compose_config_command.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0
 
 import os
+import textwrap
 import unittest
 
 from tests.integration.test_utils import RunSubprocessMixin
@@ -31,3 +32,28 @@ class TestConfigCommand(unittest.TestCase, RunSubprocessMixin):
 
         out, _ = self.run_subprocess_assert_returncode(config_cmd)
         self.assertEqual(out.decode("utf-8"), "")
+
+    def test_config_short_syntax_env(self) -> None:
+        out, _ = self.run_subprocess_assert_returncode(
+            [
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path("short_syntax"),
+                "config",
+            ],
+            0,
+        )
+        expected = textwrap.dedent("""\
+            services:
+              app:
+                command:
+                - /bin/busybox
+                - sh
+                - -c
+                - env | grep ZZVAR3
+                environment:
+                  ZZVAR3: TEST
+                image: nopush/podman-compose-test
+
+            """)
+        self.assertEqual(out.decode("utf-8"), expected)

--- a/tests/unit/test_rec_subs.py
+++ b/tests/unit/test_rec_subs.py
@@ -64,6 +64,16 @@ class TestRecSubs(unittest.TestCase):
             "$$v1",
             "$v1",
         ),
+        (
+            "Short-form environment variable resolves to subs_dict value",
+            {"environment": {"v1": None}},
+            {"environment": {"v1": "high priority"}},
+        ),
+        (
+            "Short-form environment variable keeps None when not in subs_dict",
+            {"environment": {"missing": None}},
+            {"environment": {"missing": None}},
+        ),
     ]
 
     @parameterized.expand(substitutions)


### PR DESCRIPTION
Before this fix, `podman-compose config` printed `null` for short-form environment variables (e.g. `environment: [FOO]`) even when the value was defined in a `.env` file or the process environment. Now it correctly displays the resolved value, matching what containers actually receive.

Fixes https://github.com/containers/podman-compose/issues/1310.