### PR TITLE
Forward SELinux relabel flags for non-bind mounts

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -667,6 +667,14 @@ def mount_desc_to_mount_args(mount_desc: dict[str, Any]) -> str:
         selinux = bind_opts.get("selinux")
         if selinux is not None:
             opts.append(selinux)
+    else:
+        # The short syntax parser stores a z/Z relabel flag as a bind propagation,
+        # but relabeling applies to every mount type, so forward it here as
+        # mount_desc_to_volume_args() already does for the -v syntax.
+        bind_opts = mount_desc.get("bind", {})
+        for opt in filteri(bind_opts.get("propagation", "").split(",")):
+            if opt in ("z", "Z"):
+                opts.append(opt)
 
     # According to compose specifications https://docs.docker.com/reference/compose-file/services/#volumes
     # subpath can be used in image and volume mount type

--- a/tests/unit/test_container_to_args.py
+++ b/tests/unit/test_container_to_args.py
@@ -667,6 +667,37 @@ class TestContainerToArgs(unittest.IsolatedAsyncioTestCase):
             ],
         )
 
+    @parameterized.expand([
+        ("z", "type=volume,source=volname,destination=/mnt,z"),
+        ("Z", "type=volume,source=volname,destination=/mnt,Z"),
+    ])
+    async def test_selinux_named_volume_short_syntax(
+        self, selinux_type: str, expected_mount_arg: str
+    ) -> None:
+        c = create_compose_mock()
+        c.vols = {"volname": {"name": "volname"}}
+
+        cnt = get_minimal_container()
+
+        # This is supposed to happen during `_parse_compose_file`
+        # but that is probably getting skipped during testing
+        cnt["_service"] = cnt["service_name"]
+
+        cnt["volumes"] = [f"volname:/mnt:{selinux_type}"]
+
+        args = await container_to_args(c, cnt)
+        self.assertEqual(
+            args,
+            [
+                "--name=project_name_service_name1",
+                "-d",
+                "--mount",
+                expected_mount_arg,
+                "--network=bridge:alias=service_name",
+                "busybox",
+            ],
+        )
+
     async def test_volumes_glob_mount_source(self) -> None:
         c = create_compose_mock()
         cnt = get_minimal_container()


### PR DESCRIPTION
Closes #1516

## Contributor Checklist:

Please make sure to read development guidelines in CONTRIBUTING.md.

Compose spec for the short volume syntax the relabel flag comes from:
https://github.com/compose-spec/compose-spec/blob/main/spec.md#short-syntax-5

For any user-visible change please add a release note to newsfragments directory.

I could not add the `newsfragments/*.bugfix` file from my side; please tell me if you want me to
push one, or feel free to add it with this text: "The SELinux relabel flags `z` and `Z` given in
the short volume syntax are no longer dropped for named volumes when the mount is passed to podman
as `--mount`."

All changes require additional unit tests.

Added `test_selinux_named_volume_short_syntax` in `tests/unit/test_container_to_args.py`, next to
the existing `test_selinux_volume`. It fails on main (the `,Z` is missing from the generated
`--mount` argument) and passes with the fix; `python -m unittest discover tests/unit` is green
(480 tests), and `ruff format --check` / `ruff check` are clean on both changed files.

---

`parse_short_mount` stores the `z`/`Z` of `db:/var/lib/mysql:Z` as a bind propagation option. Since
`--mount` became the default for named volumes, `mount_desc_to_mount_args()` only read the selinux
option for bind mounts, so the relabel flag was silently dropped — which is the 1.5.0 → 1.6.0
regression reported in #1516. This forwards `z`/`Z` for the other mount types too, mirroring what
`mount_desc_to_volume_args()` already does for the `-v` syntax.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
