### PR TITLE
Add support for `uts` compose key

### DIFF
--- a/newsfragments/add_uts.feature
+++ b/newsfragments/add_uts.feature
@@ -1,0 +1,1 @@
+Maps the `uts` service option to podman's `--uts` flag.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1491,6 +1491,8 @@ async def container_to_args(
         podman_args.append("--privileged")
     if cnt.get("pid"):
         podman_args.extend(["--pid", cnt["pid"]])
+    if cnt.get("uts"):
+        podman_args.extend(["--uts", cnt["uts"]])
     pull_policy = cnt.get("pull_policy")
     if pull_policy is not None and pull_policy != "build":
         podman_args.append(f"--pull={pull_policy}")

--- a/tests/integration/uts/docker-compose.yml
+++ b/tests/integration/uts/docker-compose.yml
@@ -1,0 +1,6 @@
+version: "3"
+services:
+  serv:
+    image: busybox
+    uts: host
+    command: sh -c "cat /proc/sys/kernel/hostname"

--- a/tests/unit/test_container_to_args.py
+++ b/tests/unit/test_container_to_args.py
@@ -182,6 +182,25 @@ class TestContainerToArgs(unittest.IsolatedAsyncioTestCase):
             ],
         )
 
+    async def test_uts(self) -> None:
+        c = create_compose_mock()
+        cnt = get_minimal_container()
+
+        cnt["uts"] = "host"
+
+        args = await container_to_args(c, cnt)
+        self.assertEqual(
+            args,
+            [
+                "--name=project_name_service_name1",
+                "-d",
+                "--network=bridge:alias=service_name",
+                "--uts",
+                "host",
+                "busybox",
+            ],
+        )
+
     async def test_http_proxy(self) -> None:
         c = create_compose_mock()
 


### PR DESCRIPTION
Added the `uts` key in compose file, mirroring how PID is handled.

Spec: https://github.com/compose-spec/compose-spec/blob/main/05-services.md#uts
