### PR TITLE
tests/integration: Remove localhost HTTP requests from integration tests

### DIFF
--- a/tests/integration/build/context/Dockerfile
+++ b/tests/integration/build/context/Dockerfile
@@ -1,3 +1,3 @@
 FROM busybox
-RUN mkdir -p /var/www/html/ && date -Iseconds > /var/www/html/index.txt
+RUN mkdir -p /var/www/html/ && echo "web1-test-content" > /var/www/html/index.txt
 CMD ["busybox", "httpd", "-f", "-p", "80", "-h", "/var/www/html"]

--- a/tests/integration/build/context/Dockerfile-alt
+++ b/tests/integration/build/context/Dockerfile-alt
@@ -2,8 +2,9 @@ FROM busybox
 ARG buildno=1
 ARG httpd_port=80
 ARG other_variable=not_set
+ENV buildno ${buildno}
 ENV httpd_port ${httpd_port}
 ENV other_variable ${other_variable}
 RUN mkdir -p /var/www/html/ && \
-    echo "ALT buildno=$buildno port=$httpd_port `date -Iseconds`" > /var/www/html/index.txt
+    echo "ALT buildno=$buildno port=$httpd_port" > /var/www/html/index.txt
 CMD httpd -f -p "$httpd_port" -h /var/www/html

--- a/tests/integration/build/test_podman_compose_build.py
+++ b/tests/integration/build/test_podman_compose_build.py
@@ -3,8 +3,6 @@
 import os
 import unittest
 
-import requests
-
 from tests.integration.test_utils import RunSubprocessMixin
 from tests.integration.test_utils import podman_compose_path
 from tests.integration.test_utils import test_path
@@ -35,27 +33,49 @@ class TestComposeBuild(unittest.TestCase, RunSubprocessMixin):
                 "-d",
             ])
 
-            request = requests.get('http://localhost:8080/index.txt')
-            self.assertEqual(request.status_code, 200)
+            output, _ = self.run_subprocess_assert_returncode([
+                "podman",
+                "run",
+                "--rm",
+                "my-busybox-httpd",
+                "cat",
+                "/var/www/html/index.txt",
+            ])
+            self.assertEqual(output.decode().strip(), "web1-test-content")
 
-            alt_request_success = False
-            try:
-                # FIXME: suspicious behaviour, too often ends up in error
-                alt_request = requests.get('http://localhost:8000/index.txt')
-                self.assertEqual(alt_request.status_code, 200)
-                self.assertIn("ALT buildno=2 port=8000 ", alt_request.text)
-                alt_request_success = True
-            except requests.exceptions.ConnectionError:
-                pass
+            # Verify web2 (Dockerfile-alt) image content and build args
+            output, _ = self.run_subprocess_assert_returncode([
+                "podman",
+                "run",
+                "--rm",
+                "my-busybox-httpd2",
+                "cat",
+                "/var/www/html/index.txt",
+            ])
+            self.assertEqual(output.decode().strip(), "ALT buildno=2 port=8000")
 
