### PR TITLE
Keep non-ASCII characters in `config` output

### DIFF
--- a/newsfragments/config_keeps_non_ascii_characters.bugfix
+++ b/newsfragments/config_keeps_non_ascii_characters.bugfix
@@ -1,0 +1,1 @@
+Fixed `podman-compose config` escaping non-ASCII characters, so values such as accented bind mount paths print literally instead of as `\xE9` escapes.

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2892,7 +2892,7 @@ class PodmanCompose:
         if not getattr(args, "no_normalize", None):
             compose = normalize_final(compose, self.dirname)
         compose.pop("version", None)
-        self.merged_yaml = yaml.safe_dump(compose)
+        self.merged_yaml = yaml.safe_dump(compose, allow_unicode=True)
         merged_json_b = json.dumps(
             self.original_configuration(compose), separators=(",", ":")
         ).encode("utf-8")

--- a/tests/integration/command_config/docker-compose_non_ascii.yaml
+++ b/tests/integration/command_config/docker-compose_non_ascii.yaml
@@ -1,0 +1,5 @@
+services:
+  sample:
+    image: nopush/podman-compose-test
+    volumes:
+    - /home/développement:/home/dev

--- a/tests/integration/command_config/test_podman_compose_config_command.py
+++ b/tests/integration/command_config/test_podman_compose_config_command.py
@@ -58,6 +58,26 @@ class TestConfigCommand(unittest.TestCase, RunSubprocessMixin):
             """)
         self.assertEqual(out.decode("utf-8"), expected)
 
+    def test_config_keeps_non_ascii_characters(self) -> None:
+        out, _ = self.run_subprocess_assert_returncode(
+            [
+                podman_compose_path(),
+                "-f",
+                compose_yaml_path("_non_ascii"),
+                "config",
+            ],
+            0,
+        )
+        expected = textwrap.dedent("""\
+            services:
+              sample:
+                image: nopush/podman-compose-test
+                volumes:
+                - /home/développement:/home/dev
+
+            """)
+        self.assertEqual(out.decode("utf-8"), expected)
+
     def test_config_omits_version_and_warns(self) -> None:
         config_cmd = [
             "coverage",

--- a/tests/unit/test_merged_yaml.py
+++ b/tests/unit/test_merged_yaml.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: GPL-2.0
+# pylint: disable=protected-access
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+
+from podman_compose import PodmanCompose
+
+
+class TestMergedYaml(unittest.TestCase):
+    def test_merged_yaml_keeps_non_ascii_characters(self) -> None:
+        content = """\
+services:
+  sample:
+    image: nopush/podman-compose-test
+    volumes:
+    - /home/développement:/home/dev
+"""
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            compose_file = os.path.join(tmp_dir, "docker-compose.yaml")
+            with open(compose_file, "w", encoding="utf-8") as f:
+                f.write(content)
+
+            podman_compose = PodmanCompose()
+            podman_compose.global_args.file = [compose_file]
+            podman_compose.global_args.project_name = "test_project"
+            podman_compose.global_args.env_file = None
+            podman_compose.global_args.profile = []
+            podman_compose.global_args.in_pod = "false"
+            podman_compose._parse_compose_file()
+
+        self.assertIn("/home/développement", podman_compose.merged_yaml)


### PR DESCRIPTION
Fixes #1536.

`podman-compose config` renders any non-ASCII character in a compose value as a `\xE9`-style escape:

```yaml
services:
  sample:
    image: nopush/podman-compose-test
    volumes:
    - /home/développement:/home/dev
```

```console
$ podman-compose -f docker-compose.yaml config
services:
  sample:
    image: nopush/podman-compose-test
    volumes:
    - "/home/d\xE9veloppement:/home/dev"
```

The cause is `yaml.safe_dump`, which defaults to `allow_unicode=False`. Docker Compose prints
these characters literally. To be clear about the impact: the escaped form is valid YAML and
still parses back to the correct path, so this is a rendering/parity problem, not data loss.

I deliberately left the neighbouring `json.dumps` alone. It feeds `self.yaml_hash`, and changing
its encoding would change the hash used to decide whether containers need recreating.

One trade-off worth naming: the `print` in `compose_config` can now raise `UnicodeEncodeError`
if stdout is not UTF-8 capable, where before it silently emitted escapes. Docker Compose behaves
the same way and compose files are already read as UTF-8, so I left it alone, but I'm happy to
add handling if you'd rather.

Tests: a unit test covering the merged YAML, plus an exact-output integration test in
`tests/integration/command_config/` alongside the existing `config` cases.

Written with AI assistance; reviewed and tested locally before submitting.