### PR TITLE
Support the cgroup service field

### DIFF
--- a/newsfragments/cgroup-service-field.feature
+++ b/newsfragments/cgroup-service-field.feature
@@ -1,0 +1,1 @@
+Add support for the Compose `cgroup` service field, passing `host` and `private` modes to Podman as `--cgroupns`.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1450,6 +1450,12 @@ async def container_to_args(
     if userns_mode is not None:
         podman_args.extend(["--userns", userns_mode])
 
+    cgroup = cnt.get("cgroup")
+    if cgroup is not None:
+        if cgroup not in ("host", "private"):
+            raise ValueError(f"invalid cgroup mode [{cgroup}]")
+        podman_args.extend(["--cgroupns", cgroup])
+
     user = cnt.get("user")
     if user is not None:
         podman_args.extend(["-u", user])

--- a/tests/unit/test_container_to_args.py
+++ b/tests/unit/test_container_to_args.py
@@ -1228,6 +1228,39 @@ class TestContainerToArgs(unittest.IsolatedAsyncioTestCase):
             ],
         )
 
+    @parameterized.expand(["host", "private"])
+    async def test_cgroup_modes(self, cgroup_mode: str) -> None:
+        """Pass the cgroup namespace mode on as --cgroupns parameter"""
+
+        c = create_compose_mock()
+
+        cnt = get_minimal_container()
+        cnt["cgroup"] = cgroup_mode
+
+        args = await container_to_args(c, cnt)
+        self.assertEqual(
+            args,
+            [
+                "--name=project_name_service_name1",
+                "-d",
+                "--network=bridge:alias=service_name",
+                "--cgroupns",
+                cgroup_mode,
+                "busybox",
+            ],
+        )
+
+    async def test_cgroup_invalid_mode(self) -> None:
+        """Throw ValueError on invalid cgroup mode"""
+
+        c = create_compose_mock()
+
+        cnt = get_minimal_container()
+        cnt["cgroup"] = "invalid"
+
+        with self.assertRaisesRegex(ValueError, r"invalid cgroup mode"):
+            await container_to_args(c, cnt)
+
     @parameterized.expand(["invalid", (["a list", "is invalid too"],)])
     async def test_ipc_invalid_mode(self, ipc_mode: Any) -> None:
         """Throw ValueError on invalid ipc mode"""


### PR DESCRIPTION
Closes #1439

## Contributor Checklist:

The Compose Specification [`cgroup`](https://github.com/compose-spec/compose-spec/blob/main/spec.md#cgroup) service field was silently dropped, so `cgroup: host` still started the container in a private cgroup namespace while docker-compose puts it in the host namespace. It is now mapped to `podman run --cgroupns`, with any other value rejected the same way the neighbouring `ipc` option validates its input.

Unit tests added in `tests/unit/test_container_to_args.py` cover both valid modes and the invalid-value error; they fail without the change and pass with it.

Let me know if you'd like a `newsfragments/` entry added for this and I'll push one.