-            if alt_request_success:
-                output, _ = self.run_subprocess_assert_returncode([
-                    "podman",
-                    "inspect",
-                    "my-busybox-httpd2",
-                ])
-                self.assertIn("httpd_port=8000", str(output))
-                self.assertIn("buildno=2", str(output))
+            # Verify build args were baked into the image as env vars
+            output, _ = self.run_subprocess_assert_returncode([
+                "podman",
+                "run",
+                "--rm",
+                "my-busybox-httpd2",
+                "sh",
+                "-c",
+                "echo $httpd_port",
+            ])
+            self.assertEqual(output.decode().strip(), "8000")
+
+            output, _ = self.run_subprocess_assert_returncode([
+                "podman",
+                "run",
+                "--rm",
+                "my-busybox-httpd2",
+                "sh",
+                "-c",
+                "echo $buildno",
+            ])
+            self.assertEqual(output.decode().strip(), "2")
         finally:
             self.run_subprocess_assert_returncode([
                 podman_compose_path(),

--- a/tests/integration/nethost/test_podman_compose_nethost.py
+++ b/tests/integration/nethost/test_podman_compose_nethost.py
@@ -3,8 +3,6 @@
 import os
 import unittest
 
-import requests
-
 from tests.integration.test_utils import RunSubprocessMixin
 from tests.integration.test_utils import podman_compose_path
 from tests.integration.test_utils import test_path
@@ -15,8 +13,7 @@ def compose_yaml_path() -> str:
 
 
 class TestComposeNethost(unittest.TestCase, RunSubprocessMixin):
-    # check if container listens for http requests and sends response back
-    # as network_mode: host allows to connect to container easily
+    # check if container with network_mode: host can be started and accessed
     def test_nethost(self) -> None:
         try:
             self.run_subprocess_assert_returncode(
@@ -34,7 +31,19 @@ class TestComposeNethost(unittest.TestCase, RunSubprocessMixin):
                 ],
             )
             container_id = container_id_out.decode('utf-8').split('\n')[0]
+
             output, _ = self.run_subprocess_assert_returncode(
+                [
+                    "podman",
+                    "inspect",
+                    "--format",
+                    "{{.HostConfig.NetworkMode}}",
+                    container_id,
+                ],
+            )
+            self.assertEqual(output.decode().strip(), "host")
+
+            self.run_subprocess_assert_returncode(
                 [
                     "podman",
                     "exec",
@@ -45,9 +54,18 @@ class TestComposeNethost(unittest.TestCase, RunSubprocessMixin):
                     "echo test_123 >> /tmp/test.txt",
                 ],
             )
-            response = requests.get('http://localhost:8123/test.txt')
-            self.assertEqual(response.ok, True)
-            self.assertEqual(response.text, "test_123\n")
+
+            output, _ = self.run_subprocess_assert_returncode(
+                [
+                    "podman",
+                    "exec",
+                    "-it",
+                    container_id,
+                    "cat",
+                    "/tmp/test.txt",
+                ],
+            )
+            self.assertEqual(output.decode(), "test_123\r\n")
         finally:
             self.run_subprocess_assert_returncode([
                 podman_compose_path(),

--- a/tests/integration/nets_test1/test_podman_compose_nets_test1.py
+++ b/tests/integration/nets_test1/test_podman_compose_nets_test1.py
@@ -4,8 +4,6 @@ import json
 import os
 import unittest
 
-import requests
-
 from tests.integration.test_utils import RunSubprocessMixin
 from tests.integration.test_utils import podman_compose_path
 from tests.integration.test_utils import test_path
@@ -36,14 +34,6 @@ class TestComposeNetsTest1(unittest.TestCase, RunSubprocessMixin):
             ])
             self.assertIn(b"nets_test1_web1_1", output)
             self.assertIn(b"nets_test1_web2_1", output)
-
-            response = requests.get('http://localhost:8001/index.txt')
-            self.assertTrue(response.ok)
-            self.assertEqual(response.text, "test1\n")
-
-            response = requests.get('http://localhost:8002/index.txt')
-            self.assertTrue(response.ok)
-            self.assertEqual(response.text, "test2\n")
 
             # inspect 1st container
             output, _ = self.run_subprocess_assert_returncode([

--- a/tests/integration/nets_test2/test_podman_compose_nets_test2.py
+++ b/tests/integration/nets_test2/test_podman_compose_nets_test2.py
@@ -4,8 +4,6 @@ import json
 import os
 import unittest
 
-import requests
-
 from tests.integration.test_utils import RunSubprocessMixin
 from tests.integration.test_utils import podman_compose_path
 from tests.integration.test_utils import test_path
@@ -37,14 +35,6 @@ class TestComposeNetsTest2(unittest.TestCase, RunSubprocessMixin):
             self.assertIn(b"nets_test2_web1_1", output)
             self.assertIn(b"nets_test2_web2_1", output)
 
-            response = requests.get('http://localhost:8001/index.txt')
-            self.assertTrue(response.ok)
-            self.assertEqual(response.text, "test1\n")
-
-            response = requests.get('http://localhost:8002/index.txt')
-            self.assertTrue(response.ok)
-            self.assertEqual(response.text, "test2\n")
-
             # inspect 1st container
             output, _ = self.run_subprocess_assert_returncode([
                 "podman",
@@ -58,7 +48,7 @@ class TestComposeNetsTest2(unittest.TestCase, RunSubprocessMixin):
                 list(container_info["NetworkSettings"]["Networks"].keys())[0], "nets_test2_mystack"
             )
 
-            # check if Host port is the same as prodvided by the service port
+            # check if Host port is the same as provided by the service port
             self.assertIsNotNone(container_info['NetworkSettings']["Ports"].get("8001/tcp", None))
             self.assertGreater(len(container_info['NetworkSettings']["Ports"]["8001/tcp"]), 0)
             self.assertIsNotNone(


### PR DESCRIPTION
This PR removes HTTP requests to localhost in integration tests to avoid startup race conditions and external network dependencies.

Fixes https://github.com/containers/podman-compose/issues/998.
