### PR TITLE
Use `PodmanComposeError` for build validation failures

### DIFF
--- a/newsfragments/use_podman_compose_error_for_build.bugfix
+++ b/newsfragments/use_podman_compose_error_for_build.bugfix
@@ -1,0 +1,1 @@
+Use `PodmanComposeError` instead of generic `OSError` when build-related validation fails.

--- a/newsfragments/use_podman_compose_error_for_build.bugfix
+++ b/newsfragments/use_podman_compose_error_for_build.bugfix
@@ -1,0 +1,1 @@
+Use PodmanComposeError instead of a generic OSError when build-related validation fails to avoid printing the whole traceback.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -3567,7 +3567,9 @@ def container_to_build_args(
         dockerfile_inline = str(dockerfile_inline)
         # Error if both `dockerfile_inline` and `dockerfile` are set
         if dockerfile and dockerfile_inline:
-            raise OSError("dockerfile_inline and dockerfile can't be used simultaneously")
+            raise PodmanComposeError(
+                "dockerfile_inline and dockerfile can't be used simultaneously"
+            )
         dockerfile = tempfile.NamedTemporaryFile(delete=False, suffix=".containerfile")
         dockerfile.write(dockerfile_inline.encode())
         dockerfile.close()
@@ -3608,8 +3610,8 @@ def container_to_build_args(
         else:
             if custom_dockerfile_given:
                 # custom dockerfile name was also not found in the file system
-                raise OSError(f"Dockerfile not found in {dockerfile}")
-            raise OSError(f"Dockerfile not found in {ctx}")
+                raise PodmanComposeError(f"Dockerfile not found in {dockerfile}")
+            raise PodmanComposeError(f"Dockerfile not found in {ctx}")
 
     elif dockerfile:
         build_args.extend(["-f", dockerfile])

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -3594,7 +3594,9 @@ def container_to_build_args(
         dockerfile_inline = str(dockerfile_inline)
         # Error if both `dockerfile_inline` and `dockerfile` are set
         if dockerfile and dockerfile_inline:
-            raise OSError("dockerfile_inline and dockerfile can't be used simultaneously")
+            raise PodmanComposeError(
+                "dockerfile_inline and dockerfile can't be used simultaneously"
+            )
         dockerfile = tempfile.NamedTemporaryFile(delete=False, suffix=".containerfile")
         dockerfile.write(dockerfile_inline.encode())
         dockerfile.close()
@@ -3635,8 +3637,8 @@ def container_to_build_args(
         else:
             if custom_dockerfile_given:
                 # custom dockerfile name was also not found in the file system
-                raise OSError(f"Dockerfile not found in {dockerfile}")
-            raise OSError(f"Dockerfile not found in {ctx}")
+                raise PodmanComposeError(f"Dockerfile not found in {dockerfile}")
+            raise PodmanComposeError(f"Dockerfile not found in {ctx}")
 
     elif dockerfile:
         build_args.extend(["-f", dockerfile])

--- a/tests/integration/build_fail/test_podman_compose_build_fail.py
+++ b/tests/integration/build_fail/test_podman_compose_build_fail.py
@@ -45,7 +45,7 @@ class TestComposeBuildFail(unittest.TestCase, RunSubprocessMixin):
         result = '\n'.join(error.splitlines()[-1:])
 
         expected_path = os.path.join(os.path.dirname(__file__), "context_no_file")
-        expected = f'OSError: Dockerfile not found in {expected_path}'
+        expected = f'Error: Dockerfile not found in {expected_path}'
 
         self.assertEqual(expected, result)
 
@@ -64,6 +64,6 @@ class TestComposeBuildFail(unittest.TestCase, RunSubprocessMixin):
         result = '\n'.join(error.splitlines()[-1:])
 
         expected_path = os.path.join(os.path.dirname(__file__), "context_no_file/Dockerfile-alt")
-        expected = f'OSError: Dockerfile not found in {expected_path}'
+        expected = f'Error: Dockerfile not found in {expected_path}'
 
         self.assertEqual(expected, result)

--- a/tests/unit/test_container_to_build_args.py
+++ b/tests/unit/test_container_to_build_args.py
@@ -4,6 +4,7 @@ import os
 import unittest
 from unittest import mock
 
+from podman_compose import PodmanComposeError
 from podman_compose import container_to_build_args
 
 
@@ -223,7 +224,7 @@ class TestContainerToBuildArgs(unittest.TestCase):
         cnt['build']['context'] = "not_prefix://github.com/test_repo"
         args = get_minimal_args()
 
-        with self.assertRaises(OSError):
+        with self.assertRaises(PodmanComposeError):
             container_to_build_args(c, cnt, args, lambda path: False)
 
     def test_build_ssh_absolute_path(self):


### PR DESCRIPTION
This PR replaces generic OSError with PodmanComposeError in container_to_build_args() when the Dockerfile is missing from the build context or from a custom path, or when both `dockerfile` and `dockerfile_inline` are specified, which prevents printing the whole traceback.

Fixes https://github.com/containers/podman-compose/issues/1515.

