### PR TITLE
Warn on obsolete compose version and omit version from config output

### DIFF
--- a/newsfragments/warn_on_obsolete_version.change
+++ b/newsfragments/warn_on_obsolete_version.change
@@ -1,0 +1,1 @@
+Warn about the obsolete `version` key in `podman-compose config`, and omit it from the merged YAML output.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2793,6 +2793,12 @@ class PodmanCompose:
             if not isinstance(content, dict):
                 log.fatal("Compose file does not contain a top level object: %s", filename)
                 sys.exit(1)
+            if "version" in content:
+                log.warning(
+                    "%s: the attribute `version` is obsolete, it will be ignored, "
+                    "please remove it to avoid potential confusion",
+                    filename,
+                )
             # For files arriving via ``include:``, paths inside the file must
             # resolve against the included file's directory rather than the
             # project root (Compose Spec, ``include`` section). Pass that as
@@ -2885,6 +2891,7 @@ class PodmanCompose:
         compose["services"] = resolved_services
         if not getattr(args, "no_normalize", None):
             compose = normalize_final(compose, self.dirname)
+        compose.pop("version", None)
         self.merged_yaml = yaml.safe_dump(compose)
         merged_json_b = json.dumps(
             self.original_configuration(compose), separators=(",", ":")

--- a/tests/integration/command_config/docker-compose.yaml
+++ b/tests/integration/command_config/docker-compose.yaml
@@ -1,0 +1,5 @@
+version: '3'
+services:
+  test:
+    image: nopush/podman-compose-test
+

--- a/tests/integration/command_config/test_podman_compose_config_command.py
+++ b/tests/integration/command_config/test_podman_compose_config_command.py
@@ -11,7 +11,7 @@ from tests.integration.test_utils import test_path
 
 def compose_yaml_path(scenario: str) -> str:
     return os.path.join(
-        os.path.join(test_path(), "command_config"), f"docker-compose_{scenario}.yaml"
+        os.path.join(test_path(), "command_config"), f"docker-compose{scenario}.yaml"
     )
 
 
@@ -25,7 +25,7 @@ class TestConfigCommand(unittest.TestCase, RunSubprocessMixin):
             "run",
             podman_compose_path(),
             "-f",
-            compose_yaml_path("quiet"),
+            compose_yaml_path("_quiet"),
             "config",
             "--quiet",
         ]
@@ -38,7 +38,7 @@ class TestConfigCommand(unittest.TestCase, RunSubprocessMixin):
             [
                 podman_compose_path(),
                 "-f",
-                compose_yaml_path("short_syntax"),
+                compose_yaml_path("_short_syntax"),
                 "config",
             ],
             0,
@@ -57,3 +57,21 @@ class TestConfigCommand(unittest.TestCase, RunSubprocessMixin):
 
             """)
         self.assertEqual(out.decode("utf-8"), expected)
+
+    def test_config_omits_version_and_warns(self) -> None:
+        config_cmd = [
+            "coverage",
+            "run",
+            podman_compose_path(),
+            "-f",
+            compose_yaml_path(""),
+            "config",
+        ]
+
+        out, err = self.run_subprocess_assert_returncode(config_cmd)
+        self.assertIn(
+            b'the attribute `version` is obsolete, it will be ignored, '
+            b'please remove it to avoid potential confusion\n',
+            err,
+        )
+        self.assertEqual(out, b'services:\n  test:\n    image: nopush/podman-compose-test\n\n')

--- a/tests/integration/include_relative_paths/test_podman_compose_include_relative_paths.py
+++ b/tests/integration/include_relative_paths/test_podman_compose_include_relative_paths.py
@@ -49,7 +49,6 @@ class TestIncludeRelativePaths(unittest.TestCase, RunSubprocessMixin):
                 volumes:
                 - ./sub/./data:/data:ro
                 - ./sub/../assets:/assets:ro
-            version: '3.6'
 
             """)
         self.assertEqual(out.decode("utf-8"), expected)

--- a/tests/integration/parse-error/docker-compose.yml
+++ b/tests/integration/parse-error/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
     web1:
       image: busybox

--- a/tests/unit/test_include.py
+++ b/tests/unit/test_include.py
@@ -52,7 +52,6 @@ class TestIncludeDict(unittest.TestCase):
         self.write_yaml("test-compose-include-2.yaml", include_content_2)
 
         main_content = {
-            "version": "3.8",
             "include": include_value,
             "services": {"web": {"image": "alpine:latest"}},
         }
@@ -83,7 +82,6 @@ class TestIncludeDict(unittest.TestCase):
         self, name: str, include_value: dict | list, exception_msg: str
     ) -> None:
         main_content = {
-            "version": "3.8",
             "include": include_value,
             "services": {"web": {"image": "alpine:latest"}},
         }


### PR DESCRIPTION
When a compose file contains the obsolete `version` key, `podman-compose` now prints a file-specific warning (matching `docker-compose` behavior) and excludes the key from `config` command output.

Fixes https://github.com/containers/podman-compose/issues/624.