### PR TITLE
Add x-podman.passwd extension

### DIFF
--- a/docs/Extensions.md
+++ b/docs/Extensions.md
@@ -16,6 +16,8 @@ container is assumed to be managed externally.
 
 * `x-podman.no_hosts` - Run the container without creating /etc/hosts file
 
+* `x-podman.passwd` - Allow Podman to add entries to /etc/passwd and /etc/group when used in conjunction with the --user option. Defaults to true.
+
 For example, the following docker-compose.yml allows running a podman container with externally managed rootfs.
 ```yml
 version: "3"

--- a/newsfragments/passwd_extension.feature
+++ b/newsfragments/passwd_extension.feature
@@ -1,0 +1,1 @@
+Add x-podman.passwd extension to control the --passwd flag for podman run

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1597,6 +1597,9 @@ async def container_to_args(
         podman_args.extend(["--gidmap", gidmap])
     if cnt.get("x-podman.no_hosts", False):
         podman_args.extend(["--no-hosts"])
+    if "x-podman.passwd" in cnt:
+        # --passwd defaults to true
+        podman_args.extend([f"--passwd={'false' if not cnt['x-podman.passwd'] else 'true'}"])
     rootfs = cnt.get('x-podman.rootfs')
     if rootfs is not None:
         rootfs_mode = True

--- a/tests/unit/test_container_to_args.py
+++ b/tests/unit/test_container_to_args.py
@@ -288,6 +288,24 @@ class TestContainerToArgs(unittest.IsolatedAsyncioTestCase):
             ],
         )
 
+    async def test_passwd_extension(self) -> None:
+        c = create_compose_mock()
+
+        cnt = get_minimal_container()
+        cnt["x-podman.passwd"] = False
+
+        args = await container_to_args(c, cnt)
+        self.assertEqual(
+            args,
+            [
+                "--name=project_name_service_name1",
+                "-d",
+                "--network=bridge:alias=service_name",
+                "--passwd=false",
+                "busybox",
+            ],
+        )
+
     @parameterized.expand([
         # short syntax: only take this specific environment variable value from .env file
         ("use_env_var_from_default_env_file_short_syntax", ["ZZVAR1"], "ZZVAR1=TEST1"),


### PR DESCRIPTION
This allows controlling the --passwd flag for podman run. This flag defaults to true, so keep the default unless set explicitly to false.

Fixes #1448