### PR TITLE
Honor `container_name` in podman-compose `run`

### DIFF
--- a/newsfragments/command_run_honor_container_name.bugfix
+++ b/newsfragments/command_run_honor_container_name.bugfix
@@ -1,0 +1,1 @@
+`podman-compose run` now honors the `container_name` service-level element from the compose file when no `--name` CLI argument is provided.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -4569,7 +4569,7 @@ def compose_run_update_container_from_args(
 ) -> None:
     # adjust one-off container options
     name0 = compose.format_name(args.service, f'tmp{random.randrange(0, 65536)}')
-    cnt["name"] = args.name or name0
+    cnt["name"] = args.name or cnt.get("container_name") or name0
     if args.entrypoint:
         cnt["entrypoint"] = args.entrypoint
     if args.user:

--- a/tests/integration/container_name_run/docker-compose.yml
+++ b/tests/integration/container_name_run/docker-compose.yml
@@ -1,0 +1,5 @@
+services:
+  test:
+    image: nopush/podman-compose-test
+    container_name: my_custom_run_container
+    command: ["echo", "hello"]

--- a/tests/integration/container_name_run/test_container_name_run.py
+++ b/tests/integration/container_name_run/test_container_name_run.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: GPL-2.0
+
+import os
+import unittest
+
+from tests.integration.test_utils import RunSubprocessMixin
+from tests.integration.test_utils import podman_compose_path
+from tests.integration.test_utils import test_path
+
+
+def compose_yaml_path() -> str:
+    return os.path.join(os.path.join(test_path(), "container_name_run"), "docker-compose.yml")
+
+
+class TestContainerNameRun(unittest.TestCase, RunSubprocessMixin):
+    def setUp(self) -> None:
+        # Clean up any leftover containers from previous runs
+        self.run_subprocess(
+            [
+                "podman",
+                "rm",
+                "-f",
+                "my_custom_run_container",
+                "cli_override_name",
+            ],
+        )
+        self.run_subprocess(
+            [
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path(),
+                "down",
+            ],
+        )
+
+    def tearDown(self) -> None:
+        self.run_subprocess(
+            [
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path(),
+                "down",
+            ],
+        )
+
+    def test_run_uses_container_name(self) -> None:
+        self.run_subprocess_assert_returncode(
+            [
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path(),
+                "run",
+                "test",
+            ],
+            0,
+        )
+        out, _ = self.run_subprocess_assert_returncode(
+            [
+                "podman",
+                "ps",
+                "-a",
+                "--filter",
+                "label=io.podman.compose.project=container_name_run",
+                "--format",
+                "{{.Names}}",
+            ],
+            0,
+        )
+        self.assertEqual(b'my_custom_run_container\n', out)
+
+    def test_run_cli_name_overrides_container_name(self) -> None:
+        self.run_subprocess_assert_returncode(
+            [
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path(),
+                "run",
+                "--name",
+                "cli_override_name",
+                "test",
+            ],
+            0,
+        )
+        out, _ = self.run_subprocess_assert_returncode(
+            [
+                "podman",
+                "ps",
+                "-a",
+                "--filter",
+                "label=io.podman.compose.project=container_name_run",
+                "--format",
+                "{{.Names}}",
+            ],
+            0,
+        )
+        self.assertEqual(b'cli_override_name\n', out)

--- a/tests/unit/test_compose_run_update_container_from_args.py
+++ b/tests/unit/test_compose_run_update_container_from_args.py
@@ -50,6 +50,47 @@ class TestComposeRunUpdateContainerFromArgs(unittest.TestCase):
         }
         self.assertEqual(cnt, expected_cnt)
 
+    def test_container_name_from_compose(self) -> None:
+        cnt = {"container_name": "compose_custom_name"}
+        compose = get_minimal_compose()
+        args = get_minimal_args()
+        args.name = None
+
+        compose_run_update_container_from_args(compose, cnt, args)
+
+        expected_cnt = {
+            "container_name": "compose_custom_name",
+            "name": "compose_custom_name",
+            "tty": True,
+        }
+        self.assertEqual(cnt, expected_cnt)
+
+    def test_cli_name_overrides_container_name(self) -> None:
+        cnt = {"container_name": "compose_custom_name"}
+        compose = get_minimal_compose()
+        args = get_minimal_args()
+        args.name = "cli_override_name"
+
+        compose_run_update_container_from_args(compose, cnt, args)
+
+        expected_cnt = {
+            "container_name": "compose_custom_name",
+            "name": "cli_override_name",
+            "tty": True,
+        }
+        self.assertEqual(cnt, expected_cnt)
+
+    def test_fallback_to_generated_name(self) -> None:
+        cnt = get_minimal_container()
+        compose = get_minimal_compose()
+        args = get_minimal_args()
+        args.name = None
+
+        compose_run_update_container_from_args(compose, cnt, args)
+
+        self.assertTrue(cnt["name"].startswith("test_project_test_service_tmp"))
+        self.assertEqual(cnt["tty"], True)
+
 
 def get_minimal_container() -> dict:
     return {}


### PR DESCRIPTION
Before this fix, `podman-compose run` always generated a random temporary container name, ignoring the `container_name` field defined in the compose file.
Now it respects `container_name` when no `--name` CLI override is given, matching the behavior of `docker-compose run`.

Fixes https://github.com/containers/podman-compose/issues/1430