### PR TITLE
Warn and drop the broken healthcheck.start_interval mapping

### DIFF
--- a/newsfragments/start_interval_unsupported.bugfix
+++ b/newsfragments/start_interval_unsupported.bugfix
@@ -1,0 +1,1 @@
+Stop translating Compose `healthcheck.start_interval` to the unrelated Podman `--health-startup-interval` flag (which belongs to a separate startup-healthcheck mechanism). The field is now reported as unsupported with a warning until Podman gains a native equivalent (containers/podman#26505). Fixes #1500.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1574,7 +1574,7 @@ async def container_to_args(
         else:
             raise ValueError("'healthcheck.test' either a string or a list")
 
-    # interval, timeout, start_period, and start_interval are specified as durations.
+    # interval, timeout, and start_period are specified as durations.
     if "interval" in healthcheck:
         podman_args.extend(["--health-interval", healthcheck["interval"]])
     if "timeout" in healthcheck:
@@ -1582,7 +1582,22 @@ async def container_to_args(
     if "start_period" in healthcheck:
         podman_args.extend(["--health-start-period", healthcheck["start_period"]])
     if "start_interval" in healthcheck:
-        podman_args.extend(["--health-startup-interval", healthcheck["start_interval"]])
+        # The previous mapping translated start_interval to
+        # --health-startup-interval, but that Podman flag belongs to a
+        # separate startup-healthcheck mechanism gated by --health-startup-cmd
+        # (which podman-compose does not generate), so the Compose-spec
+        # semantics of start_interval were silently lost. Podman does not yet
+        # provide a direct equivalent (see containers/podman#26505), so warn
+        # the user and drop the broken mapping. Re-enable once the Podman
+        # native equivalent lands.
+        log.warning(
+            "Compose 'healthcheck.start_interval' is currently not supported "
+            "by podman-compose: Podman has no equivalent for the "
+            "startup-period interval yet (see containers/podman#26505); the "
+            "field %r is being ignored for service %r.",
+            healthcheck["start_interval"],
+            cnt.get("name", cnt.get("service_name", "?")),
+        )
 
     # convert other parameters to string
     if "retries" in healthcheck:

--- a/tests/unit/test_container_to_args.py
+++ b/tests/unit/test_container_to_args.py
@@ -1189,7 +1189,6 @@ class TestContainerToArgs(unittest.IsolatedAsyncioTestCase):
             "timeout": "10s",
             "retries": "3",
             "start_period": "5s",
-            "start_interval": "6s",
         }
 
         args = await container_to_args(c, cnt)
@@ -1207,13 +1206,36 @@ class TestContainerToArgs(unittest.IsolatedAsyncioTestCase):
                 '10s',
                 '--health-start-period',
                 '5s',
-                '--health-startup-interval',
-                '6s',
                 '--health-retries',
                 '3',
                 "busybox",
             ],
         )
+
+    async def test_healthcheck_start_interval_warns_and_omits_podman_flag(self) -> None:
+        """``start_interval`` has no Podman equivalent yet (containers/podman#26505).
+
+        The old behaviour silently mapped it to ``--health-startup-interval``,
+        but that flag belongs to a different mechanism gated by
+        ``--health-startup-cmd`` (which podman-compose never emits), so the
+        Compose-spec semantics were lost. The current contract is: emit a
+        warning, do not pass any ``--health-startup-interval`` flag.
+        """
+        c = create_compose_mock()
+        cnt = get_minimal_container()
+        cnt["healthcheck"] = {
+            "test": ["CMD", "true"],
+            "start_interval": "1s",
+        }
+
+        with self.assertLogs("podman_compose", level="WARNING") as cm:
+            args = await container_to_args(c, cnt)
+
+        self.assertTrue(
+            any("start_interval" in msg for msg in cm.output),
+            f"expected a warning mentioning start_interval, got: {cm.output!r}",
+        )
+        self.assertNotIn("--health-startup-interval", args)
 
     @parameterized.expand([
         "",


### PR DESCRIPTION
## Summary

Fix the silent mistranslation of `healthcheck.start_interval` to the Podman flag `--health-startup-interval`.

The two have different semantics:

- Compose `start_interval` changes the interval of the regular healthcheck during `start_period`.
- Podman `--health-startup-interval` belongs to a separate startup-healthcheck mechanism gated by `--health-startup-cmd`, which podman-compose does not generate.

So `start_interval` was being silently dropped from the user's intent, and the existing unit test only checked the generated CLI string rather than the resulting schedule.

This PR stops the broken translation and emits a `log.warning(...)` explaining that `start_interval` is not currently supported, so users get an explicit signal instead of silent loss of behaviour. The mapping can be re-enabled once Podman ships a native equivalent (tracked in [containers/podman#26505](https://github.com/containers/podman/issues/26505)).

Compose spec reference for `healthcheck.start_interval`:
https://github.com/compose-spec/compose-spec/blob/main/spec.md#healthcheck

## Changes

- `podman_compose.py`: drop the `--health-startup-interval` translation; emit a `log.warning(...)` when `start_interval` is set, including the service name and the upstream Podman tracking issue.
- `tests/unit/test_container_to_args.py`:
  - `test_healthcheck_options` no longer asserts the (now-removed) `--health-startup-interval` output.
  - New `test_healthcheck_start_interval_warns_and_omits_podman_flag` verifies the new contract: a warning mentioning `start_interval` is logged, and the resulting args list does not contain `--health-startup-interval`.
- `newsfragments/start_interval_unsupported.bugfix`: towncrier fragment.

## Verification

```
$ python -m unittest discover tests/unit
Ran 477 tests in 7.273s
OK

$ python -m ruff check podman_compose.py tests/unit/test_container_to_args.py
All checks passed!

$ python -m ruff format --check podman_compose.py tests/unit/test_container_to_args.py
2 files already formatted
```

Fixes #1500

Signed-off-by: wahajahmed010 <wahajahmed010@users.noreply.github.com>