### PR TITLE
Show `networks` top level element in command `config`

### DIFF
--- a/newsfragments/config_show_created_networks.change
+++ b/newsfragments/config_show_created_networks.change
@@ -1,0 +1,1 @@
+The output of the `config` command now includes resolved definitions for all networks, including the default network.

--- a/newsfragments/config_show_created_networks.change
+++ b/newsfragments/config_show_created_networks.change
@@ -1,0 +1,1 @@
+The output of the `config` command now includes resolved definitions for all networks (including the default network, external networks with correct names, and networks specified as `external: { name: ... }`).

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2426,7 +2426,6 @@ class PodmanCompose:
         self.all_services: set[Any] = set()
         self.prefer_volume_over_mount = True
         self.x_podman: dict[PodmanCompose.XPodmanSettingKey, Any] = {}
-        self.merged_yaml: Any
         self.yaml_hash = ""
         self.console_colors = [
             "\x1b[1;32m",
@@ -2865,7 +2864,6 @@ class PodmanCompose:
         compose["services"] = resolved_services
         if not getattr(args, "no_normalize", None):
             compose = normalize_final(compose, self.dirname)
-        self.merged_yaml = yaml.safe_dump(compose)
         merged_json_b = json.dumps(
             self.original_configuration(compose), separators=(",", ":")
         ).encode("utf-8")
@@ -4765,6 +4763,59 @@ async def compose_logs(compose: PodmanCompose, args: argparse.Namespace) -> None
     await asyncio.gather(*tasks)
 
 
+def build_compose_config(compose: PodmanCompose) -> dict[str, Any]:
+    config: dict[str, Any] = {
+        "services": {},
+    }
+    for name, service in compose.services.items():
+        config["services"][name] = compose.original_configuration(service)
+        if (
+            "networks" not in config["services"][name]
+            and "network_mode" not in config["services"][name]
+            and compose.default_net
+        ):
+            config["services"][name]["networks"] = {compose.default_net: None}
+        if "networks" in config["services"][name]:
+            networks = config["services"][name]["networks"]
+            if is_list(networks):
+                config["services"][name]["networks"] = {net: None for net in networks}
+            elif isinstance(networks, dict):
+                config["services"][name]["networks"] = {
+                    net: None if val == {} else val for net, val in networks.items()
+                }
+    if compose.networks:
+        used_networks: set[str] = set()
+        # Determine which networks are actually used by services
+        for name, service in compose.services.items():
+            if "network_mode" in service:
+                continue
+            srv_nets = service.get("networks")
+            if srv_nets:
+                if isinstance(srv_nets, dict):
+                    used_networks.update(srv_nets.keys())
+                else:
+                    used_networks.update(norm_as_list(srv_nets))
+            elif compose.default_net:
+                used_networks.add(compose.default_net)
+
+        config_networks = {}
+        for net_name, net_desc in compose.networks.items():
+            if net_name in used_networks:
+                config_networks[net_name] = net_desc or {}
+                is_ext = config_networks[net_name].get("external")
+                if "name" not in config_networks[net_name]:
+                    config_networks[net_name]["name"] = default_network_name_for_project(
+                        compose, net_name, is_ext
+                    )
+        if config_networks:
+            config["networks"] = config_networks
+    if compose.vols:
+        config["volumes"] = compose.vols
+    if compose.declared_secrets:
+        config["secrets"] = compose.declared_secrets
+    return config
+
+
 @cmd_run(podman_compose, "config", "displays the compose file")
 async def compose_config(compose: PodmanCompose, args: argparse.Namespace) -> None:
     if args.services:
@@ -4773,7 +4824,7 @@ async def compose_config(compose: PodmanCompose, args: argparse.Namespace) -> No
                 print(service)
         return
     if not args.quiet:
-        print(compose.merged_yaml)
+        print(yaml.safe_dump(build_compose_config(compose), sort_keys=False))
 
 
 @cmd_run(podman_compose, "port", "Prints the public port for a port binding.")

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -4792,6 +4792,81 @@ async def compose_logs(compose: PodmanCompose, args: argparse.Namespace) -> None
     await asyncio.gather(*tasks)
 
 
+def _normalize_service_networks(service: dict[str, Any], default_net: str | None) -> None:
+    """Inject default network and normalize network formats for config output."""
+    if "networks" not in service and "network_mode" not in service and default_net:
+        service["networks"] = {default_net: None}
+    if "networks" in service:
+        networks = service["networks"]
+        if is_list(networks):
+            service["networks"] = {net: None for net in networks}
+        elif isinstance(networks, dict):
+            service["networks"] = {net: None if val == {} else val for net, val in networks.items()}
+
+
+def _get_used_networks(services: dict[str, Any], default_net: str | None) -> set[str]:
+    """Return the set of network names actually referenced by services."""
+    used_networks: set[str] = set()
+    for service in services.values():
+        if "network_mode" in service:
+            continue
+        srv_nets = service.get("networks")
+        if srv_nets:
+            if isinstance(srv_nets, dict):
+                used_networks.update(srv_nets.keys())
+            else:
+                used_networks.update(norm_as_list(srv_nets))
+        elif default_net:
+            used_networks.add(default_net)
+    return used_networks
+
+
+def _resolve_network_name(compose: PodmanCompose, net_name: str, net_desc: dict[str, Any]) -> str:
+    """Return the effective network name for config output."""
+    external_val = net_desc.get("external")
+    if isinstance(external_val, dict):
+        return external_val.get("name", net_name)
+    if external_val:
+        return net_name
+    return default_network_name_for_project(compose, net_name, False)
+
+
+def build_compose_config(compose: PodmanCompose) -> dict[str, Any]:
+    """
+    Build the effective compose configuration for the `config` command.
+
+    This reconstructs the compose file with runtime-resolved values:
+    - Default network injection for services without explicit networks
+    - Normalized network formats (list -> dict, empty dict -> None)
+    - Resolved network names (project-prefixed for created networks,
+      original name or custom external name for external networks)
+    - Top-level volumes and secrets included if present
+    """
+    config: dict[str, Any] = {"services": {}}
+    for name, service in compose.services.items():
+        config["services"][name] = compose.original_configuration(service)
+        _normalize_service_networks(config["services"][name], compose.default_net)
+
+    if compose.networks:
+        used_networks = _get_used_networks(compose.services, compose.default_net)
+        config_networks = {}
+        for net_name, net_desc in compose.networks.items():
+            if net_name in used_networks:
+                config_networks[net_name] = net_desc or {}
+                if "name" not in config_networks[net_name]:
+                    config_networks[net_name]["name"] = _resolve_network_name(
+                        compose, net_name, config_networks[net_name]
+                    )
+        if config_networks:
+            config["networks"] = config_networks
+
+    if compose.vols:
+        config["volumes"] = compose.vols
+    if compose.declared_secrets:
+        config["secrets"] = compose.declared_secrets
+    return config
+
+
 @cmd_run(podman_compose, "config", "displays the compose file")
 async def compose_config(compose: PodmanCompose, args: argparse.Namespace) -> None:
     if args.services:
@@ -4800,7 +4875,7 @@ async def compose_config(compose: PodmanCompose, args: argparse.Namespace) -> No
                 print(service)
         return
     if not args.quiet:
-        print(compose.merged_yaml)
+        print(yaml.safe_dump(build_compose_config(compose), sort_keys=False))
 
 
 @cmd_run(podman_compose, "port", "Prints the public port for a port binding.")

--- a/tests/integration/command_config/docker-compose_external_net.yaml
+++ b/tests/integration/command_config/docker-compose_external_net.yaml
@@ -1,0 +1,8 @@
+services:
+  test:
+    image: nopush/podman-compose-test
+    networks:
+      - extnet
+networks:
+  extnet:
+    external: true

--- a/tests/integration/command_config/docker-compose_network_mode.yaml
+++ b/tests/integration/command_config/docker-compose_network_mode.yaml
@@ -1,0 +1,4 @@
+services:
+  test:
+    image: nopush/podman-compose-test
+    network_mode: host

--- a/tests/integration/command_config/docker-compose_one_net.yaml
+++ b/tests/integration/command_config/docker-compose_one_net.yaml
@@ -1,0 +1,7 @@
+services:
+  test:
+    image: nopush/podman-compose-test
+    networks:
+      - net0
+networks:
+  net0:

--- a/tests/integration/command_config/test_podman_compose_config_command.py
+++ b/tests/integration/command_config/test_podman_compose_config_command.py
@@ -14,6 +14,10 @@ def compose_yaml_path() -> str:
     return os.path.join(base_path, "docker-compose.yml")
 
 
+def compose_yaml_path_scenario(scenario: str) -> str:
+    return os.path.join(test_path(), "command_config", f"docker-compose_{scenario}.yaml")
+
+
 class TestConfigCommand(unittest.TestCase, RunSubprocessMixin):
     def test_config_quiet(self) -> None:
         """
@@ -31,3 +35,66 @@ class TestConfigCommand(unittest.TestCase, RunSubprocessMixin):
 
         out, _ = self.run_subprocess_assert_returncode(config_cmd)
         self.assertEqual(out.decode("utf-8"), "")
+
+    def test_config_shows_networks_and_default_network(self) -> None:
+        config_cmd = [
+            podman_compose_path(),
+            "-f",
+            compose_yaml_path(),
+            "config",
+        ]
+
+        out, _ = self.run_subprocess_assert_returncode(config_cmd)
+        output = out.decode("utf-8")
+
+        self.assertIn("networks:", output)
+        self.assertIn("default:", output)
+
+    def test_config_with_named_network(self) -> None:
+        config_cmd = [
+            podman_compose_path(),
+            "-f",
+            compose_yaml_path_scenario("one_net"),
+            "config",
+        ]
+
+        out, _ = self.run_subprocess_assert_returncode(config_cmd)
+        output = out.decode("utf-8")
+
+        self.assertIn("networks:", output)
+        self.assertIn("net0:", output)
+        self.assertIn("command_config_net0", output)
+        self.assertNotIn("default:", output)
+
+    def test_config_with_external_network(self) -> None:
+        config_cmd = [
+            podman_compose_path(),
+            "-f",
+            compose_yaml_path_scenario("external_net"),
+            "config",
+        ]
+
+        out, _ = self.run_subprocess_assert_returncode(config_cmd)
+        output = out.decode("utf-8")
+
+        self.assertIn("networks:", output)
+        self.assertIn("extnet:", output)
+        self.assertIn("external: true", output)
+        self.assertNotIn("command_config_extnet", output)
+
+    def test_config_with_network_mode(self) -> None:
+        config_cmd = [
+            podman_compose_path(),
+            "-f",
+            compose_yaml_path_scenario("network_mode"),
+            "config",
+        ]
+
+        out, _ = self.run_subprocess_assert_returncode(config_cmd)
+        output = out.decode("utf-8")
+
+        self.assertIn("network_mode: host", output)
+        # The service itself must not have a networks key injected
+        service_section = output.split("services:")[1]
+        self.assertNotIn("networks:", service_section)
+        self.assertNotIn("default:", service_section)

--- a/tests/integration/command_config/test_podman_compose_config_command.py
+++ b/tests/integration/command_config/test_podman_compose_config_command.py
@@ -46,6 +46,7 @@ class TestConfigCommand(unittest.TestCase, RunSubprocessMixin):
         expected = textwrap.dedent("""\
             services:
               app:
+                image: nopush/podman-compose-test
                 command:
                 - /bin/busybox
                 - sh
@@ -53,7 +54,11 @@ class TestConfigCommand(unittest.TestCase, RunSubprocessMixin):
                 - env | grep ZZVAR3
                 environment:
                   ZZVAR3: TEST
-                image: nopush/podman-compose-test
+                networks:
+                  default: null
+            networks:
+              default:
+                name: command_config_default
 
             """)
         self.assertEqual(out.decode("utf-8"), expected)
@@ -74,4 +79,104 @@ class TestConfigCommand(unittest.TestCase, RunSubprocessMixin):
             b'please remove it to avoid potential confusion\n',
             err,
         )
-        self.assertEqual(out, b'services:\n  test:\n    image: nopush/podman-compose-test\n\n')
+        self.assertEqual(
+            out.decode("utf-8"),
+            'services:\n'
+            '  test:\n'
+            '    image: nopush/podman-compose-test\n'
+            '    networks:\n'
+            '      default: null\n'
+            'networks:\n'
+            '  default:\n'
+            '    name: command_config_default\n'
+            '\n',
+        )
+
+    def test_config_shows_networks_and_default_network(self) -> None:
+        out, _ = self.run_subprocess_assert_returncode(
+            [
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path(""),
+                "config",
+            ],
+            0,
+        )
+
+        self.assertEqual(
+            out.decode("utf-8"),
+            'services:\n'
+            '  test:\n'
+            '    image: nopush/podman-compose-test\n'
+            '    networks:\n'
+            '      default: null\n'
+            'networks:\n'
+            '  default:\n'
+            '    name: command_config_default\n'
+            '\n',
+        )
+
+    def test_config_with_named_network(self) -> None:
+        out, _ = self.run_subprocess_assert_returncode(
+            [
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path("_one_net"),
+                "config",
+            ],
+            0,
+        )
+
+        self.assertEqual(
+            out.decode("utf-8"),
+            'services:\n'
+            '  test:\n'
+            '    image: nopush/podman-compose-test\n'
+            '    networks:\n'
+            '      net0: null\n'
+            'networks:\n'
+            '  net0:\n'
+            '    name: command_config_net0\n'
+            '\n',
+        )
+
+    def test_config_with_external_network(self) -> None:
+        out, _ = self.run_subprocess_assert_returncode(
+            [
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path("_external_net"),
+                "config",
+            ],
+            0,
+        )
+        self.assertEqual(
+            out.decode("utf-8"),
+            'services:\n'
+            '  test:\n'
+            '    image: nopush/podman-compose-test\n'
+            '    networks:\n'
+            '      extnet: null\n'
+            'networks:\n'
+            '  extnet:\n'
+            '    external: true\n'
+            '    name: extnet\n'
+            '\n',
+        )
+
+    def test_config_with_network_mode(self) -> None:
+        out, _ = self.run_subprocess_assert_returncode(
+            [
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path("_network_mode"),
+                "config",
+            ],
+            0,
+        )
+
+        # The service itself must not have a networks key injected
+        self.assertEqual(
+            out.decode("utf-8"),
+            'services:\n  test:\n    image: nopush/podman-compose-test\n    network_mode: host\n\n',
+        )

--- a/tests/integration/compose_file_from_env/test_podman_compose_compose_file_from_env.py
+++ b/tests/integration/compose_file_from_env/test_podman_compose_compose_file_from_env.py
@@ -25,8 +25,13 @@ class TestComposeFileFromEnv(unittest.TestCase, RunSubprocessMixin):
             out.decode("utf-8"),
             'services:\n'
             '  dotenv-service:\n'
-            '    command: echo "from-dotenv"\n'
             '    image: nopush/podman-compose-test\n'
+            '    command: echo "from-dotenv"\n'
+            '    networks:\n'
+            '      default: null\n'
+            'networks:\n'
+            '  default:\n'
+            '    name: compose_file_from_env_default\n'
             '\n',
         )
 
@@ -47,8 +52,13 @@ class TestComposeFileFromEnv(unittest.TestCase, RunSubprocessMixin):
             out.decode("utf-8"),
             'services:\n'
             '  explicit-env-service:\n'
-            '    command: echo "from-explicit-env"\n'
             '    image: nopush/podman-compose-test\n'
+            '    command: echo "from-explicit-env"\n'
+            '    networks:\n'
+            '      default: null\n'
+            'networks:\n'
+            '  default:\n'
+            '    name: compose_file_from_env_default\n'
             '\n',
         )
 
@@ -70,8 +80,13 @@ class TestComposeFileFromEnv(unittest.TestCase, RunSubprocessMixin):
             out.decode("utf-8"),
             'services:\n'
             '  explicit-service:\n'
-            '    command: echo "explicit"\n'
             '    image: nopush/podman-compose-test\n'
+            '    command: echo "explicit"\n'
+            '    networks:\n'
+            '      default: null\n'
+            'networks:\n'
+            '  default:\n'
+            '    name: compose_file_from_env_default\n'
             '\n',
         )
 
@@ -84,12 +99,18 @@ class TestComposeFileFromEnv(unittest.TestCase, RunSubprocessMixin):
             env={"COMPOSE_FILE": str(base_path / "docker-compose-var.yml")},
             cwd=base_path,
         )
+
         self.assertEqual(
             out.decode("utf-8"),
             'services:\n'
             '  var-service:\n'
-            '    command: echo "var"\n'
             '    image: nopush/podman-compose-test\n'
+            '    command: echo "var"\n'
+            '    networks:\n'
+            '      default: null\n'
+            'networks:\n'
+            '  default:\n'
+            '    name: compose_file_from_env_default\n'
             '\n',
         )
 

--- a/tests/integration/include_relative_paths/test_podman_compose_include_relative_paths.py
+++ b/tests/integration/include_relative_paths/test_podman_compose_include_relative_paths.py
@@ -39,17 +39,20 @@ class TestIncludeRelativePaths(unittest.TestCase, RunSubprocessMixin):
         ])
 
         expected = textwrap.dedent("""\
-            name: include-relative-paths
             services:
               web:
+                image: nopush/podman-compose-test
                 env_file:
                 - ./sub/./local.env
                 - ./sub/../shared.env
-                image: nopush/podman-compose-test
                 volumes:
                 - ./sub/./data:/data:ro
                 - ./sub/../assets:/assets:ro
-            version: '3.6'
+                networks:
+                  default: null
+            networks:
+              default:
+                name: include-relative-paths_default
 
             """)
         self.assertEqual(out.decode("utf-8"), expected)

--- a/tests/integration/include_relative_paths/test_podman_compose_include_relative_paths.py
+++ b/tests/integration/include_relative_paths/test_podman_compose_include_relative_paths.py
@@ -39,16 +39,20 @@ class TestIncludeRelativePaths(unittest.TestCase, RunSubprocessMixin):
         ])
 
         expected = textwrap.dedent("""\
-            name: include-relative-paths
             services:
               web:
+                image: nopush/podman-compose-test
                 env_file:
                 - ./sub/./local.env
                 - ./sub/../shared.env
-                image: nopush/podman-compose-test
                 volumes:
                 - ./sub/./data:/data:ro
                 - ./sub/../assets:/assets:ro
+                networks:
+                  default: null
+            networks:
+              default:
+                name: include-relative-paths_default
 
             """)
         self.assertEqual(out.decode("utf-8"), expected)

--- a/tests/unit/test_build_compose_config.py
+++ b/tests/unit/test_build_compose_config.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: GPL-2.0
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from podman_compose import build_compose_config
+
+
+class TestBuildComposeConfig(unittest.TestCase):
+    def _create_compose_mock(
+        self,
+        services: dict | None = None,
+        networks: dict | None = None,
+        default_net: str | None = "default",
+    ) -> mock.Mock:
+        compose = mock.Mock()
+        compose.project_name = "test_project"
+        compose.services = services or {}
+        compose.networks = networks or {}
+        compose.default_net = default_net
+        compose.vols = {}
+        compose.declared_secrets = {}
+        compose.original_configuration = lambda x: x
+        return compose
+
+    def test_default_network_injected_when_service_has_no_networks(self) -> None:
+        compose = self._create_compose_mock(
+            services={"web": {"image": "nginx"}},
+            networks={"default": None},
+            default_net="default",
+        )
+        config = build_compose_config(compose)
+        self.assertEqual(config["services"]["web"]["networks"], {"default": None})
+
+    def test_no_default_network_injected_when_service_has_network_mode(self) -> None:
+        compose = self._create_compose_mock(
+            services={"web": {"image": "nginx", "network_mode": "host"}},
+            networks={"default": None},
+            default_net="default",
+        )
+        config = build_compose_config(compose)
+        self.assertNotIn("networks", config["services"]["web"])
+        self.assertEqual(config["services"]["web"]["network_mode"], "host")
+
+    def test_no_default_network_injected_when_service_has_networks(self) -> None:
+        compose = self._create_compose_mock(
+            services={"web": {"image": "nginx", "networks": {"custom": None}}},
+            networks={"custom": None},
+            default_net=None,
+        )
+        config = build_compose_config(compose)
+        self.assertEqual(config["services"]["web"]["networks"], {"custom": None})
+        self.assertNotIn("default", config["services"]["web"])
+
+    def test_non_external_network_gets_project_name(self) -> None:
+        compose = self._create_compose_mock(
+            services={"web": {"image": "nginx"}},
+            networks={"default": None},
+            default_net="default",
+        )
+        compose.format_name = mock.Mock(return_value="test_project_default")
+        config = build_compose_config(compose)
+        self.assertEqual(config["networks"]["default"]["name"], "test_project_default")
+
+    def test_external_network_does_not_get_project_name(self) -> None:
+        compose = self._create_compose_mock(
+            services={"web": {"image": "nginx"}},
+            networks={"ext": {"external": True}},
+            default_net=None,
+        )
+        config = build_compose_config(compose)
+        self.assertNotIn("networks", config)
+
+    def test_external_network_gets_original_name(self) -> None:
+        compose = self._create_compose_mock(
+            services={"web": {"image": "nginx", "networks": ["ext"]}},
+            networks={"ext": {"external": True}},
+            default_net=None,
+        )
+        compose.format_name = mock.Mock(return_value="test_project_ext")
+        config = build_compose_config(compose)
+        self.assertEqual(config["networks"]["ext"]["name"], "ext")
+        self.assertTrue(config["networks"]["ext"]["external"])
+
+    def test_list_networks_converted_to_dict(self) -> None:
+        compose = self._create_compose_mock(
+            services={"web": {"image": "nginx", "networks": ["net0"]}},
+            networks={"net0": None},
+            default_net=None,
+        )
+        config = build_compose_config(compose)
+        self.assertEqual(config["services"]["web"]["networks"], {"net0": None})
+
+    def test_dict_networks_with_empty_dict_converted_to_null(self) -> None:
+        compose = self._create_compose_mock(
+            services={"web": {"image": "nginx", "networks": {"net0": {}}}},
+            networks={"net0": None},
+            default_net=None,
+        )
+        config = build_compose_config(compose)
+        self.assertEqual(config["services"]["web"]["networks"], {"net0": None})
+
+    def test_dict_networks_with_values_preserved(self) -> None:
+        compose = self._create_compose_mock(
+            services={"web": {"image": "nginx", "networks": {"net0": {"aliases": ["web"]}}}},
+            networks={"net0": None},
+            default_net=None,
+        )
+        config = build_compose_config(compose)
+        self.assertEqual(config["services"]["web"]["networks"], {"net0": {"aliases": ["web"]}})

--- a/tests/unit/test_build_compose_config.py
+++ b/tests/unit/test_build_compose_config.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: GPL-2.0
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from podman_compose import build_compose_config
+
+
+class TestBuildComposeConfig(unittest.TestCase):
+    def _create_compose_mock(
+        self,
+        services: dict | None = None,
+        networks: dict | None = None,
+        default_net: str | None = "default",
+        vols: dict | None = None,
+        declared_secrets: dict | None = None,
+    ) -> mock.Mock:
+        compose = mock.Mock()
+        compose.project_name = "test_project"
+        compose.services = services or {}
+        compose.networks = networks or {}
+        compose.default_net = default_net
+        compose.vols = vols or {}
+        compose.declared_secrets = declared_secrets or {}
+        compose.original_configuration = lambda x: x
+        return compose
+
+    def test_default_network_injected_when_service_has_no_networks(self) -> None:
+        compose = self._create_compose_mock(
+            services={"web": {"image": "nginx"}},
+            networks={"default": None},
+            default_net="default",
+        )
+        config = build_compose_config(compose)
+        self.assertEqual(config["services"]["web"]["networks"], {"default": None})
+
+    def test_no_default_network_injected_when_service_has_network_mode(self) -> None:
+        compose = self._create_compose_mock(
+            services={"web": {"image": "nginx", "network_mode": "host"}},
+            networks={"default": None},
+            default_net="default",
+        )
+        config = build_compose_config(compose)
+        self.assertNotIn("networks", config["services"]["web"])
+        self.assertEqual(config["services"]["web"]["network_mode"], "host")
+
+    def test_no_default_network_injected_when_service_has_networks(self) -> None:
+        compose = self._create_compose_mock(
+            services={"web": {"image": "nginx", "networks": {"custom": None}}},
+            networks={"custom": None},
+            default_net=None,
+        )
+        config = build_compose_config(compose)
+        self.assertEqual(config["services"]["web"]["networks"], {"custom": None})
+        self.assertNotIn("default", config["services"]["web"])
+
+    def test_non_external_network_gets_project_name(self) -> None:
+        compose = self._create_compose_mock(
+            services={"web": {"image": "nginx"}},
+            networks={"default": None},
+            default_net="default",
+        )
+        compose.format_name = mock.Mock(return_value="test_project_default")
+        config = build_compose_config(compose)
+        self.assertEqual(config["networks"]["default"]["name"], "test_project_default")
+
+    def test_unused_external_network_is_omitted(self) -> None:
+        compose = self._create_compose_mock(
+            services={"web": {"image": "nginx"}},
+            networks={"ext": {"external": True}},
+            default_net=None,
+        )
+        config = build_compose_config(compose)
+        self.assertNotIn("networks", config)
+
+    def test_external_network_gets_original_name(self) -> None:
+        compose = self._create_compose_mock(
+            services={"web": {"image": "nginx", "networks": ["ext"]}},
+            networks={"ext": {"external": True}},
+            default_net=None,
+        )
+        compose.format_name = mock.Mock(return_value="test_project_ext")
+        config = build_compose_config(compose)
+        self.assertEqual(config["networks"]["ext"]["name"], "ext")
+        self.assertTrue(config["networks"]["ext"]["external"])
+
+    def test_external_network_dict_with_custom_name(self) -> None:
+        compose = self._create_compose_mock(
+            services={"web": {"image": "nginx", "networks": ["ext"]}},
+            networks={"ext": {"external": {"name": "actual-net"}}},
+            default_net=None,
+        )
+        config = build_compose_config(compose)
+        self.assertEqual(config["networks"]["ext"]["name"], "actual-net")
+        self.assertEqual(config["networks"]["ext"]["external"], {"name": "actual-net"})
+
+    def test_list_networks_converted_to_dict(self) -> None:
+        compose = self._create_compose_mock(
+            services={"web": {"image": "nginx", "networks": ["net0"]}},
+            networks={"net0": None},
+            default_net=None,
+        )
+        config = build_compose_config(compose)
+        self.assertEqual(config["services"]["web"]["networks"], {"net0": None})
+
+    def test_dict_networks_with_empty_dict_converted_to_null(self) -> None:
+        compose = self._create_compose_mock(
+            services={"web": {"image": "nginx", "networks": {"net0": {}}}},
+            networks={"net0": None},
+            default_net=None,
+        )
+        config = build_compose_config(compose)
+        self.assertEqual(config["services"]["web"]["networks"], {"net0": None})
+
+    def test_dict_networks_with_values_preserved(self) -> None:
+        compose = self._create_compose_mock(
+            services={"web": {"image": "nginx", "networks": {"net0": {"aliases": ["web"]}}}},
+            networks={"net0": None},
+            default_net=None,
+        )
+        config = build_compose_config(compose)
+        self.assertEqual(config["services"]["web"]["networks"], {"net0": {"aliases": ["web"]}})
+
+    def test_network_mode_none_no_default_network_injected(self) -> None:
+        compose = self._create_compose_mock(
+            services={"web": {"image": "nginx", "network_mode": "none"}},
+            networks={"default": None},
+            default_net="default",
+        )
+        config = build_compose_config(compose)
+        self.assertNotIn("networks", config["services"]["web"])
+        self.assertEqual(config["services"]["web"]["network_mode"], "none")
+
+    def test_volumes_propagated_to_config(self) -> None:
+        compose = self._create_compose_mock(
+            services={"web": {"image": "nginx"}},
+            vols={"data": {"driver": "local"}},
+        )
+        config = build_compose_config(compose)
+        self.assertEqual(config["volumes"], {"data": {"driver": "local"}})
+
+    def test_secrets_propagated_to_config(self) -> None:
+        compose = self._create_compose_mock(
+            services={"web": {"image": "nginx"}},
+            declared_secrets={"my_secret": {"external": True}},
+        )
+        config = build_compose_config(compose)
+        self.assertEqual(config["secrets"], {"my_secret": {"external": True}})


### PR DESCRIPTION
Previously `podman-compose config` omitted the `networks` section and did not reflect runtime network resolution such as default network injection. Now it outputs the effective network configuration, including created and external networks with correct names, matching actual compose behavior.

Fixes https://github.com/containers/podman-compose/issues/623.
