### PR TITLE
examples: Make busybox example ports accessible and podman-compatible

### DIFF
--- a/examples/busybox/docker-compose.yaml
+++ b/examples/busybox/docker-compose.yaml
@@ -1,16 +1,15 @@
-version: "2"
 services:
 
     redis:
-      image: redis:alpine
+      image: docker.io/redis:alpine
       ports:
-        - "6379"
+        - "6379:6379"
       environment:
         - SECRET_KEY=aabbcc
         - ENV_IS_SET
 
     frontend:
-      image: busybox
+      image: docker.io/library/busybox:latest
       #entrypoint: []
       command: ["/bin/busybox", "httpd", "-f", "-p", "8080"]
       working_dir: /
@@ -18,7 +17,7 @@ services:
         SECRET_KEY2: aabbcc
         ENV_IS_SET2:
       ports:
-        - "8080"
+        - "8080:8080"
       links:
         - redis:myredis
       labels:


### PR DESCRIPTION
The busybox example used short port syntax ("8080" and "6379") which exposes container ports on random ephemeral host ports. This is valid compose syntax, but it makes the example confusing because users expect to reach services at `localhost:8080` and `localhost:6379`. Now `podman-compose up` in `examples/busybox/` works exactly as a new user would expect.

Fixes https://github.com/containers/podman-compose/issues/274.