### PR TITLE
Split string command and entrypoint after interpolation

### DIFF
--- a/newsfragments/split_command_entrypoint_after_interpolation.bugfix
+++ b/newsfragments/split_command_entrypoint_after_interpolation.bugfix
@@ -1,0 +1,1 @@
+Split string command and entrypoint values into argument lists after interpolation, matching Compose semantics.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2186,6 +2186,9 @@ def normalize_service_final(service: dict[str, Any], project_dir: str) -> dict[s
         if not isinstance(service["build"], dict):
             service["build"] = {}
         service["build"]["context"] = context
+    for key in ("command", "entrypoint"):
+        if isinstance(service.get(key), str):
+            service[key] = shlex.split(service[key])
     return service
 
 

--- a/tests/integration/compose_file_from_env/test_podman_compose_compose_file_from_env.py
+++ b/tests/integration/compose_file_from_env/test_podman_compose_compose_file_from_env.py
@@ -25,7 +25,9 @@ class TestComposeFileFromEnv(unittest.TestCase, RunSubprocessMixin):
             out.decode("utf-8"),
             'services:\n'
             '  dotenv-service:\n'
-            '    command: echo "from-dotenv"\n'
+            '    command:\n'
+            '    - echo\n'
+            '    - from-dotenv\n'
             '    image: nopush/podman-compose-test\n'
             '\n',
         )
@@ -47,7 +49,9 @@ class TestComposeFileFromEnv(unittest.TestCase, RunSubprocessMixin):
             out.decode("utf-8"),
             'services:\n'
             '  explicit-env-service:\n'
-            '    command: echo "from-explicit-env"\n'
+            '    command:\n'
+            '    - echo\n'
+            '    - from-explicit-env\n'
             '    image: nopush/podman-compose-test\n'
             '\n',
         )
@@ -70,7 +74,9 @@ class TestComposeFileFromEnv(unittest.TestCase, RunSubprocessMixin):
             out.decode("utf-8"),
             'services:\n'
             '  explicit-service:\n'
-            '    command: echo "explicit"\n'
+            '    command:\n'
+            '    - echo\n'
+            '    - explicit\n'
             '    image: nopush/podman-compose-test\n'
             '\n',
         )
@@ -88,7 +94,9 @@ class TestComposeFileFromEnv(unittest.TestCase, RunSubprocessMixin):
             out.decode("utf-8"),
             'services:\n'
             '  var-service:\n'
-            '    command: echo "var"\n'
+            '    command:\n'
+            '    - echo\n'
+            '    - var\n'
             '    image: nopush/podman-compose-test\n'
             '\n',
         )

--- a/tests/unit/test_normalize_final_build.py
+++ b/tests/unit/test_normalize_final_build.py
@@ -104,6 +104,22 @@ class TestNormalizeFinalBuild(unittest.TestCase):
         project_dir = cwd
         self.assertEqual(normalize_service_final(input, project_dir), expected)
 
+    cases_command_normalization = [
+        ({"image": "busybox", "command": "sleep infinity"}, ["sleep", "infinity"], None),
+        ({"image": "busybox", "command": ["sleep", "infinity"]}, ["sleep", "infinity"], None),
+        ({"image": "busybox", "entrypoint": "/bin/sh -c"}, None, ["/bin/sh", "-c"]),
+    ]
+
+    @parameterized.expand(cases_command_normalization)
+    def test_normalize_service_final_splits_string_command(
+        self, input, expected_command, expected_entrypoint
+    ):
+        # Tests that string [service.command] and [service.entrypoint] are split into
+        # lists after variable interpolation
+        actual = normalize_service_final(input, cwd)
+        self.assertEqual(actual.get("command"), expected_command)
+        self.assertEqual(actual.get("entrypoint"), expected_entrypoint)
+
     @parameterized.expand(cases_simple_normalization)
     def test_normalize_returns_absolute_path_in_context(self, input, expected):
         project_dir = cwd

--- a/tests/unit/test_normalize_final_build.py
+++ b/tests/unit/test_normalize_final_build.py
@@ -104,13 +104,11 @@ class TestNormalizeFinalBuild(unittest.TestCase):
         project_dir = cwd
         self.assertEqual(normalize_service_final(input, project_dir), expected)
 
-    cases_command_normalization = [
+    @parameterized.expand([
         ({"image": "busybox", "command": "sleep infinity"}, ["sleep", "infinity"], None),
         ({"image": "busybox", "command": ["sleep", "infinity"]}, ["sleep", "infinity"], None),
         ({"image": "busybox", "entrypoint": "/bin/sh -c"}, None, ["/bin/sh", "-c"]),
-    ]
-
-    @parameterized.expand(cases_command_normalization)
+    ])
     def test_normalize_service_final_splits_string_command(
         self, input, expected_command, expected_entrypoint
     ):


### PR DESCRIPTION
Closes #1514

## Contributor Checklist:

Please make sure to read development guidelines in CONTRIBUTING.md. Pull requests that do not
follow the guidelines WILL TAKE LONGER TO REVIEW as the first review comment will be to follow
these guidelines.

If this PR adds a new feature that improves compatibility with docker-compose, please add a link
to the exact part of compose spec that the PR touches.

For any user-visible change please add a release note to newsfragments directory, e.g.
newsfragments/my_feature.feature. See newsfragments/README.txt for more details.

All changes require additional unit tests.

---

Bug fix, not a new feature, so no compose spec link applies.

#1504 removed the `shlex.split()` of string `command`/`entrypoint` from `normalize_service` (it ran before interpolation and broke `${VAR:?error message}`), but nothing re-applied the split afterwards, so `podman-compose config` regressed to emitting `command: sleep infinity` instead of the array docker-compose produces. `normalize_service_final` runs after `rec_subs`, so the split now happens there.

Unit tests added in `tests/unit/test_normalize_final_build.py` (fail without the fix, pass with it). I did not add a newsfragment - happy to add one if you would like it for this regression fix.
