### PR TITLE
Reject dict format for service and build secrets

### DIFF
--- a/newsfragments/reject_invalid_secrets_dict.bugfix
+++ b/newsfragments/reject_invalid_secrets_dict.bugfix
@@ -1,0 +1,1 @@
+Reject dict format for service and build secrets instead of silently misbehaving.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2164,6 +2164,12 @@ def normalize_service(service: dict[str, Any], sub_dir: str = "") -> dict[str, A
             raise PodmanComposeError("ERROR: secrets must be a list, not a dict")
         if isinstance(secrets, str):
             service["secrets"] = [secrets]
+    if "build" in service and "secrets" in service["build"]:
+        build_secrets = service["build"]["secrets"]
+        if isinstance(build_secrets, dict):
+            raise PodmanComposeError("ERROR: build.secrets must be a list, not a dict")
+        if isinstance(build_secrets, str):
+            service["build"]["secrets"] = [build_secrets]
     return service
 
 

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2158,6 +2158,12 @@ def normalize_service(service: dict[str, Any], sub_dir: str = "") -> dict[str, A
                     ef["path"] = os.path.join(sub_dir, path)
             new_env_file.append(ef)
         service["env_file"] = new_env_file
+    if "secrets" in service:
+        secrets = service["secrets"]
+        if isinstance(secrets, dict):
+            raise PodmanComposeError("ERROR: secrets must be a list, not a dict")
+        if isinstance(secrets, str):
+            service["secrets"] = [secrets]
     return service
 
 

--- a/tests/integration/invalid_secrets_dict/docker-compose_build.yaml
+++ b/tests/integration/invalid_secrets_dict/docker-compose_build.yaml
@@ -1,0 +1,8 @@
+services:
+  tester:
+    build:
+      context: .
+      secrets:
+        build-secret:
+          source: build-secret
+          target: build_secret

--- a/tests/integration/invalid_secrets_dict/docker-compose_service.yaml
+++ b/tests/integration/invalid_secrets_dict/docker-compose_service.yaml
@@ -1,0 +1,8 @@
+services:
+  tester:
+    image: nopush/podman-compose-test
+    secrets:
+      test-secret:
+        source: test-secret
+        type: env
+        target: MY_VAR

--- a/tests/integration/invalid_secrets_dict/test_podman_compose_invalid_secrets_dict.py
+++ b/tests/integration/invalid_secrets_dict/test_podman_compose_invalid_secrets_dict.py
@@ -20,3 +20,9 @@ class TestComposeInvalidSecretsDict(unittest.TestCase, RunSubprocessMixin):
             [podman_compose_path(), "-f", compose_yaml_path("service"), "config"], 1
         )
         self.assertEqual(b'Error: ERROR: secrets must be a list, not a dict\n', err)
+
+    def test_invalid_build_secrets_dict_fails(self) -> None:
+        _, err = self.run_subprocess_assert_returncode(
+            [podman_compose_path(), "-f", compose_yaml_path("build"), "config"], 1
+        )
+        self.assertEqual(b'Error: ERROR: build.secrets must be a list, not a dict\n', err)

--- a/tests/integration/invalid_secrets_dict/test_podman_compose_invalid_secrets_dict.py
+++ b/tests/integration/invalid_secrets_dict/test_podman_compose_invalid_secrets_dict.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: GPL-2.0
+
+import os
+import unittest
+
+from tests.integration.test_utils import RunSubprocessMixin
+from tests.integration.test_utils import podman_compose_path
+from tests.integration.test_utils import test_path
+
+
+def compose_yaml_path(scenario: str) -> str:
+    return os.path.join(
+        os.path.join(test_path(), "invalid_secrets_dict"), f"docker-compose_{scenario}.yaml"
+    )
+
+
+class TestComposeInvalidSecretsDict(unittest.TestCase, RunSubprocessMixin):
+    def test_invalid_service_secrets_dict_fails(self) -> None:
+        _, err = self.run_subprocess_assert_returncode(
+            [podman_compose_path(), "-f", compose_yaml_path("service"), "config"], 1
+        )
+        self.assertEqual(b'Error: ERROR: secrets must be a list, not a dict\n', err)

--- a/tests/unit/test_normalize_service.py
+++ b/tests/unit/test_normalize_service.py
@@ -5,6 +5,7 @@ from typing import Union
 
 from parameterized import parameterized
 
+from podman_compose import PodmanComposeError
 from podman_compose import normalize_service
 
 
@@ -117,3 +118,22 @@ class TestNormalizeService(unittest.TestCase):
             expected_service = {}
             expected_service[key] = expected
             self.assertEqual(normalize_service(input_service), expected_service)
+
+    @parameterized.expand([
+        ("secrets_string", {"secrets": "my_secret"}, {"secrets": ["my_secret"]}),
+        ("secrets_list", {"secrets": ["my_secret"]}, {"secrets": ["my_secret"]}),
+        (
+            "secrets_list_of_dicts",
+            {"secrets": [{"source": "my_secret", "target": "ENV_VAR"}]},
+            {"secrets": [{"source": "my_secret", "target": "ENV_VAR"}]},
+        ),
+    ])
+    def test_secrets_normalization(
+        self, test_name: str, input_service: dict[str, Any], expected_service: dict[str, Any]
+    ) -> None:
+        self.assertEqual(normalize_service(input_service), expected_service)
+
+    def test_secrets_dict_raises(self) -> None:
+        with self.assertRaises(PodmanComposeError) as context:
+            normalize_service({"secrets": {"my_secret": {"source": "my_secret"}}})
+        self.assertEqual("ERROR: secrets must be a list, not a dict", str(context.exception))

--- a/tests/unit/test_normalize_service.py
+++ b/tests/unit/test_normalize_service.py
@@ -137,3 +137,10 @@ class TestNormalizeService(unittest.TestCase):
         with self.assertRaises(PodmanComposeError) as context:
             normalize_service({"secrets": {"my_secret": {"source": "my_secret"}}})
         self.assertEqual("ERROR: secrets must be a list, not a dict", str(context.exception))
+
+    def test_build_secrets_dict_raises(self) -> None:
+        with self.assertRaises(PodmanComposeError) as context:
+            normalize_service({
+                "build": {"context": ".", "secrets": {"my_secret": {"source": "my_secret"}}}
+            })
+        self.assertEqual("ERROR: build.secrets must be a list, not a dict", str(context.exception))


### PR DESCRIPTION
Reject invalid dict format for service and build secrets instead of silently misbehaving. Previously, specifying `secrets` as a mapping (dict) caused podman-compose to iterate over keys and mount secrets incorrectly. Now it raises a clear error message.

Fixes https://github.com/containers/podman-compose/issues/1365.